### PR TITLE
ESM-70 - Fix fatal when moving tickets in ET

### DIFF
--- a/src/Uplink/API/Client.php
+++ b/src/Uplink/API/Client.php
@@ -34,7 +34,7 @@ class Client {
 	 *
 	 * @var string
 	 */
-	protected $base_url = 'https://pue.theeventscalendar.com';
+	protected $base_url = 'https://licensing.stellarwp.com';
 
 	/**
 	 * Container.

--- a/src/Uplink/Admin/Plugins_Page.php
+++ b/src/Uplink/Admin/Plugins_Page.php
@@ -32,7 +32,7 @@ class Plugins_Page {
 	 *
 	 * @return void
 	 */
-	public function display_plugin_messages( string $page ): void {
+	public function display_plugin_messages( $page ): void {
 		if ( 'plugins.php' !== $page ) {
 			return;
 		}
@@ -137,7 +137,7 @@ class Plugins_Page {
 	 *
 	 * @return void
 	 */
-	public function store_admin_notices( string $page ): void {
+	public function store_admin_notices( $page ): void {
 		if ( 'plugins.php' !== $page ) {
 			return;
 		}

--- a/src/Uplink/Admin/Plugins_Page.php
+++ b/src/Uplink/Admin/Plugins_Page.php
@@ -28,7 +28,7 @@ class Plugins_Page {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $page
+	 * @param string|null $page
 	 *
 	 * @return void
 	 */
@@ -133,7 +133,7 @@ class Plugins_Page {
 	/**
 	 * Add notices as JS variable
 	 *
-	 * @param string $page
+	 * @param string|null $page
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
-When moving tickets in ET/ET+ there is a fatal error caused in the two changed methods
-The methods expect a string, but in the move modal $page is null

Artifacts
-none

_Ref:_ [ESM-70](https://stellarwp.atlassian.net/browse/ESM-70)

[ESM-70]: https://stellarwp.atlassian.net/browse/ESM-70?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