### PR TITLE
Prevent fatal errors when inject_info args is a non-object

### DIFF
--- a/src/Uplink/Admin/Plugins_Page.php
+++ b/src/Uplink/Admin/Plugins_Page.php
@@ -242,7 +242,7 @@ class Plugins_Page {
 	 * @return mixed
 	 */
 	public function inject_info( $result, string $action = null, $args = null ) {
-		$relevant = ( 'plugin_information' === $action ) && isset( $args->slug ) && ( $args->slug === $this->get_plugin()->get_slug() );
+		$relevant = ( 'plugin_information' === $action ) && is_object( $args ) && isset( $args->slug ) && ( $args->slug === $this->get_plugin()->get_slug() );
 
 		if ( ! $relevant ) {
 			return $result;


### PR DESCRIPTION
Fixes #43 

This PR simply adds a defensive `is_object` check within the `inject_info` function to ensure that if the `$args` parameter is not an object, a fatal error will not be thrown.

The bug was preventing a customer from updating any plugin on their site. I can confirm that after hot-patching their staging environment with this fix, the issue has been resolved.

![Screenshot 2023-11-21 165136](https://github.com/stellarwp/uplink/assets/3214928/e9617a1f-06a4-4b65-9ee8-481b0b58b615)
