### PR TITLE
Add views autoload namespace to fix strauss copy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "psr-4": {
             "StellarWP\\Uplink\\": "src/Uplink/",
             "StellarWP\\Uplink\\Admin_Views\\": "src/admin-views/",
-            "StellarWP\\Uplink\\Assets_Dir\\": "src/assets/"
+            "StellarWP\\Uplink\\Assets_Dir\\": "src/assets/",
+            "StellarWP\\Uplink\\Views\\": "src/views/"
         }
     },
     "autoload-dev": {


### PR DESCRIPTION
Fixes Strauss not copying the views folder