### PR TITLE
Allow group name to be filtered

### DIFF
--- a/src/Uplink/Admin/Field.php
+++ b/src/Uplink/Admin/Field.php
@@ -61,7 +61,9 @@ abstract class Field {
 	 * @return string
 	 */
 	public function get_group_name( string $group_modifier = '' ) : string {
-		return sprintf( '%s_%s', self::STELLARWP_UPLINK_GROUP, $group_modifier );
+		$group_name = sprintf( '%s_%s', self::STELLARWP_UPLINK_GROUP, $group_modifier );
+
+		return apply_filters( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/license_field_group_name', $group_name, self::STELLARWP_UPLINK_GROUP, $group_modifier );
 	}
 
 	/**


### PR DESCRIPTION
Allowing this to be filtered means I can use it in my settings page without `_wpnonce` conflicting. I can set the group name to be the same as my settings page.