### PR TITLE
Fix deprecated messages in PHP 8.1

### DIFF
--- a/src/Uplink/Resources/Collection.php
+++ b/src/Uplink/Resources/Collection.php
@@ -28,7 +28,7 @@ class Collection implements \ArrayAccess, \Iterator {
 	/**
 	 * @inheritDoc
 	 */
-	public function current() {
+	public function current(): Plugin {
 		return current( $this->resources );
 	}
 
@@ -89,6 +89,7 @@ class Collection implements \ArrayAccess, \Iterator {
 	/**
 	 * @inheritDoc
 	 */
+	#[\ReturnTypeWillChange]
 	public function key() {
 		return key( $this->resources );
 	}
@@ -96,7 +97,7 @@ class Collection implements \ArrayAccess, \Iterator {
 	/**
 	 * @inheritDoc
 	 */
-	public function next() {
+	public function next(): void {
 		next( $this->resources );
 	}
 
@@ -110,21 +111,21 @@ class Collection implements \ArrayAccess, \Iterator {
 	/**
 	 * @inheritDoc
 	 */
-	public function offsetGet( $offset ) {
+	public function offsetGet( $offset ): Plugin {
 		return $this->resources[ $offset ];
 	}
 
 	/**
 	 * @inheritDoc
 	 */
-	public function offsetSet( $offset, $value ) {
+	public function offsetSet( $offset, $value ): void {
 		$this->resources[ $offset ] = $value;
 	}
 
 	/**
 	 * @inheritDoc
 	 */
-	public function offsetUnset( $offset ) {
+	public function offsetUnset( $offset ): void {
 		unset( $this->resources[ $offset ] );
 	}
 
@@ -144,7 +145,7 @@ class Collection implements \ArrayAccess, \Iterator {
 	/**
 	 * @inheritDoc
 	 */
-	public function rewind() {
+	public function rewind(): void {
 		reset( $this->resources );
 	}
 

--- a/src/Uplink/Resources/Collection.php
+++ b/src/Uplink/Resources/Collection.php
@@ -28,7 +28,8 @@ class Collection implements \ArrayAccess, \Iterator {
 	/**
 	 * @inheritDoc
 	 */
-	public function current(): Plugin {
+	#[\ReturnTypeWillChange]
+	public function current() {
 		return current( $this->resources );
 	}
 
@@ -111,7 +112,8 @@ class Collection implements \ArrayAccess, \Iterator {
 	/**
 	 * @inheritDoc
 	 */
-	public function offsetGet( $offset ): Plugin {
+	#[\ReturnTypeWillChange]
+	public function offsetGet( $offset ) {
 		return $this->resources[ $offset ];
 	}
 


### PR DESCRIPTION
Since the Collection class implements [ArrayAccess](https://www.php.net/manual/en/class.arrayaccess.php) interface, deprecated messages are thrown in PHP 8.1 when the returned type is not defined. 

Example:
```
Return type of Iconic_WSB_NS\StellarWP\Uplink\Resources\Collection::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```

This PR adds the returned types. It's important to notice that the `void` type was added in PHP 7.1.0. If we want to keep compatibility with older versions, we have to replace `void` with `#[\ReturnTypeWillChange]` to avoid the deprecated messages.

**How to test this change**:

1. Update the composer.json

```json
"repositories": [
...
{
      "type": "vcs",
      "url": "https://github.com/Rahmon/uplink.git"
    }
],
"require": {
...
"stellarwp/uplink": "dev-fix/collection-deprecated-warnings",
}
```

2. Run `composer update stellarwp/uplink`