### PR TITLE
[fix] Strip tags instead of sanitize

### DIFF
--- a/src/Uplink/API/Client.php
+++ b/src/Uplink/API/Client.php
@@ -6,6 +6,7 @@ use StellarWP\ContainerContract\ContainerInterface;
 use StellarWP\Uplink\Config;
 use StellarWP\Uplink\Resources\Resource;
 use StellarWP\Uplink\Site\Data;
+use StellarWP\Uplink\Utils;
 
 /**
  * API Client class.
@@ -203,7 +204,7 @@ class Client {
 		$args      = $resource->get_validation_args();
 
 		if ( ! empty( $key ) ) {
-			$args['key'] = strip_tags( $key );
+			$args['key'] = Utils\Sanitize::key( $key );
 		}
 
 		$args['domain'] = $site_data->get_domain();

--- a/src/Uplink/API/Client.php
+++ b/src/Uplink/API/Client.php
@@ -203,7 +203,7 @@ class Client {
 		$args      = $resource->get_validation_args();
 
 		if ( ! empty( $key ) ) {
-			$args['key'] = sanitize_text_field( $key );
+			$args['key'] = strip_tags( $key );
 		}
 
 		$args['domain'] = $site_data->get_domain();

--- a/src/Uplink/Resources/License.php
+++ b/src/Uplink/Resources/License.php
@@ -359,10 +359,10 @@ class License {
 		$this->key = $key;
 
 		if ( 'network' === $type && is_multisite() ) {
-			return update_network_option( 0, $this->get_key_option_name(), sanitize_text_field( $key ) );
+			return update_network_option( 0, $this->get_key_option_name(), strip_tags( $key ) );
 		}
 
-		return update_option( $this->get_key_option_name(), sanitize_text_field( $key ) );
+		return update_option( $this->get_key_option_name(), strip_tags( $key ) );
 	}
 
 	/**

--- a/src/Uplink/Resources/License.php
+++ b/src/Uplink/Resources/License.php
@@ -359,10 +359,10 @@ class License {
 		$this->key = $key;
 
 		if ( 'network' === $type && is_multisite() ) {
-			return update_network_option( 0, $this->get_key_option_name(), strip_tags( $key ) );
+			return update_network_option( 0, $this->get_key_option_name(), Utils\Sanitize::key( $key ) );
 		}
 
-		return update_option( $this->get_key_option_name(), strip_tags( $key ) );
+		return update_option( $this->get_key_option_name(), Utils\Sanitize::key( $key ) );
 	}
 
 	/**

--- a/src/Uplink/Utils/Sanitize.php
+++ b/src/Uplink/Utils/Sanitize.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace StellarWP\Uplink\Utils;
+
+class Sanitize {
+	/**
+	 * Sanitizes a key.
+	 *
+	 * @since 1.2.2
+	 *
+	 * @param string $key
+	 *
+	 * @return string
+	 */
+	public static function key( $key ) {
+		$key = strip_tags( $key );
+		$key = str_replace( [ '`', '"', "'" ], '', $key );
+
+		return $key;
+	}
+
+}


### PR DESCRIPTION
`sanitize_text_field()` causes an issue when the license key looks like this:

`sk_xK%ud%FDKXNws2LO#cDn^js8dfjj`

It turns it into this:

`sk_xK%udKXNws2LO#cDn^js8dfjj`

Which ends up being invalid.

Is `strip_tags()` enough to pass security checks?