### PR TITLE
base64 encode the uplink_callback query parameter

### DIFF
--- a/src/Uplink/Auth/Auth_Url_Builder.php
+++ b/src/Uplink/Auth/Auth_Url_Builder.php
@@ -31,6 +31,8 @@ final class Auth_Url_Builder {
 	/**
 	 * Build a brand's authorization URL, with the uplink_callback base64 query variable.
 	 *
+	 * @note This URL requires escaping.
+	 *
 	 * @param  string  $slug  The product/service slug.
 	 * @param  string  $domain  An optional domain associated with a license key to pass along.
 	 *

--- a/src/Uplink/Auth/Auth_Url_Builder.php
+++ b/src/Uplink/Auth/Auth_Url_Builder.php
@@ -1,0 +1,71 @@
+<?php declare( strict_types=1 );
+
+namespace StellarWP\Uplink\Auth;
+
+use StellarWP\Uplink\API\V3\Auth\Contracts\Auth_Url;
+
+final class Auth_Url_Builder {
+
+	/**
+	 * @var Nonce
+	 */
+	private $nonce;
+
+	/**
+	 * @var Auth_Url
+	 */
+	private $auth_url_manager;
+
+	/**
+	 * @param  Nonce  $nonce  The Nonce creator.
+	 * @param  Auth_Url  $auth_url_manager  The auth URL manager.
+	 */
+	public function __construct(
+		Nonce $nonce,
+		Auth_Url $auth_url_manager
+	) {
+		$this->nonce            = $nonce;
+		$this->auth_url_manager = $auth_url_manager;
+	}
+
+	/**
+	 * Build a brand's authorization URL, with the uplink_callback base64 query variable.
+	 *
+	 * @param  string  $slug  The product/service slug.
+	 * @param  string  $domain  An optional domain associated with a license key to pass along.
+	 *
+	 * @return string
+	 */
+	public function build( string $slug, string $domain = '' ): string {
+		global $pagenow;
+
+		if ( empty( $pagenow ) ) {
+			return '';
+		}
+
+		$auth_url = $this->auth_url_manager->get( $slug );
+
+		if ( ! $auth_url ) {
+			return '';
+		}
+
+		// Query arguments to combine with $_GET and add to the authorization URL.
+		$args = [
+			'uplink_domain' => $domain,
+			'uplink_slug'   => $slug,
+		];
+
+		$url = add_query_arg(
+			array_filter( array_merge( $_GET, $args ) ),
+			admin_url( $pagenow )
+		);
+
+		return sprintf( '%s?%s',
+			$auth_url,
+			http_build_query( [
+				'uplink_callback' => base64_encode( $this->nonce->create_url( $url ) ),
+			] )
+		);
+	}
+
+}

--- a/src/Uplink/Components/Admin/Authorize_Button_Controller.php
+++ b/src/Uplink/Components/Admin/Authorize_Button_Controller.php
@@ -3,10 +3,9 @@
 namespace StellarWP\Uplink\Components\Admin;
 
 use InvalidArgumentException;
-use StellarWP\Uplink\API\V3\Auth\Contracts\Auth_Url;
 use StellarWP\Uplink\Auth\Admin\Disconnect_Controller;
+use StellarWP\Uplink\Auth\Auth_Url_Builder;
 use StellarWP\Uplink\Auth\Authorizer;
-use StellarWP\Uplink\Auth\Nonce;
 use StellarWP\Uplink\Auth\Token\Contracts\Token_Manager;
 use StellarWP\Uplink\Components\Controller;
 use StellarWP\Uplink\Config;
