### PR TITLE
[fix] Fix update URL

### DIFF
--- a/src/Uplink/API/Validation_Response.php
+++ b/src/Uplink/API/Validation_Response.php
@@ -284,7 +284,7 @@ class Validation_Response {
 		$update->url         = $this->response->homepage ?? '';
 		$update->tested      = $this->response->tested ?? '';
 		$update->requires    = $this->response->requires ?? '';
-		$update->package     = $this->response->download_url ? $this->response->download_url . '&pu_get_download=1&key=' . $this->get_key() : '';
+		$update->package     = $this->response->download_url ? $this->response->download_url . '&key=' . urlencode( $this->get_key() ) : '';
 
 		if ( ! empty( $this->response->upgrade_notice ) ) {
 			$update->upgrade_notice = $this->response->upgrade_notice;
@@ -495,7 +495,7 @@ class Validation_Response {
 		}
 
 		//Other fields need to be renamed and/or transformed.
-		$info->download_link = isset( $this->response->download_url ) ? $this->response->download_url . '&pu_get_download=1' : '';
+		$info->download_link = isset( $this->response->download_url ) ? $this->response->download_url : '';
 
 		if ( ! empty( $this->author_homepage ) && ! empty( $this->response->author ) ) {
 			$info->author = sprintf( '<a href="%s">%s</a>', esc_url( $this->author_homepage ), $this->response->author );

--- a/tests/_support/Helper/Http_API/Http_API_Mock.php
+++ b/tests/_support/Helper/Http_API/Http_API_Mock.php
@@ -2,6 +2,8 @@
 
 namespace StellarWP\Uplink\Tests\Http_API;
 
+use WpOrg\Requests\Response as Requests_Response;
+
 abstract class Http_API_Mock {
 	/**
 	 * A map from status codes to the HTTP standard status description.
@@ -99,7 +101,7 @@ abstract class Http_API_Mock {
 
 		$url = rtrim( $this->get_url(), '/' );
 		$current_date = ( new \DateTime( 'now', new \DateTimezone( 'GMT' ) ) )->format( 'D, d M Y H:i:s GMT' );
-		$request_response = new \Requests_Response();
+		$request_response = new Requests_Response();
 		$request_response->headers = new \Requests_Response_Headers( [
 			'date'                          => [ $current_date ],
 			'content-type'                  => [ "$content_type; charset=UTF-8" ],


### PR DESCRIPTION
The update URL wasn't working because of a legacy argument and the key needed encoding.

@borkweb Do we need to worry about the `download_url` if it's already set in `$response->download_url`?