### PR TITLE
Only show update message if version is greater

### DIFF
--- a/src/Uplink/Resources/Plugin.php
+++ b/src/Uplink/Resources/Plugin.php
@@ -69,7 +69,7 @@ class Plugin extends Resource {
 			}
 
 			// In order to show relevant issues on plugins page parse response data and add it to transient
-			if ( version_compare( $this->get_version_from_response( $results ), $this->get_installed_version(), '>=' ) && in_array( $results->get_result(), [ 'expired', 'invalid' ] ) ) {
+			if ( version_compare( $this->get_version_from_response( $results ), $this->get_installed_version(), '>' ) && in_array( $results->get_result(), [ 'expired', 'invalid' ] ) ) {
 				/** @var \stdClass $transient */
 				if ( ! isset( $transient->response ) ) {
 					$transient->response = [];


### PR DESCRIPTION
If the license is invalid, the update message shows when the version is the same or greater. We should only show it if the PUE version is greater than the current.