@@ -30,43 +29,27 @@ final class Authorize_Button_Controller extends Controller {
 	private $token_manager;
 
 	/**
-	 * @var Nonce
+	 * @var Auth_Url_Builder
 	 */
-	private $nonce;
-
-	/**
-	 * @var Auth_Url
-	 */
-	private $auth_url_manager;
-
-	/**
-	 * The auth URL for the origin as fetched remotely from the
-	 * licensing server when we want to render the button.
-	 *
-	 * @var string
-	 */
-	private $auth_url = '';
+	private $url_builder;
 
 	/**
 	 * @param  View  $view  The View Engine to render views.
 	 * @param  Authorizer  $authorizer  Determines if the current user can perform actions.
 	 * @param  Token_Manager  $token_manager  The Token Manager.
-	 * @param  Nonce  $nonce  The Nonce Manager.
-	 * @param  Auth_Url  $auth_url_manager  The Brand Auth URL fetcher.
+	 * @param  Auth_Url_Builder  $url_builder  The Auth URL Builder.
 	 */
 	public function __construct(
 		View $view,
 		Authorizer $authorizer,
 		Token_Manager $token_manager,
-		Nonce $nonce,
-		Auth_Url $auth_url_manager
+		Auth_Url_Builder $url_builder
 	) {
 		parent::__construct( $view );
 
-		$this->authorizer       = $authorizer;
-		$this->token_manager    = $token_manager;
-		$this->nonce            = $nonce;
-		$this->auth_url_manager = $auth_url_manager;
+		$this->authorizer    = $authorizer;
+		$this->token_manager = $token_manager;
+		$this->url_builder   = $url_builder;
 	}
 
 	/**
@@ -88,16 +71,15 @@ final class Authorize_Button_Controller extends Controller {
 			throw new InvalidArgumentException( __( 'The Product slug cannot be empty', '%TEXTDOMAIN%' ) );
 		}
 
-		$this->auth_url = $this->auth_url_manager->get( $slug );
+		$url = $this->url_builder->build( $slug, $domain );
 
-		if ( ! $this->auth_url ) {
+		if ( ! $url ) {
 			return;
 		}
 
 		$authenticated = false;
 		$target        = '_blank';
 		$link_text     = __( 'Connect', '%TEXTDOMAIN%' );
-		$url           = $this->build_auth_url( $domain );
 		$classes       = [
 			'uplink-authorize',
 			'not-authorized',
@@ -194,31 +176,6 @@ final class Authorize_Button_Controller extends Controller {
 			'tag'       => $tag,
 			'classes'   => $this->classes( $classes ),
 		] );
-	}
-
-	/**
-	 * We assume this button is only displayed within wp-admin,
-	 *
-	 * Build the callback URL with the current URL the user is on.
-	 */
-	private function build_auth_url( string $domain ): string {
-		global $pagenow;
-
-		if ( empty( $pagenow ) ) {
-			return '';
-		}
-
-		$url = add_query_arg(
-			array_filter( array_merge( $_GET, [ 'uplink_domain' => $domain ] ) ),
-			admin_url( $pagenow )
-		);
-
-		return sprintf( '%s?%s',
-			$this->auth_url,
-			http_build_query( [
-				'uplink_callback' => base64_encode( $this->nonce->create_url( $url ) ),
-			] )
-		);
 	}
 
 }

--- a/src/Uplink/Components/Admin/Authorize_Button_Controller.php
+++ b/src/Uplink/Components/Admin/Authorize_Button_Controller.php
@@ -216,7 +216,7 @@ final class Authorize_Button_Controller extends Controller {
 		return sprintf( '%s?%s',
 			$this->auth_url,
 			http_build_query( [
-				'uplink_callback' => $this->nonce->create_url( $url ),
+				'uplink_callback' => base64_encode( $this->nonce->create_url( $url ) ),
 			] )
 		);
 	}

--- a/src/Uplink/functions.php
+++ b/src/Uplink/functions.php
@@ -3,6 +3,7 @@
 namespace StellarWP\Uplink;
 
 use StellarWP\Uplink\API\V3\Auth\Token_Authorizer;
+use StellarWP\Uplink\Auth\Auth_Url_Builder;
 use StellarWP\Uplink\Auth\Token\Contracts\Token_Manager;
 use StellarWP\Uplink\Components\Admin\Authorize_Button_Controller;
 use Throwable;
