### PR TITLE
Fix: multiple notices showing

### DIFF
--- a/src/Uplink/Auth/Admin/Connect_Controller.php
+++ b/src/Uplink/Auth/Admin/Connect_Controller.php
@@ -83,6 +83,12 @@ final class Connect_Controller {
 		if ( ! $args ) {
 			return;
 		}
+		$slug   = $args[ self::SLUG ] ?? '';
+		$plugin = $this->collection->offsetGet( $slug );
+		// If the plugin is not found assume another instance is handling the request.
+		if ( ! $plugin ) {
+			return;
+		}
 
 		if ( ! $this->authorizer->can_auth() ) {
 			$this->notice->add( new Notice( Notice::ERROR,
@@ -96,18 +102,6 @@ final class Connect_Controller {
 		if ( ! Nonce::verify( $args[ self::NONCE ] ?? '' ) ) {
 			$this->notice->add( new Notice( Notice::ERROR,
 				__( 'Unable to save token data: nonce verification failed.', '%TEXTDOMAIN%' ),
-				true
-			) );
-
-			return;
-		}
-
-		$slug   = $args[ self::SLUG ] ?? '';
-		$plugin = $this->collection->offsetGet( $slug );
-
-		if ( ! $plugin ) {
-			$this->notice->add( new Notice( Notice::ERROR,
-				__( 'Plugin or Service slug not found.', '%TEXTDOMAIN%' ),
 				true
 			) );
 


### PR DESCRIPTION
This prevents multiple notices from showing when authorizing a plugin. If for example you have Kadence Blocks and Kadence Starter Templates both using auth they are using different instances of uplink and so one will show connected, the other will show plugin or service not found.