### PR TITLE
Token authorization caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ add_action( 'plugins_loaded', function() {
 	 */
 	Config::set_token_auth_prefix( 'my_origin' );
 
+	// Optionally, change the default auth token caching.
+	Config::set_auth_cache_expiration( WEEK_IN_SECONDS );
+
+	// Or, disable it completely.
+	Config::set_auth_cache_expiration( -1 );
+
 	Uplink::init();
 }, 0 );
 ```

--- a/src/Uplink/API/V3/Auth/Contracts/Token_Authorizer.php
+++ b/src/Uplink/API/V3/Auth/Contracts/Token_Authorizer.php
@@ -1,0 +1,21 @@
+<?php declare( strict_types=1 );
+
+namespace StellarWP\Uplink\API\V3\Auth\Contracts;
+
+interface Token_Authorizer {
+
+	/**
+	 * Check if a license is authorized.
+	 *
+	 * @see is_authorized()
+	 * @see \StellarWP\Uplink\API\V3\Auth\Token_Authorizer
+	 *
+	 * @param  string  $license  The license key.
+	 * @param  string  $token    The stored token.
+	 * @param  string  $domain   The user's domain.
+	 *
+	 * @return bool
+	 */
+	public function is_authorized( string $license, string $token, string $domain ): bool;
+
+}

--- a/src/Uplink/API/V3/Auth/Token_Authorizer.php
+++ b/src/Uplink/API/V3/Auth/Token_Authorizer.php
@@ -12,7 +12,7 @@ use function StellarWP\Uplink\is_authorized;
 /**
  * Manages authorization.
  */
-final class Token_Authorizer {
+class Token_Authorizer implements Contracts\Token_Authorizer {
 
 	use With_Debugging;
 

--- a/src/Uplink/API/V3/Auth/Token_Authorizer_Cache_Decorator.php
+++ b/src/Uplink/API/V3/Auth/Token_Authorizer_Cache_Decorator.php
@@ -1,0 +1,86 @@
+<?php declare( strict_types=1 );
+
+namespace StellarWP\Uplink\API\V3\Auth;
+
+use StellarWP\Uplink\API\V3\Provider;
+use StellarWP\Uplink\Config;
+
+/**
+ * Token Authorizer Cache Decorator.
+ *
+ * @see Config::set_auth_cache_expiration() to enable.
+ */
+final class Token_Authorizer_Cache_Decorator implements Contracts\Token_Authorizer {
+
+	public const TRANSIENT_PREFIX = 'stellarwp_auth_';
+
+	/**
+	 * @var Token_Authorizer
+	 */
+	private $authorizer;
+
+	/**
+	 * The cache expiration in seconds.
+	 *
+	 * @var int
+	 */
+	private $expiration;
+
+	/**
+	 * @see Config::set_auth_cache_expiration()
+	 * @see Provider::register_token_authorizer()
+	 *
+	 * @param  Token_Authorizer  $authorizer The original authorizer.
+	 * @param  int               $expiration The expiration time in seconds.
+	 */
+	public function __construct(
+		Token_Authorizer $authorizer,
+		int $expiration = 21600
+	) {
+		$this->authorizer = $authorizer;
+		$this->expiration = $expiration;
+	}
+
+	/**
+	 * Check if a license is authorized and cache successful responses.
+	 *
+	 * @see Config::set_auth_cache_expiration()
+	 * @see is_authorized()
+	 * @see Token_Authorizer
+	 *
+	 * @param  string  $license  The license key.
+	 * @param  string  $token    The stored token.
+	 * @param  string  $domain   The user's domain.
+	 *
+	 * @return bool
+	 */
+	public function is_authorized( string $license, string $token, string $domain ): bool {
+		$transient     = $this->build_transient( [ $license, $token, $domain ] );
+		$is_authorized = get_transient( $transient );
+
+		if ( $is_authorized === true ) {
+			return true;
+		}
+
+		$is_authorized = $this->authorizer->is_authorized( $license, $token, $domain );
+
+		// Only cache successful responses.
+		if ( $is_authorized ) {
+			set_transient( $transient, true, $this->expiration );
+		}
+
+		return $is_authorized;
+	}
+
+	/**
+	 * Build a transient key.
+	 *
+	 * @param  array<int, string>  ...$args
+	 *
+	 * @return string
+	 */
+	public function build_transient( array ...$args ): string {
+		return self::TRANSIENT_PREFIX . hash( 'sha256', json_encode( $args ) );
+	}
+
+}

--- a/src/Uplink/Config.php
+++ b/src/Uplink/Config.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types=1 );
 
 namespace StellarWP\Uplink;
 
@@ -10,8 +10,12 @@ use StellarWP\Uplink\Utils\Sanitize;
 
 class Config {
 
-	public const TOKEN_OPTION_NAME = 'uplink.token_prefix';
+	public const TOKEN_OPTION_NAME  = 'uplink.token_prefix';
 
+	/**
+	 * The default authorization cache time in seconds (6 hours).
+	 */
+	public const DEFAULT_AUTH_CACHE = 21600;
 
 	/**
 	 * Container object.
@@ -30,6 +34,14 @@ class Config {
 	 * @var string
 	 */
 	protected static $hook_prefix = '';
+
+	/**
+	 * How long in seconds we cache successful authorization
+	 * token requests.
+	 *
+	 * @var int
+	 */
+	protected static $auth_cache_expiration = self::DEFAULT_AUTH_CACHE;
 
 	/**
 	 * Get the container.
@@ -103,7 +115,8 @@ class Config {
 	 * @return void
 	 */
 	public static function reset(): void {
-		static::$hook_prefix = '';
+		static::$hook_prefix           = '';
+		static::$auth_cache_expiration = self::DEFAULT_AUTH_CACHE;
 
 		if ( self::has_container() ) {
 			self::$container->singleton( self::TOKEN_OPTION_NAME, null );
@@ -172,6 +185,27 @@ class Config {
 		}
 
 		self::get_container()->singleton( self::TOKEN_OPTION_NAME, $key );
+	}
+
+	/**
+	 * Set the token authorization expiration.
+	 *
+	 * @param  int  $seconds  The time seconds the cache will exist for.
+	 *                        -1 = disabled, 0 = no expiration.
+	 *
+	 * @return void
+	 */
+	public static function set_auth_cache_expiration( int $seconds ): void {
+		static::$auth_cache_expiration = $seconds;
+	}
+
+	/**
+	 * Get the token authorization expiration.
+	 *
+	 * @return int
+	 */
+	public static function get_auth_cache_expiration(): int {
+		return static::$auth_cache_expiration;
 	}
 
 }

--- a/src/Uplink/Pipeline/Pipeline.php
+++ b/src/Uplink/Pipeline/Pipeline.php
@@ -223,7 +223,7 @@ final class Pipeline {
 	 *
 	 * @return ContainerInterface
 	 */
-	protected function getContainer(): ?ContainerInterface {
+	protected function getContainer(): ContainerInterface {
 		if ( ! $this->container ) {
 			throw new RuntimeException( 'A container instance has not been passed to the Pipeline.' );
 		}

--- a/src/Uplink/functions.php
+++ b/src/Uplink/functions.php
@@ -2,7 +2,7 @@
 
 namespace StellarWP\Uplink;
 
-use StellarWP\Uplink\API\V3\Auth\Token_Authorizer;
+use StellarWP\Uplink\API\V3\Auth\Contracts\Token_Authorizer;
 use StellarWP\Uplink\Auth\Auth_Url_Builder;
 use StellarWP\Uplink\Auth\Token\Contracts\Token_Manager;
 use StellarWP\Uplink\Components\Admin\Authorize_Button_Controller;
@@ -48,7 +48,9 @@ function get_authorization_token(): ?string {
 }
 
 /**
- * Manually check if a license is authorized.
+ * Check if a license is authorized.
+ *
+ * @note This response may be cached.
  *
  * @param  string  $license  The license key.
  * @param  string  $token  The stored token.

--- a/tests/_support/Helper/Licensing/Service_Mock.php
+++ b/tests/_support/Helper/Licensing/Service_Mock.php
@@ -5,6 +5,7 @@ namespace StellarWP\Uplink\Tests\Licensing;
 use StellarWP\Uplink\Tests\Http_API\Http_API_Mock;
 
 class Service_Mock extends Http_API_Mock {
+
 	/**
 	 * Returns the body of a success response to the key validation request, in array format.
 	 *
@@ -50,11 +51,11 @@ class Service_Mock extends Http_API_Mock {
 		];
 	}
 
-
 	/**
 	 * {@inheritdoc }
 	 */
 	protected function get_url(): string {
-		return 'https://pue.theeventscalendar.com/api/';
+		return 'https://licensing.stellarwp.com/api/';
 	}
+
 }

--- a/tests/_support/Helper/UplinkTestCase.php
+++ b/tests/_support/Helper/UplinkTestCase.php
@@ -32,4 +32,10 @@ class UplinkTestCase extends WPTestCase {
 		$this->container = Config::get_container();
 	}
 
+	protected function tearDown(): void {
+		Config::reset();
+
+		parent::tearDown();
+	}
+
 }

--- a/tests/wpunit/API/V3/AuthorizerCacheTest.php
+++ b/tests/wpunit/API/V3/AuthorizerCacheTest.php
@@ -1,0 +1,65 @@
+<?php declare( strict_types=1 );
+
+namespace StellarWP\Uplink\Tests\API\V3;
+
+use StellarWP\Uplink\API\V3\Auth\Contracts\Token_Authorizer;
+use StellarWP\Uplink\API\V3\Auth\Token_Authorizer_Cache_Decorator;
+use StellarWP\Uplink\Tests\UplinkTestCase;
+
+final class AuthorizerCacheTest extends UplinkTestCase {
+
+	public function test_it_binds_the_correct_instance_when_auth_cache_is_enabled(): void {
+		$this->assertInstanceOf(
+			Token_Authorizer_Cache_Decorator::class,
+			$this->container->get( Token_Authorizer::class )
+		);
+	}
+
+	public function test_it_caches_a_valid_token_response(): void {
+		$authorizer_mock = $this->makeEmpty( \StellarWP\Uplink\API\V3\Auth\Token_Authorizer::class, [
+			'is_authorized' => static function (): bool {
+				return true;
+			},
+		] );
+
+		$this->container->bind( \StellarWP\Uplink\API\V3\Auth\Token_Authorizer::class, $authorizer_mock );
+
+		$decorator = $this->container->get( Token_Authorizer::class );
+		$transient = $decorator->build_transient( [ '1234', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' ] );
+
+		// No cache should exist.
+		$this->assertFalse( get_transient( $transient ) );
+
+		$authorized = $decorator->is_authorized( '1234', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' );
+
+		$this->assertTrue( $authorized );
+
+		// Cache should now be present.
+		$this->assertTrue( get_transient( $transient ) );
+		$this->assertTrue( $decorator->is_authorized( '1234', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' ) );
+	}
+
+	public function test_it_does_not_cache_an_invalid_token_response(): void {
+		$authorizer_mock = $this->makeEmpty( \StellarWP\Uplink\API\V3\Auth\Token_Authorizer::class, [
+			'is_authorized' => static function (): bool {
+				return false;
+			},
+		] );
+
+		$this->container->bind( \StellarWP\Uplink\API\V3\Auth\Token_Authorizer::class, $authorizer_mock );
+
+		$decorator = $this->container->get( Token_Authorizer::class );
+		$transient = $decorator->build_transient( [ '1234', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' ] );
+
+		// No cache should exist.
+		$this->assertFalse( get_transient( $transient ) );
+
+		$authorized = $decorator->is_authorized( '1234', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' );
+
+		$this->assertFalse( $authorized );
+
+		// Cache should still be empty, unfortunately the default is "false" for transients, so this isn't the best test.
+		$this->assertFalse( get_transient( $transient ) );
+	}
+
+}

--- a/tests/wpunit/API/V3/AuthorizerTest.php
+++ b/tests/wpunit/API/V3/AuthorizerTest.php
@@ -4,9 +4,27 @@ namespace StellarWP\Uplink\Tests\API\V3;
 
 use StellarWP\Uplink\API\V3\Auth\Token_Authorizer;
 use StellarWP\Uplink\API\V3\Contracts\Client_V3;
+use StellarWP\Uplink\Config;
 use StellarWP\Uplink\Tests\UplinkTestCase;
+use StellarWP\Uplink\Uplink;
 
 final class AuthorizerTest extends UplinkTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		// Disable auth caching.
+		Config::set_auth_cache_expiration( -1 );
+
+		Uplink::init();
+	}
+
+	public function test_it_binds_the_correct_instance_when_auth_cache_is_disabled(): void {
+		$this->assertInstanceOf(
+			Token_Authorizer::class,
+			$this->container->get( \StellarWP\Uplink\API\V3\Auth\Contracts\Token_Authorizer::class )
+		);
+	}
 
 	public function test_it_authorizes_a_valid_token(): void {
 		$clientMock = $this->makeEmpty( Client_V3::class, [

--- a/tests/wpunit/ConfigTest.php
+++ b/tests/wpunit/ConfigTest.php
@@ -55,7 +55,7 @@ final class ConfigTest extends UplinkTestCase {
 	}
 
 	public function test_it_gets_and_sets_auth_token_cache_expiration(): void {
-		$this->assertSame( 21600, Config::get_auth_cache_expiration() );
+		$this->assertSame( Config::DEFAULT_AUTH_CACHE, Config::get_auth_cache_expiration() );
 
 		Config::set_auth_cache_expiration( DAY_IN_SECONDS );
 

--- a/tests/wpunit/ConfigTest.php
+++ b/tests/wpunit/ConfigTest.php
@@ -54,4 +54,12 @@ final class ConfigTest extends UplinkTestCase {
 		Config::set_token_auth_prefix( 'fluffy_unicorn_rainbow_sunshine_happy_smile_peace_joy_love_puppy_harmony_giggles_dreams_celebrate_fantastic_wonderful_whimsical_serendipity_butterfly_magic_sparkle_sweetness_trust_' );
 	}
 
+	public function test_it_gets_and_sets_auth_token_cache_expiration(): void {
+		$this->assertSame( 21600, Config::get_auth_cache_expiration() );
+
+		Config::set_auth_cache_expiration( DAY_IN_SECONDS );
+
+		$this->assertSame( DAY_IN_SECONDS, Config::get_auth_cache_expiration() );
+	}
+
 }


### PR DESCRIPTION
- Adds a configurable caching decorator for Token Authorization caching (default is 6 hours).
- Fixes existing failing tests after the licensing URL changed.