@@ -66,5 +67,26 @@ function is_authorized( string $license, string $token, string $domain ): bool {
 		}
 
 		return false;
+	}
+}
+
+/**
+ * Build a brand's authorization URL, with the uplink_callback base64 query variable.
+ *
+ * @param  string  $slug  The Product slug to render the button for.
+ * @param  string  $domain  An optional domain associated with a license key to pass along.
+ *
+ * @return string
+ */
+function build_auth_url( string $slug, string $domain = '' ): string {
+	try {
+		return Config::get_container()->get( Auth_Url_Builder::class )
+		                              ->build( $slug, $domain );
+	} catch ( Throwable $e ) {
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			error_log( "Error building auth URL: {$e->getMessage()} {$e->getFile()}:{$e->getLine()} {$e->getTraceAsString()}" );
+		}
+
+		return '';
 	}
 }

--- a/tests/wpunit/API/V3/AuthUrlTest.php
+++ b/tests/wpunit/API/V3/AuthUrlTest.php
@@ -5,6 +5,7 @@ namespace StellarWP\Uplink\Tests\API\V3;
 use StellarWP\Uplink\API\V3\Auth\Auth_Url;
 use StellarWP\Uplink\API\V3\Auth\Auth_Url_Cache_Decorator;
 use StellarWP\Uplink\API\V3\Contracts\Client_V3;
+use StellarWP\Uplink\Auth\Auth_Url_Builder;
 use StellarWP\Uplink\Tests\UplinkTestCase;
 
 final class AuthUrlTest extends UplinkTestCase {
@@ -32,6 +33,32 @@ final class AuthUrlTest extends UplinkTestCase {
 		$auth_url = $this->container->get( Auth_Url::class )->get( 'kadence-blocks-pro' );
 
 		$this->assertSame( 'https://www.kadencewp.com/account-auth/', $auth_url );
+	}
+
+	public function test_it_builds_an_auth_url(): void {
+		$clientMock = $this->makeEmpty( Client_V3::class, [
+			'get' => static function () {
+				return [
+					'response' => [
+						'code' => 200,
+					],
+					'body'   => json_decode( '{"success":true,"data":{"status":200,"auth_url":"https://www.kadencewp.com/account-auth/"}}', true ),
+				];
+			},
+		] );
+
+		$this->container->bind( Client_V3::class, $clientMock );
+
+		$auth_url = $this->container->get( Auth_Url_Builder::class )->build( 'kadence-blocks', 'test.com' );
+
+		parse_str( parse_url( $auth_url, PHP_URL_QUERY ), $query_vars );
+
+		$callback = base64_decode( urldecode( $query_vars['uplink_callback'] ), true );
+
+		$this->assertStringStartsWith(
+			'http://wordpress.test/wp-admin/index.php?uplink_domain=test.com&uplink_slug=kadence-blocks&_uplink_nonce=',
+			$callback
+		);
 	}
 
 	public function test_it_does_not_get_an_auth_url(): void {


### PR DESCRIPTION
Companion PR: https://github.com/stellarwp/uplink-origin/pull/49

The connect button URL now looks something like this in order to avoid query string parsing issues on the Uplink Origin side of things: 

```
https://www.kadencewp.com/account-auth/?uplink_callback=aHR0cHM6Ly91cGxpbmtzYW1wbGUubG5kby5zaXRlL3dwL3dwLWFkbWluL2VkaXQucGhwP3Bvc3RfdHlwZT1wYWdlJnVwbGlua19kb21haW49dGVzdC5jb20mX3VwbGlua19ub25jZT1temVmQnA3WWpoMjlTWWUw
```

And in this example, `uplink_callback` base64 decodes to:

```
https://uplinksample.lndo.site/wp/wp-admin/edit.php?post_type=page&uplink_domain=test.com&_uplink_nonce=mzefBp7Yjh29SYe0
```