### PR TITLE
WIP - Refactor to cater for falsey get_plugin() return value

### DIFF
--- a/src/Uplink/Admin/License_Field.php
+++ b/src/Uplink/Admin/License_Field.php
@@ -30,6 +30,10 @@ class License_Field extends Field {
 		$collection = Config::get_container()->get( Collection::class );
 		$plugin     = $collection->current();
 
+		if ( ! $plugin ) {
+			return;
+		}
+
 		add_settings_section(
 			sprintf( '%s_%s', self::LICENSE_FIELD_ID, sanitize_title( $plugin->get_slug() ) ),
 			'',
@@ -78,8 +82,14 @@ class License_Field extends Field {
 	 * @inheritDoc
 	 */
 	public function render( bool $show_title = true, bool $show_button = true ) {
+		$plugin = $this->get_plugin();
+
+		if ( ! $plugin ) {
+			return;
+		}
+
 		echo $this->get_content( [
-			'plugin'      => $this->get_plugin(),
+			'plugin'      => $plugin,
 			'show_title'  => $show_title,
 			'show_button' => $show_button,
 		] );
@@ -91,8 +101,14 @@ class License_Field extends Field {
 	 * @return void
 	 */
 	public function enqueue_assets() {
+		$plugin = $this->get_plugin();
+
+		if ( ! $plugin ) {
+			return;
+		}
+
 		$handle = sprintf( 'stellarwp-uplink-license-admin-%s', Config::get_hook_prefix() );
-		$path   = preg_replace( '/.*\/vendor/', plugin_dir_url( $this->get_plugin()->get_path() ) . 'vendor', dirname( __DIR__, 2 ) );
+		$path   = preg_replace( '/.*\/vendor/', plugin_dir_url( $plugin->get_path() ) . 'vendor', dirname( __DIR__, 2 ) );
 		$js_src = apply_filters( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/admin_js_source', $path . '/assets/js/key-admin.js' );
 		wp_register_script( $handle, $js_src, [ 'jquery' ], '1.0.0', true );
 		wp_enqueue_script( $handle );

--- a/src/Uplink/Admin/Plugins_Page.php
+++ b/src/Uplink/Admin/Plugins_Page.php
@@ -31,8 +31,14 @@ class Plugins_Page {
 			return;
 		}
 
-		$messages       = [];
-		$plugin_file    = $this->get_plugin()->get_path();
+		$messages = [];
+		$plugin   = $this->get_plugin();
+
+		if ( ! $plugin ) {
+			return;
+		}
+
+		$plugin_file    = $plugin->get_path();
 		$plugin_updates = get_plugin_updates();
 		$resource       = $plugin_updates[ $plugin_file ] ?? null;
 
@@ -72,7 +78,7 @@ class Plugins_Page {
 			} else {
 				$update_message = sprintf(
 					esc_html__( 'There is a new version of %1$s available. %2$s', '%TEXTDOMAIN%' ),
-					$this->get_plugin()->get_name(),
+					$plugin->get_name(),
 					$update_now_link
 				);
 			}
@@ -103,7 +109,7 @@ class Plugins_Page {
 		);
 
 		$this->plugin_notice = [
-			'slug'             => $this->get_plugin()->get_slug(),
+			'slug'             => $plugin->get_slug(),
 			'message_row_html' => $message_row_html,
 		];
 	}
@@ -142,7 +148,13 @@ class Plugins_Page {
 	 * @return void
 	 */
 	public function output_notices_script() {
-		$slug = $this->get_plugin()->get_slug();
+		$plugin = $this->get_plugin();
+
+		if ( ! $plugin ) {
+			return;
+		}
+
+		$slug = $plugin->get_slug();
 		$notice = $this->get_plugin_notice();
 
 		if ( empty( $notice ) ) {
@@ -204,7 +216,13 @@ class Plugins_Page {
 	 * @return void
 	 */
 	public function remove_default_inline_update_msg() {
-		remove_action( "after_plugin_row_{$this->get_plugin()->get_path()}", 'wp_plugin_update_row' );
+		$plugin = $this->get_plugin();
+
+		if ( ! $plugin ) {
+			return;
+		}
+
+		remove_action( "after_plugin_row_{$plugin->get_path()}", 'wp_plugin_update_row' );
 	}
 
 	/**
@@ -214,7 +232,13 @@ class Plugins_Page {
 	 */
 	public function check_for_updates( $transient ) {
 		try {
-			return $this->get_plugin()->check_for_updates( $transient );
+			$plugin = $this->get_plugin();
+
+			if ( ! $plugin ) {
+				return $transient;
+			}
+
+			return $plugin->check_for_updates( $transient );
 		} catch ( \Throwable $exception ) {
 			return $transient;
 		}
@@ -242,13 +266,19 @@ class Plugins_Page {
 	 * @return mixed
 	 */
 	public function inject_info( $result, string $action = null, $args = null ) {
-		$relevant = ( 'plugin_information' === $action ) && is_object( $args ) && isset( $args->slug ) && ( $args->slug === $this->get_plugin()->get_slug() );
+		$plugin = $this->get_plugin();
+
+		if ( ! $plugin ) {
+			return $result;
+		}
+
+		$relevant = ( 'plugin_information' === $action ) && is_object( $args ) && isset( $args->slug ) && ( $args->slug === $plugin->get_slug() );
 
 		if ( ! $relevant ) {
 			return $result;
 		}
 
-		$plugin_info = $this->get_plugin()->validate_license();
+		$plugin_info = $plugin->validate_license();
 
 		if ( $plugin_info ) {
 			return $plugin_info->to_wp_format();

--- a/src/Uplink/Resources/Collection.php
+++ b/src/Uplink/Resources/Collection.php
@@ -30,11 +30,11 @@ class Collection implements ArrayAccess, Iterator {
 	}
 
 	/**
-	 * @return Resource
+	 * @return Resource|bool
 	 */
 	#[\ReturnTypeWillChange]
-	public function current(): Resource {
-		return current( $this->resources );
+	public function current() {
+		return ( ! $this->resources ) ? current( $this->resources ) : false;
 	}
 
 	/**

--- a/src/Uplink/Resources/Filters/Path_FilterIterator.php
+++ b/src/Uplink/Resources/Filters/Path_FilterIterator.php
@@ -32,6 +32,10 @@ class Path_FilterIterator extends \FilterIterator implements \Countable {
 	public function accept(): bool {
 		$resource = $this->getInnerIterator()->current();
 
+		if ( ! $resource ) {
+			return false;
+		}
+
 		return in_array( $resource->get_path(), $this->paths, true );
 	}
 

--- a/tests/wpunit/Resources/CollectionTest.php
+++ b/tests/wpunit/Resources/CollectionTest.php
@@ -105,7 +105,9 @@ class CollectionTest extends UplinkTestCase {
 	 */
 	public function it_should_loop_over_resources() {
 		foreach ( $this->collection as $resource ) {
-			$this->assertInstanceOf( Uplink_Resources\Resource::class, $resource );
+			if ( $resource ) {
+				$this->assertInstanceOf( Uplink_Resources\Resource::class, $resource );
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes: #45 

This PR refactors any instance of `get_plugin` to handle the fact that this could return boolean false, thanks to interference from 3rd party plugins. Unit tests have been updated to cater for the possible false return value.

These changes only deal with the problem as it presents, the exact source of the problem is still unclear, and I'm waiting for a customer to provide access to a staging site so that I can identify the plugin causing the problem on production.

