### PR TITLE
Fixes issue with event tickets

### DIFF
--- a/src/Uplink/Admin/Plugins_Page.php
+++ b/src/Uplink/Admin/Plugins_Page.php
@@ -28,11 +28,11 @@ class Plugins_Page {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $page
+	 * @param mixed $page
 	 *
 	 * @return void
 	 */
-	public function display_plugin_messages( string $page ): void {
+	public function display_plugin_messages( $page ): void {
 		if ( 'plugins.php' !== $page ) {
 			return;
 		}
@@ -133,11 +133,11 @@ class Plugins_Page {
 	/**
 	 * Add notices as JS variable
 	 *
-	 * @param string $page
+	 * @param mixed $page
 	 *
 	 * @return void
 	 */
-	public function store_admin_notices( string $page ): void {
+	public function store_admin_notices( $page ): void {
 		if ( 'plugins.php' !== $page ) {
 			return;
 		}


### PR DESCRIPTION
Fatal error: Uncaught TypeError: KadenceWP\KadencePro\StellarWP\Uplink\Admin\Plugins_Page::display_plugin_messages(): Argument #1 ($page) must be of type string, null given, called in /home/arronpar/domains/karla.wppluginsupport.net/public_html/wp-content/plugins/kadence-pro/vendor/vendor-prefixed/stellarwp/uplink/src/Uplink/Admin/Provider.php on line 143 and defined in /home/arronpar/domains/karla.wppluginsupport.net/public_html/wp-content/plugins/kadence-pro/vendor/vendor-prefixed/stellarwp/uplink/src/Uplink/Admin/Plugins_Page.php:41