### PR TITLE
Fix nonce double escaping

### DIFF
--- a/src/Uplink/Auth/Nonce.php
+++ b/src/Uplink/Auth/Nonce.php
@@ -62,14 +62,14 @@ final class Nonce {
 	/**
 	 * Attach a nonce to a URL.
 	 *
+	 * @note Unlike WordPress' function, you should escape this manually.
+	 *
 	 * @param  string  $url The existing URL to attach the nonce to.
 	 *
 	 * @return string
 	 */
 	public function create_url( string $url ): string {
-		$url = str_replace( '&amp;', '&', $url );
-
-		return esc_html( add_query_arg( '_uplink_nonce', $this->create(), $url ) );
+		return add_query_arg( '_uplink_nonce', $this->create(), $url );
 	}
 
 	/**

--- a/src/Uplink/Auth/Nonce.php
+++ b/src/Uplink/Auth/Nonce.php
@@ -69,7 +69,7 @@ final class Nonce {
 	 * @return string
 	 */
 	public function create_url( string $url ): string {
-		return add_query_arg( '_uplink_nonce', $this->create(), $url );
+		return esc_url_raw( add_query_arg( '_uplink_nonce', $this->create(), $url ) );
 	}
 
 	/**

--- a/tests/wpunit/Auth/NonceTest.php
+++ b/tests/wpunit/Auth/NonceTest.php
@@ -54,8 +54,7 @@ final class NonceTest extends UplinkTestCase {
 	public function test_it_creates_a_nonce_url_with_extra_query_arguments(): void {
 		$url = 'http://wordpress.test/wp-admin/post.php?post=1&action=edit';
 
-		// URL is escaped, reverse that.
-		$nonce_url = html_entity_decode( $this->nonce->create_url( $url ) );
+		$nonce_url = $this->nonce->create_url( $url );
 
 		$this->assertStringStartsWith(
 			'http://wordpress.test/wp-admin/post.php?post=1&action=edit&_uplink_nonce=',


### PR DESCRIPTION
The core `wp_nonce_url()` function I copied has a number of existing issues, so now [we just escape it once, inside the view.](https://github.com/stellarwp/uplink/blob/f57fb87412a6434761edab1ca7ed6cdf16adb7a9/src/views/admin/authorize-button.php#L19)

For previous attempts to fix this, see: https://core.trac.wordpress.org/ticket/20771