### PR TITLE
Bugfix: Support all Resources in the collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Register::service(
 
 In order to render license key form just add the following to your settings page, tab, etc.
 
-> ⚠️ This will render license key fields for all of your registered plugins/services.
+> ⚠️ This will render license key fields for all of your registered plugins/services in the same Uplink/Container instance.
 
 ```php
 use StellarWP\Uplink\Config;

--- a/README.md
+++ b/README.md
@@ -141,7 +141,11 @@ Register::service(
 ```
 
 ## Render license key form on your settings page
+
 In order to render license key form just add the following to your settings page, tab, etc.
+
+> ⚠️ This will render license key fields for all of your registered plugins/services.
+
 ```php
 use StellarWP\Uplink\Config;
 
@@ -151,6 +155,19 @@ $fields = Config::get_container()->get( License_Field::class );
 $fields->render();               // Render the fields, titles, and submit button.
 $fields->render( false );        // Render the fields without the titles.
 $fields->render( false, false ); // Render the fields without the titles or submit buttons.
+```
+
+To render a single product's license key, use the following:
+
+```php
+use StellarWP\Uplink\Config;
+
+$fields = Config::get_container()->get( License_Field::class );
+
+// Do one of the following:
+$fields->render_single( 'my-plugin' );               // Render the fields, titles, and submit button.
+$fields->render_single( 'my-plugin', false );        // Render the fields without the titles.
+$fields->render_single( 'my-plugin', false, false ); // Render the fields without the titles or submit buttons.
 ```
 
 ### Example: Register settings page and render license fields
@@ -178,7 +195,7 @@ function render_settings_page() {
     // ...
 
     $fields = Config::get_container()->get( License_Field::class );
-    $fields->render();
+    $fields->render(); // or $fields->render_single( 'my-plugin' ); to render a single plugin
 
     //....
 }

--- a/src/Uplink/Admin/Ajax.php
+++ b/src/Uplink/Admin/Ajax.php
@@ -25,7 +25,6 @@ class Ajax {
 	public function validate_license(): void {
 		$submission = [
 			'_wpnonce' => sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ?? '' ) ),
-			'plugin'   => sanitize_text_field( wp_unslash( $_POST['plugin'] ?? '' ) ),
 			'slug'     => sanitize_text_field( wp_unslash( $_POST['slug'] ?? '' ) ),
 			'key'      => Utils\Sanitize::key( wp_unslash( $_POST['key'] ?? '' ) ),
 		];
@@ -51,7 +50,7 @@ class Ajax {
 		}
 
 		$results = $plugin->validate_license( $submission['key'] );
-		$message = is_plugin_active_for_network( $submission['plugin'] ) ? $results->get_network_message()->get() : $results->get_message()->get();
+		$message = is_plugin_active_for_network( $plugin->get_path() ) ? $results->get_network_message()->get() : $results->get_message()->get();
 
 		wp_send_json( [
 			'status'  => absint( $results->is_valid() ),

--- a/src/Uplink/Admin/Field.php
+++ b/src/Uplink/Admin/Field.php
@@ -1,8 +1,7 @@
-<?php
+<?php declare( strict_types=1 );
 
 namespace StellarWP\Uplink\Admin;
 
-use StellarWP\ContainerContract\ContainerInterface;
 use StellarWP\Uplink\Config;
 use StellarWP\Uplink\Resources\Collection;
 
@@ -25,6 +24,18 @@ abstract class Field {
 	 * @return void
 	 */
 	abstract public function register_settings(): void;
+
+	/**
+	 * Renders the field.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param bool $show_title Whether to show the title or not.
+	 * @param bool $show_button Whether to show the submit button or not.
+	 *
+	 * @return void
+	 */
+	abstract public function render( bool $show_title = true, bool $show_button = true ): void;
 
 	/**
 	 * @param array<string> $args
@@ -105,16 +116,6 @@ abstract class Field {
 	}
 
 	/**
-	 * @since 1.0.0
-	 *
-	 * @param bool $show_title Whether to show the title or not.
-	 * @param bool $show_button Whether to show the submit button or not.
-	 *
-	 * @return void
-	 */
-	abstract public function render( bool $show_title = true, bool $show_button = true ): void;
-
-	/**
 	 * @param array<mixed> $context
 	 *
 	 * @return false|string
@@ -135,12 +136,12 @@ abstract class Field {
 	}
 
 	/**
-	 * @return false|mixed
+	 * Get the collection of Plugins/Services.
+	 *
+	 * @return Collection
 	 */
-	protected function get_plugin() {
-		$collection = Config::get_container()->get( Collection::class );
-
-		return $collection->current();
+	protected function get_resources(): Collection {
+		return Config::get_container()->get( Collection::class );
 	}
 
 	/**

--- a/src/Uplink/Admin/Field.php
+++ b/src/Uplink/Admin/Field.php
@@ -101,7 +101,7 @@ abstract class Field {
 			$this->add_nonce_field(),
 			esc_attr( $args['plugin'] ),
 			esc_attr( $args['plugin_slug'] ),
-			Config::get_hook_prefix_underscored()
+			esc_attr( Config::get_hook_prefix_underscored() )
 		);
 
 		echo apply_filters( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/license_field_html_render', $field, $args );

--- a/src/Uplink/Admin/Field.php
+++ b/src/Uplink/Admin/Field.php
@@ -84,7 +84,7 @@ abstract class Field {
 	 */
 	public function field_html( array $args = [] ): void {
 		$field = sprintf(
-			'<div class="%6$s" id="%2$s" data-slug="%2$s" data-plugin="%9$s" data-plugin-slug="%10$s">
+			'<div class="%6$s" id="%2$s" data-slug="%2$s" data-plugin="%9$s" data-plugin-slug="%10$s" data-action="%11$s">
                     <fieldset class="stellarwp-uplink__settings-group">
                         <input type="%1$s" name="%3$s" value="%4$s" placeholder="%5$s" class="regular-text stellarwp-uplink__settings-field" />
                         %7$s
@@ -99,7 +99,8 @@ abstract class Field {
 			esc_attr( $args['html_classes'] ?: '' ),
 			$this->get_html_content( $args ),
 			$this->add_nonce_field(),
-			$args['plugin'],
+			esc_attr( $args['plugin'] ),
+			esc_attr( $args['plugin_slug'] ),
 			Config::get_hook_prefix_underscored()
 		);
 

--- a/src/Uplink/Admin/License_Field.php
+++ b/src/Uplink/Admin/License_Field.php
@@ -36,7 +36,7 @@ class License_Field extends Field {
 	 *
 	 * @return string
 	 */
-	public function get_section_name( $plugin ) : string {
+	public static function get_section_name( $plugin ) : string {
 		return sprintf( '%s_%s', self::LICENSE_FIELD_ID, sanitize_title( $plugin->get_slug() ) );
 	}
 
@@ -48,7 +48,7 @@ class License_Field extends Field {
 	public function register_settings(): void {
 		foreach ( $this->get_resources() as $resource ) {
 			add_settings_section(
-				sprintf( '%s_%s', self::LICENSE_FIELD_ID, sanitize_title( $resource->get_slug() ) ),
+				self::get_section_name( $resource ),
 				'',
 				[ $this, 'description' ], // @phpstan-ignore-line
 				$this->get_group_name( sanitize_title( $resource->get_slug() ) )
@@ -64,7 +64,7 @@ class License_Field extends Field {
 				__( 'License Key', '%TEXTDOMAIN%' ),
 				[ $this, 'field_html' ],
 				$this->get_group_name( sanitize_title( $resource->get_slug() ) ),
-				$this->get_section_name( $resource ),
+				self::get_section_name( $resource ),
 				[
 					'id'           => $resource->get_license_object()->get_key_option_name(),
 					'label_for'    => $resource->get_license_object()->get_key_option_name(),

--- a/src/Uplink/Admin/License_Field.php
+++ b/src/Uplink/Admin/License_Field.php
@@ -75,6 +75,7 @@ class License_Field extends Field {
 					'html'         => $this->get_field_html( $resource ),
 					'html_classes' => 'stellarwp-uplink-license-key-field',
 					'plugin'       => $resource->get_path(),
+					'plugin_slug'  => $resource->get_slug(),
 				]
 			);
 		}

--- a/src/Uplink/Admin/License_Field.php
+++ b/src/Uplink/Admin/License_Field.php
@@ -1,10 +1,11 @@
-<?php
+<?php declare( strict_types=1 );
 
 namespace StellarWP\Uplink\Admin;
 
 use StellarWP\Uplink\Config;
-use StellarWP\Uplink\Resources\Collection;
 use StellarWP\Uplink\Resources\Plugin;
+use StellarWP\Uplink\Resources\Resource;
+use StellarWP\Uplink\Resources\Service;
 use StellarWP\Uplink\Uplink;
 
 class License_Field extends Field {
@@ -22,6 +23,7 @@ class License_Field extends Field {
 	 * @var string
 	 */
 	private $handle;
+
 	/**
 	 * Constructor. Initializes handle.
 	 */
@@ -30,11 +32,11 @@ class License_Field extends Field {
 	}
 
 	/**
-	 * @param Plugin $plugin
+	 * @param Plugin|Service|Resource $plugin
 	 *
 	 * @return string
 	 */
-	public function get_section_name( Plugin $plugin ) : string {
+	public function get_section_name( $plugin ) : string {
 		return sprintf( '%s_%s', self::LICENSE_FIELD_ID, sanitize_title( $plugin->get_slug() ) );
 	}
 
@@ -44,46 +46,48 @@ class License_Field extends Field {
 	 * @return void
 	 */
 	public function register_settings(): void {
-		$collection = Config::get_container()->get( Collection::class );
-		$plugin     = $collection->current();
+		foreach ( $this->get_resources() as $resource ) {
+			add_settings_section(
+				sprintf( '%s_%s', self::LICENSE_FIELD_ID, sanitize_title( $resource->get_slug() ) ),
+				'',
+				[ $this, 'description' ], // @phpstan-ignore-line
+				$this->get_group_name( sanitize_title( $resource->get_slug() ) )
+			);
 
-		add_settings_section(
-			sprintf( '%s_%s', self::LICENSE_FIELD_ID, sanitize_title( $plugin->get_slug() ) ),
-			'',
-			[ $this, 'description' ], // @phpstan-ignore-line
-			$this->get_group_name( sanitize_title( $plugin->get_slug() ) )
-		);
+			register_setting(
+				$this->get_group_name( sanitize_title( $resource->get_slug() ) ),
+				$resource->get_license_object()->get_key_option_name()
+			);
 
-		register_setting( $this->get_group_name( sanitize_title( $plugin->get_slug() ) ), $plugin->get_license_object()->get_key_option_name() );
-
-		add_settings_field(
-			$plugin->get_license_object()->get_key_option_name(),
-			__( 'License Key', '%TEXTDOMAIN%' ),
-			[ $this, 'field_html' ],
-			$this->get_group_name( sanitize_title( $plugin->get_slug() ) ),
-			$this->get_section_name( $plugin ),
-			[
-				'id'           => $plugin->get_license_object()->get_key_option_name(),
-				'label_for'    => $plugin->get_license_object()->get_key_option_name(),
-				'type'         => 'text',
-				'path'         => $plugin->get_path(),
-				'value'        => $plugin->get_license_key(),
-				'placeholder'  => __( 'License Number', '%TEXTDOMAIN%' ),
-				'html'         => $this->get_field_html( $plugin ),
-				'html_classes' => 'stellarwp-uplink-license-key-field',
-				'plugin'       => $plugin->get_path(),
-			]
-		);
+			add_settings_field(
+				$resource->get_license_object()->get_key_option_name(),
+				__( 'License Key', '%TEXTDOMAIN%' ),
+				[ $this, 'field_html' ],
+				$this->get_group_name( sanitize_title( $resource->get_slug() ) ),
+				$this->get_section_name( $resource ),
+				[
+					'id'           => $resource->get_license_object()->get_key_option_name(),
+					'label_for'    => $resource->get_license_object()->get_key_option_name(),
+					'type'         => 'text',
+					'path'         => $resource->get_path(),
+					'value'        => $resource->get_license_key(),
+					'placeholder'  => __( 'License Number', '%TEXTDOMAIN%' ),
+					'html'         => $this->get_field_html( $resource ),
+					'html_classes' => 'stellarwp-uplink-license-key-field',
+					'plugin'       => $resource->get_path(),
+				]
+			);
+		}
 	}
 
 	/**
 	 * @since 1.0.0
 	 *
-	 * @param Plugin $plugin
+	 * @param Plugin|Service|Resource $plugin
 	 *
 	 * @return string
 	 */
-	public function get_field_html( Plugin $plugin ) : string {
+	public function get_field_html( $plugin ) : string {
 		$html = sprintf( '<p class="tooltip description">%s</p>', __( 'A valid license key is required for support and updates', '%TEXTDOMAIN%' ) );
 		$html .= '<div class="license-test-results"><img src="' . esc_url( admin_url( 'images/wpspin_light.gif' ) ) . '" class="ajax-loading-license" alt="Loading" style="display: none"/>';
 		$html .= '<div class="key-validity"></div></div>';
@@ -92,25 +96,48 @@ class License_Field extends Field {
 	}
 
 	/**
+	 * Renders a license field for all registered Resources.
+	 *
 	 * @inheritDoc
 	 */
 	public function render( bool $show_title = true, bool $show_button = true ): void {
-		wp_enqueue_script( $this->handle );
-		wp_enqueue_style( $this->handle );
+		foreach ( $this->get_resources() as $resource ) {
+			$this->render_single( $resource->get_slug(), $show_title, $show_button );
+		}
+	}
+
+	/**
+	 * Renders a single resource's license field.
+	 *
+	 * @param string $plugin_slug The plugin slug to render.
+	 * @param bool $show_title Whether to show the title or not.
+	 * @param bool $show_button Whether to show the submit button or not.
+	 *
+	 * @return void
+	 */
+	public function render_single( string $plugin_slug, bool $show_title = true, bool $show_button = true ): void {
+		$this->enqueue_assets();
+
+		$resource = $this->get_resources()->offsetGet( $plugin_slug );
+
+		if ( ! $resource ) {
+			return;
+		}
 
 		echo $this->get_content( [
-			'plugin'      => $this->get_plugin(),
+			'plugin'      => $resource,
 			'show_title'  => $show_title,
 			'show_button' => $show_button,
 		] );
 	}
+
 
 	/**
 	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
-	public function enqueue_assets(): void {
+	public function register_assets(): void {
 		$path   = Config::get_container()->get( Uplink::UPLINK_ASSETS_URI );
 		$js_src = apply_filters( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/admin_js_source', $path . '/js/key-admin.js' );
 		wp_register_script( $this->handle, $js_src, [ 'jquery' ], '1.0.0', true );
@@ -121,4 +148,15 @@ class License_Field extends Field {
 		$css_src = apply_filters( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/admin_css_source', $path . '/css/main.css' );
 		wp_register_style( $this->handle, $css_src );
 	}
+
+	/**
+	 * Enqueue the registered scripts and styles, only when rendering fields.
+	 *
+	 * @return void
+	 */
+	protected function enqueue_assets(): void {
+		wp_enqueue_script( $this->handle );
+		wp_enqueue_style( $this->handle );
+	}
+
 }

--- a/src/Uplink/Admin/Package_Handler.php
+++ b/src/Uplink/Admin/Package_Handler.php
@@ -100,11 +100,8 @@ class Package_Handler {
 
 		$container = Config::get_container();
 		$resource  = $container->get( Resources\Collection::class )->get_by_path( $plugin );
-		if ( $resource->count() === 0 ) {
-			return false;
-		}
 
-		return true;
+		return (bool) $resource->count();
 	}
 
 	/**

--- a/src/Uplink/Admin/Plugins_Page.php
+++ b/src/Uplink/Admin/Plugins_Page.php
@@ -3,7 +3,6 @@
 namespace StellarWP\Uplink\Admin;
 
 use StellarWP\Uplink\Config;
-use StellarWP\Uplink\Messages;
 use StellarWP\Uplink\Resources\Collection;
 use StellarWP\Uplink\Resources\Plugin;
 use Throwable;
@@ -201,21 +200,6 @@ class Plugins_Page {
 		</script>
 		<?php
 		endforeach;
-	}
-
-	/**
-	 * Get the plugin message.
-	 *
-	 * @TODO Matt, this isn't used anywhere, can we delete?
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param Plugin $resource
-	 *
-	 * @return Messages\Message_Abstract|null
-	 */
-	public function get_plugin_message( Plugin $resource ) {
-		return new Messages\Expired_Key();
 	}
 
 	/**

--- a/src/Uplink/Admin/Plugins_Page.php
+++ b/src/Uplink/Admin/Plugins_Page.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types=1 );
 
 namespace StellarWP\Uplink\Admin;
 
@@ -6,15 +6,23 @@ use StellarWP\Uplink\Config;
 use StellarWP\Uplink\Messages;
 use StellarWP\Uplink\Resources\Collection;
 use StellarWP\Uplink\Resources\Plugin;
+use Throwable;
 
 class Plugins_Page {
 
 	/**
-	 * Storing the `plugin_notice` message.
+	 * Storing the `plugin_notice` message for each plugin.
 	 *
-	 * @var array<mixed>
+	 * @var array<string, array{slug: string, message_row_html: string}>
 	 */
-	public $plugin_notice = [];
+	private $plugin_notices = [];
+
+	/**
+	 * The memoization cache for existing plugins.
+	 *
+	 * @var ?Collection<Plugin>
+	 */
+	private $plugins;
 
 	/**
 	 * Displays messages on the plugins page in the dashboard.
@@ -31,91 +39,96 @@ class Plugins_Page {
 		}
 
 		$messages       = [];
-		$plugin_file    = $this->get_plugin()->get_path();
+		$plugins        = $this->get_plugins();
 		$plugin_updates = get_plugin_updates();
-		$resource       = $plugin_updates[ $plugin_file ] ?? null;
 
-		if ( empty( $resource ) ) {
-			return;
-		}
+		foreach ( $plugins as $plugin ) {
+			$plugin_file = $plugin->get_path();
+			$resource    = $plugin_updates[ $plugin_file ] ?? null;
 
-		if ( ! empty( $resource->update->license_error ) ) {
-			$messages[] = $resource->update->license_error;
-		} elseif ( current_user_can( 'update_plugins' ) ) {
-			if ( empty( $resource->update->new_version ) ) {
-				return;
-			}
-			// A plugin update is available
-			$update_now = sprintf(
-				esc_html__( 'Update now to version %s.', '%TEXTDOMAIN%' ),
-				$resource->update->new_version
-			);
-
-			$href = wp_nonce_url(
-				self_admin_url( 'update.php?action=upgrade-plugin&plugin=' ) . $plugin_file,
-				'upgrade-plugin_' . $plugin_file
-			);
-
-			$update_now_link = sprintf(
-				' <a href="%1$s" class="update-link">%2$s</a>',
-				$href,
-				$update_now
-			);
-
-			if ( ! empty ( $resource->update->upgrade_notice ) ) {
-				$update_message = sprintf(
-					esc_html__( '%1$s. %2$s', '%TEXTDOMAIN%' ),
-					$resource->update->upgrade_notice,
-					$update_now_link
-				);
-			} else {
-				$update_message = sprintf(
-					esc_html__( 'There is a new version of %1$s available. %2$s', '%TEXTDOMAIN%' ),
-					$this->get_plugin()->get_name(),
-					$update_now_link
-				);
+			if ( empty( $resource ) ) {
+				continue;
 			}
 
+			if ( ! empty( $resource->update->license_error ) ) {
+				$messages[] = $resource->update->license_error;
+			} elseif ( current_user_can( 'update_plugins' ) ) {
+				if ( empty( $resource->update->new_version ) ) {
+					continue;
+				}
 
-			$messages[] = sprintf(
-				'<p>%s</p>',
-				$update_message
+				// A plugin update is available
+				$update_now = sprintf(
+					esc_html__( 'Update now to version %s.', '%TEXTDOMAIN%' ),
+					$resource->update->new_version
+				);
+
+				$href = wp_nonce_url(
+					self_admin_url( 'update.php?action=upgrade-plugin&plugin=' ) . $plugin_file,
+					'upgrade-plugin_' . $plugin_file
+				);
+
+				$update_now_link = sprintf(
+					' <a href="%1$s" class="update-link">%2$s</a>',
+					$href,
+					$update_now
+				);
+
+				if ( ! empty ( $resource->update->upgrade_notice ) ) {
+					$update_message = sprintf(
+						esc_html__( '%1$s. %2$s', '%TEXTDOMAIN%' ),
+						$resource->update->upgrade_notice,
+						$update_now_link
+					);
+				} else {
+					$update_message = sprintf(
+						esc_html__( 'There is a new version of %1$s available. %2$s', '%TEXTDOMAIN%' ),
+						$plugin->get_name(),
+						$update_now_link
+					);
+				}
+
+
+				$messages[] = sprintf(
+					'<p>%s</p>',
+					$update_message
+				);
+			}
+
+			if ( empty( $messages ) ) {
+				continue;
+			}
+
+			$message_row_html = '';
+
+			foreach ( $messages as $message ) {
+				$message_row_html .= sprintf(
+					'<div class="update-message notice inline notice-warning notice-alt">%s</div>',
+					$message
+				);
+			}
+
+			$message_row_html = sprintf(
+				'<tr class="plugin-update-tr active"><td colspan="4" class="plugin-update">%s</td></tr>',
+				$message_row_html
 			);
+
+			$this->plugin_notices[ $plugin->get_slug() ] = [
+				'slug'             => $plugin->get_slug(),
+				'message_row_html' => $message_row_html,
+			];
 		}
-
-		if ( empty( $messages ) ) {
-			return;
-		}
-
-		$message_row_html = '';
-
-		foreach ( $messages as $message ) {
-			$message_row_html .= sprintf(
-				'<div class="update-message notice inline notice-warning notice-alt">%s</div>',
-				$message
-			);
-		}
-
-		$message_row_html = sprintf(
-			'<tr class="plugin-update-tr active"><td colspan="4" class="plugin-update">%s</td></tr>',
-			$message_row_html
-		);
-
-		$this->plugin_notice = [
-			'slug'             => $this->get_plugin()->get_slug(),
-			'message_row_html' => $message_row_html,
-		];
 	}
 
 	/**
-	 * Get plugin notice.
+	 * Get plugin notices.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return array
+	 * @return array<string, array{slug: string, message_row_html: string}>
 	 */
-	public function get_plugin_notice() {
-		return apply_filters( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/plugin_notices', $this->plugin_notice );
+	public function get_plugin_notices(): array {
+		return apply_filters( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/plugin_notices', $this->plugin_notices );
 	}
 
 	/**
@@ -141,12 +154,18 @@ class Plugins_Page {
 	 * @return void
 	 */
 	public function output_notices_script(): void {
-		$slug   = $this->get_plugin()->get_slug();
-		$notice = $this->get_plugin_notice();
+		$notices = $this->get_plugin_notices();
 
-		if ( empty( $notice ) ) {
+		if ( empty( $notices ) ) {
 			return;
 		}
+
+		foreach ( $this->get_plugins() as $resource ) :
+			$notice = $notices[ $resource->get_slug() ] ?? null;
+
+			if ( ! $notice ) {
+				continue;
+			}
 		?>
 		<script>
 		/**
@@ -159,7 +178,7 @@ class Plugins_Page {
 			'use strict';
 
 			my.init = function() {
-				var $active_plugin_row = $( 'tr.active[data-slug="<?php echo esc_attr( $slug ); ?>"]' );
+				var $active_plugin_row = $( 'tr.active[data-slug="<?php echo esc_attr( $resource->get_slug() ); ?>"]' );
 
 				if ( ! $active_plugin_row.length ) {
 					return;
@@ -181,10 +200,13 @@ class Plugins_Page {
 		})( jQuery, {} );
 		</script>
 		<?php
+		endforeach;
 	}
 
 	/**
 	 * Get the plugin message.
+	 *
+	 * @TODO Matt, this isn't used anywhere, can we delete?
 	 *
 	 * @since 1.0.0
 	 *
@@ -203,7 +225,9 @@ class Plugins_Page {
 	 * @return void
 	 */
 	public function remove_default_inline_update_msg(): void {
-		remove_action( "after_plugin_row_{$this->get_plugin()->get_path()}", 'wp_plugin_update_row' );
+		foreach ( $this->get_plugins() as $plugin ) {
+			remove_action( "after_plugin_row_{$plugin->get_path()}", 'wp_plugin_update_row' );
+		}
 	}
 
 	/**
@@ -213,19 +237,28 @@ class Plugins_Page {
 	 */
 	public function check_for_updates( $transient ) {
 		try {
-			return $this->get_plugin()->check_for_updates( $transient );
-		} catch ( \Throwable $exception ) {
+			/** @var Plugin $resource */
+			foreach ( $this->get_plugins() as $resource ) {
+				$transient = $resource->check_for_updates( $transient );
+			}
+		} catch ( Throwable $exception ) {
 			return $transient;
 		}
+
+		return $transient;
 	}
 
 	/**
-	 * @return false|mixed
+	 * Get the collection of Plugins/Services.
+	 *
+	 * @return Collection<Plugin>
 	 */
-	protected function get_plugin() {
-		$collection = Config::get_container()->get( Collection::class );
+	protected function get_plugins(): Collection {
+		if ( isset( $this->plugins ) ) {
+			return $this->plugins;
+		}
 
-		return $collection->current();
+		return $this->plugins = Config::get_container()->get( Collection::class )->get_plugins();
 	}
 
 	/**
@@ -235,25 +268,25 @@ class Plugins_Page {
 	 * @see plugins_api()
 	 *
 	 * @param mixed  $result
-	 * @param  string|null  $action
-	 * @param  array<mixed>|object|null  $args
+	 * @param string|null  $action
+	 * @param array<mixed>|object|null  $args
 	 *
 	 * @return mixed
 	 */
 	public function inject_info( $result, ?string $action = null, $args = null ) {
-		$relevant = ( 'plugin_information' === $action ) && is_object( $args ) && isset( $args->slug ) && ( $args->slug === $this->get_plugin()->get_slug() );
+		$relevant = ( 'plugin_information' === $action ) && is_object( $args ) && ! empty( $args->slug );
 
 		if ( ! $relevant ) {
 			return $result;
 		}
 
-		$plugin_info = $this->get_plugin()->validate_license();
+		$plugin = $this->get_plugins()->offsetGet( $args->slug );
 
-		if ( $plugin_info ) {
-			return $plugin_info->to_wp_format();
+		if ( ! $plugin ) {
+			return $result;
 		}
 
-		return $result;
+		return $plugin->validate_license()->to_wp_format();
 	}
 
 }

--- a/src/Uplink/Admin/Plugins_Page.php
+++ b/src/Uplink/Admin/Plugins_Page.php
@@ -2,7 +2,6 @@
 
 namespace StellarWP\Uplink\Admin;
 
-use StellarWP\ContainerContract\ContainerInterface;
 use StellarWP\Uplink\Config;
 use StellarWP\Uplink\Messages;
 use StellarWP\Uplink\Resources\Collection;

--- a/src/Uplink/Admin/Provider.php
+++ b/src/Uplink/Admin/Provider.php
@@ -1,9 +1,8 @@
-<?php
+<?php declare( strict_types=1 );
 
 namespace StellarWP\Uplink\Admin;
 
 use StellarWP\Uplink\Config;
-use StellarWP\Uplink\Uplink;
 use StellarWP\Uplink\Contracts\Abstract_Provider;
 
 class Provider extends Abstract_Provider {
@@ -43,7 +42,7 @@ class Provider extends Abstract_Provider {
 		add_action($action, [ $this, 'ajax_validate_license' ], 10, 0 );
 		add_action( 'admin_init', [ $this, 'admin_init' ], 10, 0 );
 		add_action( 'admin_enqueue_scripts', [ $this, 'display_plugin_messages' ], 1, 1 );
-		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ], 10, 0 );
+		add_action( 'admin_enqueue_scripts', [ $this, 'register_assets' ], 10, 0 );
 		add_action( 'admin_enqueue_scripts', [ $this, 'store_admin_notices' ], 10, 1 );
 		add_action( 'admin_notices', [ $this, 'admin_notices' ], 10, 0 );
 		add_action( 'load-plugins.php', [ $this, 'remove_default_update_message' ], 50, 0 );
@@ -84,7 +83,7 @@ class Provider extends Abstract_Provider {
 	 *
 	 * @return void
 	 */
-	public function ajax_validate_license() {
+	public function ajax_validate_license(): void {
 		$this->container->get( Ajax::class )->validate_license();
 	}
 
@@ -95,19 +94,19 @@ class Provider extends Abstract_Provider {
 	 *
 	 * @return void
 	 */
-	public function admin_init() {
+	public function admin_init(): void {
 		$this->container->get( License_Field::class )->register_settings();
 	}
 
 	/**
-	 * Hooked to the admin_enqueue_scripts action. Enqueues assets.
+	 * Hooked to the admin_enqueue_scripts action. Register assets.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
-	public function enqueue_assets() {
-		$this->container->get( License_Field::class )->enqueue_assets();
+	public function register_assets(): void {
+		$this->container->get( License_Field::class )->register_assets();
 	}
 
 	/**
@@ -117,7 +116,7 @@ class Provider extends Abstract_Provider {
 	 *
 	 * @return void
 	 */
-	public function admin_notices() {
+	public function admin_notices(): void {
 		$this->container->get( Notice::class )->setup_notices();
 	}
 
@@ -130,7 +129,7 @@ class Provider extends Abstract_Provider {
 	 *
 	 * @return void
 	 */
-	public function display_plugin_messages( $page ) {
+	public function display_plugin_messages( $page ): void {
 		$this->container->get( Plugins_Page::class )->display_plugin_messages( $page );
 	}
 
@@ -143,7 +142,7 @@ class Provider extends Abstract_Provider {
 	 *
 	 * @return void
 	 */
-	public function store_admin_notices( $page ) {
+	public function store_admin_notices( $page ): void {
 		$this->container->get( Plugins_Page::class )->store_admin_notices( $page );
 	}
 
@@ -154,7 +153,7 @@ class Provider extends Abstract_Provider {
 	 *
 	 * @return void
 	 */
-	public function remove_default_update_message() {
+	public function remove_default_update_message(): void {
 		$this->container->get( Plugins_Page::class )->remove_default_inline_update_msg();
 	}
 

--- a/src/Uplink/Admin/Update_Prevention.php
+++ b/src/Uplink/Admin/Update_Prevention.php
@@ -1,11 +1,10 @@
-<?php
+<?php declare( strict_types=1 );
 
 namespace StellarWP\Uplink\Admin;
 
 use StellarWP\ContainerContract\ContainerInterface;
 use StellarWP\Uplink\Config;
 use StellarWP\Uplink\Resources\Collection;
-use StellarWP\Uplink\Resources\Plugin;
 use WP_Error;
 use WP_Upgrader;
 
@@ -27,7 +26,7 @@ class Update_Prevention {
 
 	/**
 	 * Checks for the list of constants associate with plugin to make sure we are dealing
-	 * with a plugin owned by The Events Calendar.
+	 * with a plugin owned by the plugin using this library.
 	 *
 	 * @since  4.9.12
 	 *
@@ -37,15 +36,13 @@ class Update_Prevention {
 	 */
 	public function is_stellar_uplink_resource( string $plugin ): bool {
 		$collection = $this->container->get( Collection::class );
-		$resource   = $collection->get_by_path( $plugin );
+		$resources  = $collection->get_by_path( $plugin );
 
-		foreach ( $resource as $data ) {
-			if ( $data instanceof Plugin ) {
-				return true;
-			}
+		if ( ! $resources->count() ) {
+			return false;
 		}
 
-		return false;
+		return (bool) $collection->get_plugins( $resources )->count();
 	}
 
 	/**
@@ -85,7 +82,7 @@ class Update_Prevention {
 		}
 
 		/**
-		 * Filter the if we should prevent the update.
+		 * Filter if we should prevent the update.
 		 *
 		 * @since  4.9.12
 		 *
@@ -118,6 +115,7 @@ class Update_Prevention {
 
 		$link_read_more = '<a href="http://evnt.is/1aev" target="_blank">' . esc_html__( 'Read more', '%TEXTDOMAIN%' ) . '.</a>';
 
+		// @TODO: Matt wants to adjust this.
 		$message = sprintf(
 			esc_html__( 'Your update failed due to an incompatibility between the version (%1$s) of the %2$s you tried to update to. %3$s', '%TEXTDOMAIN%' ),
 			esc_html( $plugin_data['Version'] ),

--- a/src/Uplink/Admin/Update_Prevention.php
+++ b/src/Uplink/Admin/Update_Prevention.php
@@ -115,7 +115,6 @@ class Update_Prevention {
 
 		$link_read_more = '<a href="http://evnt.is/1aev" target="_blank">' . esc_html__( 'Read more', '%TEXTDOMAIN%' ) . '.</a>';
 
-		// @TODO: Matt wants to adjust this.
 		$message = sprintf(
 			esc_html__( 'Your update failed due to an incompatibility between the version (%1$s) of the %2$s you tried to update to. %3$s', '%TEXTDOMAIN%' ),
 			esc_html( $plugin_data['Version'] ),

--- a/src/Uplink/Resources/Collection.php
+++ b/src/Uplink/Resources/Collection.php
@@ -19,12 +19,12 @@ class Collection implements ArrayAccess, Iterator, Countable {
 	/**
 	 * The original Iterator, for memoization.
 	 *
-	 * @var Iterator|null
+	 * @var Iterator<string, Resource>|null
 	 */
 	private $iterator;
 
 	/**
-	 * @param Iterator|array<string, Resource> $resources An array or iterator of Resources.
+	 * @param Iterator<string, Resource>|array<string, Resource> $resources An array or iterator of Resources.
 	 */
 	public function __construct( $resources = [] ) {
 		if ( $resources instanceof Iterator ) {
@@ -44,7 +44,7 @@ class Collection implements ArrayAccess, Iterator, Countable {
 	 *
 	 * @return Resource
 	 */
-	public function add( Resource $resource ) {
+	public function add( Resource $resource ): Resource {
 		if ( ! $this->offsetExists( $resource->get_slug() ) ) {
 			$this->offsetSet( $resource->get_slug(), $resource );
 		}
@@ -66,7 +66,7 @@ class Collection implements ArrayAccess, Iterator, Countable {
 	 * @since 1.0.0
 	 *
 	 * @param string $path Path to filter collection by.
-	 * @param Iterator|null  $iterator Optional. Iterator to filter.
+	 * @param Iterator<string, Resource>|null  $iterator Optional. Iterator to filter.
 	 *
 	 * @return self
 	 */
@@ -82,7 +82,7 @@ class Collection implements ArrayAccess, Iterator, Countable {
 	 * @since 1.0.0
 	 *
 	 * @param array<string> $paths Paths to filter collection by.
-	 * @param Iterator|null  $iterator Optional. Iterator to filter.
+	 * @param Iterator<string, Resource>|null  $iterator Optional. Iterator to filter.
 	 *
 	 * @return self
 	 */
@@ -97,7 +97,7 @@ class Collection implements ArrayAccess, Iterator, Countable {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param  Iterator|null  $iterator Optional. Iterator to filter.
+	 * @param  Iterator<string, Resource>|null  $iterator Optional. Iterator to filter.
 	 *
 	 * @return self
 	 */
@@ -112,7 +112,7 @@ class Collection implements ArrayAccess, Iterator, Countable {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param  Iterator|null  $iterator Optional. Iterator to filter.
+	 * @param  Iterator<string, Resource>|null  $iterator Optional. Iterator to filter.
 	 *
 	 * @return self
 	 */
@@ -219,7 +219,7 @@ class Collection implements ArrayAccess, Iterator, Countable {
 	/**
 	 * Returns a clone of the underlying iterator.
 	 *
-	 * @return Iterator
+	 * @return Iterator<string, Resource>
 	 */
 	public function getIterator(): Iterator {
 		if ( isset( $this->iterator ) ) {

--- a/src/Uplink/Resources/Collection.php
+++ b/src/Uplink/Resources/Collection.php
@@ -209,6 +209,11 @@ class Collection implements ArrayAccess, Iterator, Countable {
 		return count( $this->resources );
 	}
 
+	/**
+	 * Returns a clone of the underlying iterator.
+	 *
+	 * @return ArrayIterator
+	 */
 	public function getIterator(): ArrayIterator {
 		return new ArrayIterator( $this->resources );
 	}

--- a/src/Uplink/Resources/Filters/Path_FilterIterator.php
+++ b/src/Uplink/Resources/Filters/Path_FilterIterator.php
@@ -28,8 +28,8 @@ class Path_FilterIterator extends FilterIterator implements Countable {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param Iterator $iterator Iterator to filter.
-	 * @param array<string> $paths Paths to filter.
+	 * @param  Iterator<string, Resource>  $iterator  Iterator to filter.
+	 * @param  string[]  $paths  Paths to filter.
 	 */
 	public function __construct( Iterator $iterator, array $paths ) {
 		parent::__construct( $iterator );

--- a/src/Uplink/Resources/Filters/Path_FilterIterator.php
+++ b/src/Uplink/Resources/Filters/Path_FilterIterator.php
@@ -1,8 +1,19 @@
-<?php
+<?php declare( strict_types=1 );
 
 namespace StellarWP\Uplink\Resources\Filters;
 
-class Path_FilterIterator extends \FilterIterator implements \Countable {
+use Countable;
+use FilterIterator;
+use Iterator;
+use StellarWP\Uplink\Resources\Plugin;
+use StellarWP\Uplink\Resources\Resource;
+use StellarWP\Uplink\Resources\Service;
+
+/**
+ * @method Resource|Plugin|Service current()
+ */
+class Path_FilterIterator extends FilterIterator implements Countable {
+
 	/**
 	 * Paths to filter.
 	 *
@@ -10,17 +21,17 @@ class Path_FilterIterator extends \FilterIterator implements \Countable {
 	 *
 	 * @var array<string>
 	 */
-	private $paths = [];
+	private $paths;
 
 	/**
 	 * Constructor.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param \Iterator $iterator Iterator to filter.
+	 * @param Iterator $iterator Iterator to filter.
 	 * @param array<string> $paths Paths to filter.
 	 */
-	public function __construct( \Iterator $iterator, array $paths ) {
+	public function __construct( Iterator $iterator, array $paths ) {
 		parent::__construct( $iterator );
 
 		$this->paths = $paths;
@@ -39,11 +50,7 @@ class Path_FilterIterator extends \FilterIterator implements \Countable {
 	 * @inheritDoc
 	 */
 	public function count() : int {
-		$count = 0;
-		foreach ( $this as $item ) {
-			$count++;
-		}
-
-		return $count;
+		return iterator_count( $this );
 	}
+
 }

--- a/src/Uplink/Resources/Filters/Plugin_FilterIterator.php
+++ b/src/Uplink/Resources/Filters/Plugin_FilterIterator.php
@@ -1,8 +1,16 @@
-<?php
+<?php declare( strict_types=1 );
 
 namespace StellarWP\Uplink\Resources\Filters;
 
-class Plugin_FilterIterator extends \FilterIterator implements \Countable {
+use Countable;
+use FilterIterator;
+use StellarWP\Uplink\Resources\Plugin;
+
+/**
+ * @method Plugin current()
+ */
+class Plugin_FilterIterator extends FilterIterator implements Countable {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -16,11 +24,7 @@ class Plugin_FilterIterator extends \FilterIterator implements \Countable {
 	 * @inheritDoc
 	 */
 	public function count() : int {
-		$count = 0;
-		foreach ( $this as $item ) {
-			$count++;
-		}
-
-		return $count;
+		return iterator_count( $this );
 	}
+
 }

--- a/src/Uplink/Resources/Filters/Service_FilterIterator.php
+++ b/src/Uplink/Resources/Filters/Service_FilterIterator.php
@@ -1,8 +1,16 @@
-<?php
+<?php declare( strict_types=1 );
 
 namespace StellarWP\Uplink\Resources\Filters;
 
-class Service_FilterIterator extends \FilterIterator implements \Countable {
+use Countable;
+use FilterIterator;
+use StellarWP\Uplink\Resources\Service;
+
+/**
+ * @method Service current()
+ */
+class Service_FilterIterator extends FilterIterator implements Countable {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -16,11 +24,7 @@ class Service_FilterIterator extends \FilterIterator implements \Countable {
 	 * @inheritDoc
 	 */
 	public function count() : int {
-		$count = 0;
-		foreach ( $this as $item ) {
-			$count++;
-		}
-
-		return $count;
+		return iterator_count( $this );
 	}
+
 }

--- a/src/Uplink/Uplink.php
+++ b/src/Uplink/Uplink.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types=1 );
 
 namespace StellarWP\Uplink;
 
@@ -16,10 +16,10 @@ class Uplink {
 	 *
 	 * @return void
 	 */
-	public static function init() {
+	public static function init(): void {
 		if ( ! Config::has_container() ) {
 			throw new RuntimeException(
-				__( 'You must call StellarWP\Uplink\Config::set_container() before calling StellarWP\Telemetry::init().', '%TEXTDOMAIN%' )
+				__( 'You must call StellarWP\Uplink\Config::set_container() before calling StellarWP\Uplink::init().', '%TEXTDOMAIN%' )
 			);
 		}
 

--- a/src/admin-views/fields/settings.php
+++ b/src/admin-views/fields/settings.php
@@ -32,7 +32,7 @@ $action_postfix = Config::get_hook_prefix_underscored();
 				<table class="form-table" role="presentation">
 			<?php endif; ?>
 				<div class="stellarwp-uplink__license-field">
-					<?php $field->do_settings_fields( $group, sprintf( '%s_%s', License_Field::LICENSE_FIELD_ID, sanitize_title( Config::get_hook_prefix() ) ), $action_postfix, $show_title ); ?>
+					<?php $field->do_settings_fields( $group, sprintf( '%s_%s', License_Field::LICENSE_FIELD_ID, sanitize_title( $plugin->get_slug() ) ), $action_postfix, $show_title ); ?>
 				</div>
 			<?php if ( $show_title ) : ?>
 				</table>

--- a/src/admin-views/fields/settings.php
+++ b/src/admin-views/fields/settings.php
@@ -32,7 +32,7 @@ $action_postfix = Config::get_hook_prefix_underscored();
 				<table class="form-table" role="presentation">
 			<?php endif; ?>
 				<div class="stellarwp-uplink__license-field">
-					<?php $field->do_settings_fields( $group, sprintf( '%s_%s', License_Field::LICENSE_FIELD_ID, sanitize_title( $plugin->get_slug() ) ), $action_postfix, $show_title ); ?>
+					<?php $field->do_settings_fields( $group, License_Field::get_section_name( $plugin ), $action_postfix, $show_title ); ?>
 				</div>
 			<?php if ( $show_title ) : ?>
 				</table>

--- a/src/assets/js/key-admin.js
+++ b/src/assets/js/key-admin.js
@@ -20,7 +20,6 @@
 	obj.validateKey = function( $el ) {
 		const field       	 = $el.find( 'input[type="text"]' )
 		const action	     = $el.data( 'action' );
-		const plugin         = $el.data( 'plugin' );
 		const slug           = $el.data( 'plugin-slug' );
 		let $validityMessage = $el.find( '.key-validity' );
 
@@ -40,7 +39,6 @@
 
 		const data = {
 			action: window[`stellarwp_config_${action}`]['action'],
-			plugin: plugin,
 			slug: slug,
 			key: licenseKey,
 			_wpnonce: $($el).find('.wp-nonce').val()

--- a/src/assets/js/key-admin.js
+++ b/src/assets/js/key-admin.js
@@ -1,5 +1,6 @@
 ( function( $, obj ) {
 
+	// TODO: This all needs a look over for the situation where multiple license fields appear together.
 	obj.init = function() {
 		$( '.stellarwp-uplink-license-key-field' ).each( function() {
 			var $el = $( this );
@@ -38,26 +39,36 @@
 		let licenseKey = field.val().trim();
 		field.val( licenseKey );
 
-		var data = {
+		const data = {
 			action: window[`stellarwp_config_${slug}`]['action'],
 			plugin: plugin,
 			key: licenseKey,
-			_wpnonce: $( $el ).find( '.wp-nonce' ).val()
+			_wpnonce: $($el).find('.wp-nonce').val()
 		};
 
-		$.post( ajaxurl, data, function ( response ) {
-			var data = $.parseJSON( response );
+		$.post(ajaxurl, data, function (response) {
+			$.each(response, function (index, value) {
+				$validityMessage.show();
+				$validityMessage.html(value.message);
 
-			$( $el ).find( '.ajax-loading-license' ).hide();
+				switch (value.status) {
+					case 1:
+						$validityMessage.addClass('valid-key').removeClass('invalid-key');
+						break;
+					case 2:
+						$validityMessage.addClass('valid-key service-msg');
+						break;
+					default:
+						$validityMessage.addClass('invalid-key').removeClass('valid-key');
+						break;
+				}
+			});
+		}).fail(function(error) {
 			$validityMessage.show();
-			$validityMessage.html( data.message );
-
-			switch ( data.status ) {
-				case 1: $validityMessage.addClass( 'valid-key' ).removeClass( 'invalid-key' ); break;
-				case 2: $validityMessage.addClass( 'valid-key service-msg' ); break;
-				default: $validityMessage.addClass( 'invalid-key' ).removeClass( 'valid-key' ); break;
-			}
-		} );
+			$validityMessage.html(error.message);
+		}).always(function() {
+			$($el).find('.ajax-loading-license').hide();
+		});
 	};
 
 	$( function() {

--- a/src/assets/js/key-admin.js
+++ b/src/assets/js/key-admin.js
@@ -18,8 +18,8 @@
 	};
 
 	obj.validateKey = function( $el ) {
-		const field       	 = $el.find( 'input[type="text"]' )
-		const action	     = $el.data( 'action' );
+		const field          = $el.find( 'input[type="text"]' )
+		const action         = $el.data( 'action' );
 		const slug           = $el.data( 'plugin-slug' );
 		let $validityMessage = $el.find( '.key-validity' );
 

--- a/src/assets/js/key-admin.js
+++ b/src/assets/js/key-admin.js
@@ -1,6 +1,4 @@
 ( function( $, obj ) {
-
-	// TODO: This all needs a look over for the situation where multiple license fields appear together.
 	obj.init = function() {
 		$( '.stellarwp-uplink-license-key-field' ).each( function() {
 			var $el = $( this );
@@ -21,6 +19,7 @@
 
 	obj.validateKey = function( $el ) {
 		const field       	 = $el.find( 'input[type="text"]' )
+		const action	     = $el.data( 'action' );
 		const plugin         = $el.data( 'plugin' );
 		const slug           = $el.data( 'plugin-slug' );
 		let $validityMessage = $el.find( '.key-validity' );
@@ -40,29 +39,28 @@
 		field.val( licenseKey );
 
 		const data = {
-			action: window[`stellarwp_config_${slug}`]['action'],
+			action: window[`stellarwp_config_${action}`]['action'],
 			plugin: plugin,
+			slug: slug,
 			key: licenseKey,
 			_wpnonce: $($el).find('.wp-nonce').val()
 		};
 
 		$.post(ajaxurl, data, function (response) {
-			$.each(response, function (index, value) {
-				$validityMessage.show();
-				$validityMessage.html(value.message);
+			$validityMessage.show();
+			$validityMessage.html(response.message);
 
-				switch (value.status) {
-					case 1:
-						$validityMessage.addClass('valid-key').removeClass('invalid-key');
-						break;
-					case 2:
-						$validityMessage.addClass('valid-key service-msg');
-						break;
-					default:
-						$validityMessage.addClass('invalid-key').removeClass('valid-key');
-						break;
-				}
-			});
+			switch (response.status) {
+				case 1:
+					$validityMessage.addClass('valid-key').removeClass('invalid-key');
+					break;
+				case 2:
+					$validityMessage.addClass('valid-key service-msg');
+					break;
+				default:
+					$validityMessage.addClass('invalid-key').removeClass('valid-key');
+					break;
+			}
 		}).fail(function(error) {
 			$validityMessage.show();
 			$validityMessage.html(error.message);

--- a/tests/wpunit/Resources/CollectionTest.php
+++ b/tests/wpunit/Resources/CollectionTest.php
@@ -1,22 +1,31 @@
-<?php
+<?php declare( strict_types=1 );
 
 namespace StellarWP\Uplink\Tests\Resources;
 
-use StellarWP\Uplink\Config;
 use StellarWP\Uplink\Tests\UplinkTestCase;
 use StellarWP\Uplink\Uplink;
 use StellarWP\Uplink\Register;
 use StellarWP\Uplink\Resources as Uplink_Resources;
 
-class CollectionTest extends UplinkTestCase {
-	public $collection;
-	public $container;
+final class CollectionTest extends UplinkTestCase {
+
+	/**
+	 * @var Uplink_Resources\Collection
+	 */
+	private $collection;
+
+	/**
+	 * The root directory for plugin/services paths.
+	 *
+	 * @var string
+	 */
+	private $root;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->container  = Config::get_container();
-		$this->collection = $this->container->make( Uplink_Resources\Collection::class );
+		$this->collection = $this->container->get( Uplink_Resources\Collection::class );
+		$this->root       = dirname( __DIR__, 3 );
 
 		$resources = $this->get_resources();
 		foreach ( $resources as $resource ) {
@@ -34,14 +43,12 @@ class CollectionTest extends UplinkTestCase {
 	/**
 	 * Resources.
 	 */
-	public function get_resources() {
-		$root = dirname( dirname( dirname( __DIR__ ) ) );
-
+	public function get_resources(): array {
 		return [
 			'plugin-1' => [
 				'slug'          => 'plugin-1',
 				'name'          => 'Plugin 1',
-				'path'          => $root . '/plugin.php',
+				'path'          => $this->root . '/plugin.php',
 				'class'         => Uplink::class,
 				'license_class' => Uplink::class,
 				'version'       => '1.0.0',
@@ -50,7 +57,7 @@ class CollectionTest extends UplinkTestCase {
 			'plugin-2' => [
 				'slug'          => 'plugin-2',
 				'name'          => 'Plugin 2',
-				'path'          => $root . '/plugin.php',
+				'path'          => $this->root . '/plugin.php',
 				'class'         => Uplink::class,
 				'license_class' => Uplink::class,
 				'version'       => '2.0.0',
@@ -59,7 +66,7 @@ class CollectionTest extends UplinkTestCase {
 			'service-1' => [
 				'slug'          => 'service-1',
 				'name'          => 'Service 1',
-				'path'          => $root . '/plugin.php',
+				'path'          => $this->root . '/service1.php',
 				'class'         => Uplink::class,
 				'license_class' => Uplink::class,
 				'version'       => '3.0.0',
@@ -68,7 +75,7 @@ class CollectionTest extends UplinkTestCase {
 			'service-2' => [
 				'slug'          => 'service-2',
 				'name'          => 'Service 2',
-				'path'          => $root . '/plugin.php',
+				'path'          => $this->root . '/service2.php',
 				'class'         => Uplink::class,
 				'license_class' => Uplink::class,
 				'version'       => '4.0.0',
@@ -79,10 +86,9 @@ class CollectionTest extends UplinkTestCase {
 
 	/**
 	 * It should register a plugin into the collection.
-	 *
-	 * @test
 	 */
-	public function it_should_register_resources() {
+	public function test_it_should_register_resources(): void {
+		$this->assertSame( 4, $this->collection->count() );
 
 		$this->assertInstanceOf( Uplink_Resources\Plugin::class, $this->collection['plugin-1'] );
 		$this->assertInstanceOf( Uplink_Resources\Plugin::class, $this->collection['plugin-2'] );
@@ -98,14 +104,78 @@ class CollectionTest extends UplinkTestCase {
 		$this->assertEquals( '2.0.0', $this->collection['plugin-2']->get_version() );
 	}
 
-	/**
-	 * It should loop over resources.
-	 *
-	 * @test
-	 */
-	public function it_should_loop_over_resources() {
+	public function test_it_should_loop_over_resources(): void {
 		foreach ( $this->collection as $resource ) {
 			$this->assertInstanceOf( Uplink_Resources\Resource::class, $resource );
 		}
 	}
+
+	public function test_it_gets_multiple_resources_by_path(): void {
+		$resources = $this->collection->get_by_path( $this->root . '/plugin.php' );
+
+		$this->assertSame( 2, $resources->count() );
+
+		// Assert we didn't modify the underlying collection.
+		$this->assertSame( 4, $this->collection->count() );
+
+		foreach ( $resources as $resource ) {
+			$this->assertThat( $resource->get_slug(), $this->logicalOr(
+				$this->equalTo( 'plugin-1' ),
+				$this->equalTo( 'plugin-2' )
+			) );
+		}
+	}
+
+	public function test_it_gets_multiple_resources_by_multiple_paths(): void {
+		$resources = $this->collection->get_by_paths( [
+			$this->root . '/plugin.php',
+			$this->root . '/service1.php',
+		] );
+
+		$this->assertSame( 3, $resources->count() );
+
+		// Assert we didn't modify the underlying collection.
+		$this->assertSame( 4, $this->collection->count() );
+
+		foreach ( $resources as $resource ) {
+			$this->assertThat( $resource->get_slug(), $this->logicalOr(
+				$this->equalTo( 'plugin-1' ),
+				$this->equalTo( 'plugin-2' ),
+				$this->equalTo( 'service-1' )
+			) );
+		}
+	}
+
+	public function test_it_gets_plugins(): void {
+		$resources = $this->collection->get_plugins();
+
+		$this->assertSame( 2, $resources->count() );
+
+		// Assert we didn't modify the underlying collection.
+		$this->assertSame( 4, $this->collection->count() );
+
+		foreach ( $resources as $resource ) {
+			$this->assertThat( $resource->get_slug(), $this->logicalOr(
+				$this->equalTo( 'plugin-1' ),
+				$this->equalTo( 'plugin-2' )
+			) );
+		}
+	}
+
+	public function test_it_gets_services(): void {
+		$resources = $this->collection->get_services();
+
+		$this->assertSame( 2, $resources->count() );
+
+		// Assert we didn't modify the underlying collection.
+		$this->assertSame( 4, $this->collection->count() );
+
+		foreach ( $resources as $resource ) {
+			$this->assertThat( $resource->get_slug(), $this->logicalOr(
+				$this->equalTo( 'service-1' ),
+				$this->equalTo( 'service-2' )
+			) );
+		}
+	}
+
 }

--- a/tests/wpunit/Resources/CollectionTest.php
+++ b/tests/wpunit/Resources/CollectionTest.php
@@ -2,6 +2,7 @@
 
 namespace StellarWP\Uplink\Tests\Resources;
 
+use ArrayIterator;
 use StellarWP\Uplink\Tests\UplinkTestCase;
 use StellarWP\Uplink\Uplink;
 use StellarWP\Uplink\Register;
@@ -114,9 +115,11 @@ final class CollectionTest extends UplinkTestCase {
 		$resources = $this->collection->get_by_path( $this->root . '/plugin.php' );
 
 		$this->assertSame( 2, $resources->count() );
+		$this->assertInstanceOf( Uplink_Resources\Collection::class, $resources );
 
 		// Assert we didn't modify the underlying collection.
 		$this->assertSame( 4, $this->collection->count() );
+		$this->assertCount( 4, $this->collection->getIterator() );
 
 		foreach ( $resources as $resource ) {
 			$this->assertThat( $resource->get_slug(), $this->logicalOr(
@@ -133,9 +136,11 @@ final class CollectionTest extends UplinkTestCase {
 		] );
 
 		$this->assertSame( 3, $resources->count() );
+		$this->assertInstanceOf( Uplink_Resources\Collection::class, $resources );
 
 		// Assert we didn't modify the underlying collection.
 		$this->assertSame( 4, $this->collection->count() );
+		$this->assertCount( 4, $this->collection->getIterator() );
 
 		foreach ( $resources as $resource ) {
 			$this->assertThat( $resource->get_slug(), $this->logicalOr(
@@ -150,6 +155,7 @@ final class CollectionTest extends UplinkTestCase {
 		$resources = $this->collection->get_plugins();
 
 		$this->assertSame( 2, $resources->count() );
+		$this->assertInstanceOf( Uplink_Resources\Collection::class, $resources );
 
 		// Assert we didn't modify the underlying collection.
 		$this->assertSame( 4, $this->collection->count() );
@@ -166,6 +172,7 @@ final class CollectionTest extends UplinkTestCase {
 		$resources = $this->collection->get_services();
 
 		$this->assertSame( 2, $resources->count() );
+		$this->assertInstanceOf( Uplink_Resources\Collection::class, $resources );
 
 		// Assert we didn't modify the underlying collection.
 		$this->assertSame( 4, $this->collection->count() );
@@ -176,6 +183,40 @@ final class CollectionTest extends UplinkTestCase {
 				$this->equalTo( 'service-2' )
 			) );
 		}
+	}
+
+	public function test_it_accepts_an_iterator(): void {
+		$plugins   = array_slice( $this->get_resources(), 0, 2 );
+		$resources = [];
+
+		foreach ( $plugins as $slug => $plugin ) {
+			$resources[ $slug ] = new Uplink_Resources\Plugin( $plugin['slug'],
+				$plugin['name'],
+				$plugin['version'],
+				$plugin['path'],
+				$plugin['class'] );
+		}
+
+		$collection = new Uplink_Resources\Collection( new ArrayIterator( $resources ) );
+
+		$this->assertSame( 2, $collection->count() );
+		$this->assertCount( 2, $collection->getIterator() );
+
+		foreach ( $collection as $resource ) {
+			$this->assertThat( $resource->get_slug(), $this->logicalOr(
+				$this->equalTo( 'plugin-1' ),
+				$this->equalTo( 'plugin-2' )
+			) );
+		}
+
+		$services = $collection->get_services();
+
+		$this->assertCount( 0, $services );
+
+		// Assert the original underlying iterator was not changed.
+		$this->assertSame( 2, $collection->count() );
+		$this->assertCount( 2, $collection->getIterator() );
+
 	}
 
 }


### PR DESCRIPTION
- Fixes https://github.com/stellarwp/uplink/issues/45 (fatal errors when updating other plugins)
- Allows rendering of license fields for all registered resources in the same Uplink/Container instance, or rendering a single resource using the new [render_single( 'my-product-slug' ) method](https://github.com/stellarwp/uplink/pull/49/files#diff-5e7d56d43b7f5e062a0066ea9b38a28105b70dfc51631b9c31ef4660bc788ab7R119)

Multiple Resources in the same Uplink/Container instance:

![image](https://github.com/stellarwp/uplink/assets/1066195/c569fa15-ca43-445c-8d8b-4812e9d0e06a)

This branch pulled into the Iconic WooCommerce Account Pages plugin on the same WordPress install:

![image](https://github.com/stellarwp/uplink/assets/1066195/03d6469d-3609-4292-98a1-cac5bdb506c7)

