### PR TITLE
ESM-7 - change default parameter to all

### DIFF
--- a/src/Uplink/Resources/Resource.php
+++ b/src/Uplink/Resources/Resource.php
@@ -230,7 +230,7 @@ abstract class Resource {
 	 *
 	 * @return string
 	 */
-	public function get_license_key( $type = 'local' ): string {
+	public function get_license_key( $type = 'all' ): string {
 		return $this->get_license_object()->get_key( $type );
 	}
 

--- a/src/Uplink/Resources/Resource.php
+++ b/src/Uplink/Resources/Resource.php
@@ -230,7 +230,7 @@ abstract class Resource {
 	 *
 	 * @return string
 	 */
-	public function get_license_key( $type = 'all' ): string {
+	public function get_license_key( $type = 'any' ): string {
 		return $this->get_license_object()->get_key( $type );
 	}
 


### PR DESCRIPTION
- When testing the license for Event Schedule Manager the license key from file method is not called. 

 This is do to the get_license_key default parameter being set to local. 

The settings field calls get_license_key without parameters:
(https://github.com/stellarwp/uplink/blob/3f500360004c631ddf20730e90bee81d7faa41f2/src/Uplink/Admin/License_Field.php#L53)

Which calls the method changed in this PR:
https://github.com/stellarwp/uplink/blob/3f500360004c631ddf20730e90bee81d7faa41f2/src/Uplink/Resources/Resource.php#L233

That calls the License get_key method:
https://github.com/stellarwp/uplink/blob/3f500360004c631ddf20730e90bee81d7faa41f2/src/Uplink/Resources/License.php#L128

This is the line that requires all or default to get the license key from the field. 
https://github.com/stellarwp/uplink/blob/3f500360004c631ddf20730e90bee81d7faa41f2/src/Uplink/Resources/License.php#L145

An alternative to this change could be to remove the default parameter from get_license_key and use the default from get_key.  