### PR TITLE
[fix] Use sanitize function for key

### DIFF
--- a/src/Uplink/Admin/Ajax.php
+++ b/src/Uplink/Admin/Ajax.php
@@ -5,6 +5,7 @@ namespace StellarWP\Uplink\Admin;
 use StellarWP\ContainerContract\ContainerInterface;
 use StellarWP\Uplink\Config;
 use StellarWP\Uplink\Resources\Collection;
+use StellarWP\Uplink\Utils;
 
 class Ajax {
 
@@ -22,11 +23,11 @@ class Ajax {
 	 * @return void
 	 */
 	public function validate_license() {
-		$submission = filter_var_array( $_POST, [
-			'_wpnonce' => FILTER_SANITIZE_STRING,
-			'key'      => FILTER_SANITIZE_STRING,
-			'plugin'   => FILTER_SANITIZE_STRING,
-		] );
+		$submission = [];
+
+		$submission['_wpnonce'] = isset( $_POST['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ) : '';
+		$submission['plugin']   = isset( $_POST['plugin'] ) ? sanitize_text_field( wp_unslash( $_POST['plugin'] ) ) : '';
+		$submission['key']      = isset( $_POST['key'] ) ? Utils\Sanitize::key( wp_unslash( $_POST['key'] ) ) : '';
 
 		if ( empty( $submission ) || empty( $submission['key'] ) || ! wp_verify_nonce( $submission['_wpnonce'], $this->container->get( License_Field::class )->get_group_name() ) ) {
 			echo json_encode( [

--- a/src/Uplink/Resources/Resource.php
+++ b/src/Uplink/Resources/Resource.php
@@ -7,6 +7,8 @@ use StellarWP\Uplink\API;
 use StellarWP\Uplink\Config;
 use StellarWP\Uplink\Exceptions;
 use StellarWP\Uplink\Site\Data;
+use StellarWP\Uplink\Utils;
+
 /**
  * The base resource class for StellarWP Uplink plugins and services.
  *
@@ -174,8 +176,8 @@ abstract class Resource {
 		$args['wp_version']        = $stats['versions']['wp'];
 
 		// the following is for install key inclusion (will apply later with PUE addons.)
-		$args['key'] = sanitize_text_field( $this->get_license_object()->get_key() ?: '' );
-		$args['dk']  = sanitize_text_field( $this->get_license_object()->get_key( 'default' ) ?: '' );
+		$args['key'] = Utils\Sanitize::key( $this->get_license_object()->get_key() ?: '' );
+		$args['dk']  = Utils\Sanitize::key( $this->get_license_object()->get_key( 'default' ) ?: '' );
 		$args['o']   = sanitize_text_field( $this->get_license_object()->get_key_origin_code() );
 
 		return $args;
@@ -299,8 +301,8 @@ abstract class Resource {
 	public function get_validation_args() {
 		$args = [];
 
-		$args['key']            = sanitize_text_field( $this->get_license_object()->get_key() ?: '' );
-		$args['default_key']    = sanitize_text_field( $this->get_license_object()->get_key( 'default' ) ?: '' );
+		$args['key']            = Utils\Sanitize::key( $this->get_license_object()->get_key() ?: '' );
+		$args['default_key']    = Utils\Sanitize::key( $this->get_license_object()->get_key( 'default' ) ?: '' );
 		$args['license_origin'] = sanitize_text_field( $this->get_license_object()->get_key_origin_code() );
 		$args['plugin']         = sanitize_text_field( $this->get_slug() );
 		$args['version']        = sanitize_text_field( $this->get_installed_version() ?: '' );

--- a/src/Uplink/Utils/Sanitize.php
+++ b/src/Uplink/Utils/Sanitize.php
@@ -13,10 +13,6 @@ class Sanitize {
 	 * @return string
 	 */
 	public static function key( $key ) {
-		$key = strip_tags( $key );
-		$key = str_replace( [ '`', '"', "'" ], '', $key );
-
-		return $key;
+		return str_replace( [ '`', '"', "'" ], '', $key );
 	}
-
 }


### PR DESCRIPTION
We needed to decrease the sanitization of license keys to enable the following special characters:

`!@#$%^&*()-_[]{}<>~+=.;:?`

These exist in some Freemius-based keys. We can't use `strip_tags()` because some keys look like this: `sk_sdfj4<sdlgfne>fsgdfg`