### PR TITLE
Bugfix: dynamic asset loading

### DIFF
--- a/src/Uplink/Admin/Field.php
+++ b/src/Uplink/Admin/Field.php
@@ -17,21 +17,21 @@ abstract class Field {
 	 *
 	 * @var string
 	 */
-	protected string $path = '';
+	protected $path = '';
 
 	/**
 	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
-	abstract public function register_settings();
+	abstract public function register_settings(): void;
 
 	/**
 	 * @param array<string> $args
 	 *
 	 * @return void
 	 */
-	public function get_description( array $args = [] ) {
+	public function get_description( array $args = [] ): void {
 		if ( empty( $args['description'] ) ) {
 			return;
 		}
@@ -71,7 +71,7 @@ abstract class Field {
 	 *
 	 * @return void
 	 */
-	public function field_html( array $args = [] ) {
+	public function field_html( array $args = [] ): void {
 		$field = sprintf(
 			'<div class="%6$s" id="%2$s" data-slug="%2$s" data-plugin="%9$s" data-plugin-slug="%10$s">
                     <fieldset class="stellarwp-uplink__settings-group">
@@ -112,7 +112,7 @@ abstract class Field {
 	 *
 	 * @return void
 	 */
-	abstract public function render( bool $show_title = true, bool $show_button = true );
+	abstract public function render( bool $show_title = true, bool $show_button = true ): void;
 
 	/**
 	 * @param array<mixed> $context
@@ -155,11 +155,11 @@ abstract class Field {
 	 * @since 1.0.0
 	 *
 	 * @param string $page Slug title of the admin page whose settings fields you want to show.
-	 * @param string $page Slug title of the admin page whose settings fields you want to show.
+	 * @param string $section Slug title of the settings section whose fields you want to show.
 	 * @param string $plugin_slug Slug title of the settings section whose fields you want to show.
 	 * @param bool   $show_title Whether to show the title or not.
 	 */
-	public function do_settings_fields( string $page, string $section, string $plugin_slug, bool $show_title = true ) {
+	public function do_settings_fields( string $page, string $section, string $plugin_slug, bool $show_title = true ): void {
 		global $wp_settings_fields;
 
 		if ( ! isset( $wp_settings_fields[ $page ][ $section ] ) ) {

--- a/src/Uplink/Admin/License_Field.php
+++ b/src/Uplink/Admin/License_Field.php
@@ -17,6 +17,17 @@ class License_Field extends Field {
 	protected $path = '/admin-views/fields/settings.php';
 
 	/**
+	 * The script and style handle when registering assets for this field.
+	 *
+	 * @var string
+	 */
+	private $handle;
+
+	public function __construct() {
+		$this->handle = sprintf( 'stellarwp-uplink-license-admin-%s', Config::get_hook_prefix() );
+	}
+
+	/**
 	 * @param Plugin $plugin
 	 *
 	 * @return string
@@ -82,6 +93,9 @@ class License_Field extends Field {
 	 * @inheritDoc
 	 */
 	public function render( bool $show_title = true, bool $show_button = true ): void {
+		wp_enqueue_script( $this->handle );
+		wp_enqueue_style( $this->handle );
+
 		echo $this->get_content( [
 			'plugin'      => $this->get_plugin(),
 			'show_title'  => $show_title,
@@ -96,14 +110,13 @@ class License_Field extends Field {
 	 */
 	public function enqueue_assets(): void {
 		$path   = Config::get_container()->get( Uplink::UPLINK_ASSETS_URI );
-		$handle = sprintf( 'stellarwp-uplink-license-admin-%s', Config::get_hook_prefix() );
 		$js_src = apply_filters( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/admin_js_source', $path . '/js/key-admin.js' );
-		wp_register_script( $handle, $js_src, [ 'jquery' ], '1.0.0', true );
-		wp_enqueue_script( $handle );
+		wp_register_script( $this->handle, $js_src, [ 'jquery' ], '1.0.0', true );
+
 		$action_postfix = Config::get_hook_prefix_underscored();
-		wp_localize_script( $handle, sprintf( 'stellarwp_config_%s', $action_postfix ), [ 'action' => sprintf( 'pue-validate-key-uplink-%s', $action_postfix ) ] );
+		wp_localize_script( $this->handle, sprintf( 'stellarwp_config_%s', $action_postfix ), [ 'action' => sprintf( 'pue-validate-key-uplink-%s', $action_postfix ) ] );
 
 		$css_src = apply_filters( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/admin_css_source', $path . '/css/main.css' );
-		wp_enqueue_style( $handle, $css_src );
+		wp_register_style( $this->handle, $css_src );
 	}
 }

--- a/src/Uplink/Admin/License_Field.php
+++ b/src/Uplink/Admin/License_Field.php
@@ -5,12 +5,16 @@ namespace StellarWP\Uplink\Admin;
 use StellarWP\Uplink\Config;
 use StellarWP\Uplink\Resources\Collection;
 use StellarWP\Uplink\Resources\Plugin;
+use StellarWP\Uplink\Uplink;
 
 class License_Field extends Field {
 
 	public const LICENSE_FIELD_ID = 'stellarwp_uplink_license';
 
-	protected string $path = '/admin-views/fields/settings.php';
+	/**
+	 * @var string
+	 */
+	protected $path = '/admin-views/fields/settings.php';
 
 	/**
 	 * @param Plugin $plugin
@@ -26,7 +30,7 @@ class License_Field extends Field {
 	 *
 	 * @return void
 	 */
-	public function register_settings() {
+	public function register_settings(): void {
 		$collection = Config::get_container()->get( Collection::class );
 		$plugin     = $collection->current();
 
@@ -77,7 +81,7 @@ class License_Field extends Field {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( bool $show_title = true, bool $show_button = true ) {
+	public function render( bool $show_title = true, bool $show_button = true ): void {
 		echo $this->get_content( [
 			'plugin'      => $this->get_plugin(),
 			'show_title'  => $show_title,
@@ -90,16 +94,16 @@ class License_Field extends Field {
 	 *
 	 * @return void
 	 */
-	public function enqueue_assets() {
+	public function enqueue_assets(): void {
+		$path   = Config::get_container()->get( Uplink::UPLINK_ASSETS_URI );
 		$handle = sprintf( 'stellarwp-uplink-license-admin-%s', Config::get_hook_prefix() );
-		$path   = preg_replace( '/.*\/vendor/', plugin_dir_url( $this->get_plugin()->get_path() ) . 'vendor', dirname( __DIR__, 2 ) );
-		$js_src = apply_filters( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/admin_js_source', $path . '/assets/js/key-admin.js' );
+		$js_src = apply_filters( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/admin_js_source', $path . '/js/key-admin.js' );
 		wp_register_script( $handle, $js_src, [ 'jquery' ], '1.0.0', true );
 		wp_enqueue_script( $handle );
 		$action_postfix = Config::get_hook_prefix_underscored();
 		wp_localize_script( $handle, sprintf( 'stellarwp_config_%s', $action_postfix ), [ 'action' => sprintf( 'pue-validate-key-uplink-%s', $action_postfix ) ] );
 
-		$css_src = apply_filters( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/admin_css_source', $path . '/assets/css/main.css' );
+		$css_src = apply_filters( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/admin_css_source', $path . '/css/main.css' );
 		wp_enqueue_style( $handle, $css_src );
 	}
 }

--- a/src/Uplink/Admin/License_Field.php
+++ b/src/Uplink/Admin/License_Field.php
@@ -22,7 +22,9 @@ class License_Field extends Field {
 	 * @var string
 	 */
 	private $handle;
-
+	/**
+	 * Constructor. Initializes handle.
+	 */
 	public function __construct() {
 		$this->handle = sprintf( 'stellarwp-uplink-license-admin-%s', Config::get_hook_prefix() );
 	}

--- a/src/Uplink/Admin/Plugins_Page.php
+++ b/src/Uplink/Admin/Plugins_Page.php
@@ -15,7 +15,7 @@ class Plugins_Page {
 	 *
 	 * @var array<mixed>
 	 */
-	public array $plugin_notice = [];
+	public $plugin_notice = [];
 
 	/**
 	 * Displays messages on the plugins page in the dashboard.
@@ -26,7 +26,7 @@ class Plugins_Page {
 	 *
 	 * @return void
 	 */
-	public function display_plugin_messages( string $page ) {
+	public function display_plugin_messages( string $page ): void {
 		if ( 'plugins.php' !== $page ) {
 			return;
 		}
@@ -126,7 +126,7 @@ class Plugins_Page {
 	 *
 	 * @return void
 	 */
-	public function store_admin_notices( string $page ) {
+	public function store_admin_notices( string $page ): void {
 		if ( 'plugins.php' !== $page ) {
 			return;
 		}
@@ -141,8 +141,8 @@ class Plugins_Page {
 	 *
 	 * @return void
 	 */
-	public function output_notices_script() {
-		$slug = $this->get_plugin()->get_slug();
+	public function output_notices_script(): void {
+		$slug   = $this->get_plugin()->get_slug();
 		$notice = $this->get_plugin_notice();
 
 		if ( empty( $notice ) ) {
@@ -203,7 +203,7 @@ class Plugins_Page {
 	 *
 	 * @return void
 	 */
-	public function remove_default_inline_update_msg() {
+	public function remove_default_inline_update_msg(): void {
 		remove_action( "after_plugin_row_{$this->get_plugin()->get_path()}", 'wp_plugin_update_row' );
 	}
 
@@ -235,13 +235,13 @@ class Plugins_Page {
 	 *
 	 * @see plugins_api()
 	 *
-	 * @param mixed               $result
-	 * @param string              $action
-	 * @param array<mixed>|object $args
+	 * @param mixed  $result
+	 * @param  string|null  $action
+	 * @param  array<mixed>|object|null  $args
 	 *
 	 * @return mixed
 	 */
-	public function inject_info( $result, string $action = null, $args = null ) {
+	public function inject_info( $result, ?string $action = null, $args = null ) {
 		$relevant = ( 'plugin_information' === $action ) && is_object( $args ) && isset( $args->slug ) && ( $args->slug === $this->get_plugin()->get_slug() );
 
 		if ( ! $relevant ) {

--- a/src/Uplink/Uplink.php
+++ b/src/Uplink/Uplink.php
@@ -7,6 +7,8 @@ use StellarWP\ContainerContract\ContainerInterface;
 
 class Uplink {
 
+	public const UPLINK_ASSETS_URI = 'uplink.assets.uri';
+
 	/**
 	 * Initializes the service provider.
 	 *
@@ -23,6 +25,7 @@ class Uplink {
 
 		$container = Config::get_container();
 
+		$container->singleton( self::UPLINK_ASSETS_URI, dirname( plugin_dir_url( __FILE__ ) ) . '/assets' );
 		$container->bind( ContainerInterface::class, $container );
 		$container->singleton( View\Provider::class, View\Provider::class );
 		$container->singleton( API\Client::class, API\Client::class );

--- a/tests/wpunit/ContainerTest.php
+++ b/tests/wpunit/ContainerTest.php
@@ -1,20 +1,30 @@
-<?php
+<?php declare( strict_types=1 );
 
 namespace wpunit;
 
 use StellarWP\ContainerContract\ContainerInterface;
 use StellarWP\Uplink\Config;
 use StellarWP\Uplink\Tests\UplinkTestCase;
+use StellarWP\Uplink\Uplink;
 
 class ContainerTest extends UplinkTestCase {
+
 	/**
 	 * Test that the container is correctly instantiated.
-	 *
-	 * @test
 	 */
-	public function it_should_instantiate() {
+	public function test_it_should_instantiate(): void {
 		$container = Config::get_container();
 
 		$this->assertInstanceOf( ContainerInterface::class, $container );
+	}
+
+	public function test_it_gets_the_uplink_assets_uri(): void {
+		$uri = $this->container->get( Uplink::UPLINK_ASSETS_URI );
+
+		$this->assertSame( 'http://wordpress.test/wp-content/plugins/uplink/src/assets', $uri );
+
+		$uri = Config::get_container()->get( Uplink::UPLINK_ASSETS_URI );
+
+		$this->assertSame( 'http://wordpress.test/wp-content/plugins/uplink/src/assets', $uri );
 	}
 }


### PR DESCRIPTION
- Properly load license field frontend assets no matter where the uplink library lives.
- Only enqueue license field frontend assets if the field is being rendered. 
- Remove non PHP7.1 types (class property types aren't available until PHP 7.4).