### PR TITLE
Bugfix: Use unique actions for each resource slug for token connect/disconnect

### DIFF
--- a/src/Uplink/Auth/Action_Manager.php
+++ b/src/Uplink/Auth/Action_Manager.php
@@ -14,7 +14,7 @@ use StellarWP\Uplink\Resources\Resource;
  */
 final class Action_Manager {
 
-	public const ACTION = 'uplink_admin_action';
+	public const ACTION = 'admin_action';
 
 	/**
 	 * @var Disconnect_Controller

--- a/src/Uplink/Auth/Action_Manager.php
+++ b/src/Uplink/Auth/Action_Manager.php
@@ -90,7 +90,7 @@ final class Action_Manager {
 	}
 
 	/**
-	 * When an `uplink_slug` query parameter is available, fire off the appropriaate
+	 * When an `uplink_slug` query parameter is available, fire off the appropriate
 	 * resource action.
 	 *
 	 * @action current_screen

--- a/src/Uplink/Auth/Action_Manager.php
+++ b/src/Uplink/Auth/Action_Manager.php
@@ -39,8 +39,8 @@ final class Action_Manager {
 		Collection $resources
 	) {
 		$this->disconnect_controller = $disconnect_controller;
-		$this->connect_controller = $connect_controller;
-		$this->resources = $resources;
+		$this->connect_controller    = $connect_controller;
+		$this->resources             = $resources;
 	}
 
 	/**

--- a/src/Uplink/Auth/Action_Manager.php
+++ b/src/Uplink/Auth/Action_Manager.php
@@ -1,0 +1,105 @@
+<?php declare( strict_types=1 );
+
+namespace StellarWP\Uplink\Auth;
+
+use StellarWP\Uplink\Auth\Admin\Connect_Controller;
+use StellarWP\Uplink\Auth\Admin\Disconnect_Controller;
+use StellarWP\Uplink\Resources\Collection;
+use StellarWP\Uplink\Resources\Resource;
+
+/**
+ * Manages Token Authorization WordPress actions to connect/disconnect
+ * tokens.
+ */
+final class Action_Manager {
+
+	/**
+	 * @var Disconnect_Controller
+	 */
+	private $disconnect_controller;
+
+	/**
+	 * @var Connect_Controller
+	 */
+	private $connect_controller;
+
+	/**
+	 * @var Collection
+	 */
+	private $resources;
+
+	/**
+	 * @param  Disconnect_Controller  $disconnect_controller
+	 * @param  Connect_Controller     $connect_controller
+	 * @param  Collection             $resources
+	 */
+	public function __construct(
+		Disconnect_Controller $disconnect_controller,
+		Connect_Controller $connect_controller,
+		Collection $resources
+	) {
+		$this->disconnect_controller = $disconnect_controller;
+		$this->connect_controller = $connect_controller;
+		$this->resources = $resources;
+	}
+
+	/**
+	 * Get the resource's unique hook name.
+	 *
+	 * @param  Resource  $resource The resource.
+	 *
+	 * @return string
+	 */
+	public function get_hook_name( Resource $resource ): string {
+		return sprintf( 'uplink_admin_action_%s', $resource->get_slug() );
+	}
+
+	/**
+	 * Register a unique action for each resource in order to fire off connect/disconnect logic
+	 * uniquely so as one plugin would not interfere with another.
+	 *
+	 * @action admin_init
+	 *
+	 * @return void
+	 */
+	public function add_actions(): void {
+		foreach ( $this->resources as $resource ) {
+			$hook_name = $this->get_hook_name( $resource );
+
+			add_action(
+				$hook_name,
+				[ $this->disconnect_controller, 'maybe_disconnect' ]
+			);
+
+			add_action(
+				$hook_name,
+				[ $this->connect_controller, 'maybe_store_token_data' ]
+			);
+		}
+	}
+
+	/**
+	 * When an `uplink_slug` query parameter is available, fire off the appropriaate
+	 * resource action.
+	 *
+	 * @action current_screen
+	 *
+	 * @return void
+	 */
+	public function do_action(): void {
+		if ( empty( $_REQUEST[ Disconnect_Controller::SLUG ] ) ) {
+			return;
+		}
+
+		$action = $_REQUEST[ Disconnect_Controller::SLUG ];
+
+		/**
+		 * Fires when an 'uplink_slug' request variable is sent.
+		 *
+		 * The dynamic portion of the hook name, `$action`, refers to
+		 * the action derived from the `GET` or `POST` request.
+		 */
+		do_action( "uplink_admin_action_$action" );
+	}
+
+}

--- a/src/Uplink/Auth/Action_Manager.php
+++ b/src/Uplink/Auth/Action_Manager.php
@@ -4,6 +4,7 @@ namespace StellarWP\Uplink\Auth;
 
 use StellarWP\Uplink\Auth\Admin\Connect_Controller;
 use StellarWP\Uplink\Auth\Admin\Disconnect_Controller;
+use StellarWP\Uplink\Config;
 use StellarWP\Uplink\Resources\Collection;
 use StellarWP\Uplink\Resources\Resource;
 
@@ -13,7 +14,7 @@ use StellarWP\Uplink\Resources\Resource;
  */
 final class Action_Manager {
 
-	public const ACTION = 'uplink_admin_action_%s';
+	public const ACTION = 'uplink_admin_action';
 
 	/**
 	 * @var Disconnect_Controller
@@ -48,12 +49,18 @@ final class Action_Manager {
 	/**
 	 * Get the resource's unique hook name.
 	 *
-	 * @param  Resource  $resource The resource.
+	 * @param  Resource  $resource  The resource.
+	 *
+	 * @throws \RuntimeException
 	 *
 	 * @return string
 	 */
 	public function get_hook_name( Resource $resource ): string {
-		return sprintf( self::ACTION, $resource->get_slug() );
+		return sprintf( 'stellarwp/uplink/%s/%s_%s',
+			Config::get_hook_prefix(),
+			self::ACTION,
+			$resource->get_slug()
+		);
 	}
 
 	/**
@@ -61,6 +68,8 @@ final class Action_Manager {
 	 * uniquely so as one plugin would not interfere with another.
 	 *
 	 * @action admin_init
+	 *
+	 * @throws \RuntimeException
 	 *
 	 * @return void
 	 */
@@ -86,6 +95,8 @@ final class Action_Manager {
 	 *
 	 * @action current_screen
 	 *
+	 * @throws \RuntimeException
+	 *
 	 * @return void
 	 */
 	public function do_action(): void {
@@ -101,7 +112,11 @@ final class Action_Manager {
 		 * The dynamic portion of the hook name, `$action`, refers to
 		 * the action derived from the `GET` or `POST` request.
 		 */
-		do_action( sprintf( self::ACTION, $action ) );
+		do_action( sprintf( 'stellarwp/uplink/%s/%s_%s',
+			Config::get_hook_prefix(),
+			self::ACTION,
+			$action
+		) );
 	}
 
 }

--- a/src/Uplink/Auth/Action_Manager.php
+++ b/src/Uplink/Auth/Action_Manager.php
@@ -13,6 +13,8 @@ use StellarWP\Uplink\Resources\Resource;
  */
 final class Action_Manager {
 
+	public const ACTION = 'uplink_admin_action_%s';
+
 	/**
 	 * @var Disconnect_Controller
 	 */
@@ -51,7 +53,7 @@ final class Action_Manager {
 	 * @return string
 	 */
 	public function get_hook_name( Resource $resource ): string {
-		return sprintf( 'uplink_admin_action_%s', $resource->get_slug() );
+		return sprintf( self::ACTION, $resource->get_slug() );
 	}
 
 	/**
@@ -99,7 +101,7 @@ final class Action_Manager {
 		 * The dynamic portion of the hook name, `$action`, refers to
 		 * the action derived from the `GET` or `POST` request.
 		 */
-		do_action( "uplink_admin_action_$action" );
+		do_action( sprintf( self::ACTION, $action ) );
 	}
 
 }

--- a/src/Uplink/Auth/Admin/Connect_Controller.php
+++ b/src/Uplink/Auth/Admin/Connect_Controller.php
@@ -64,7 +64,7 @@ final class Connect_Controller {
 	/**
 	 * Store the token data passed back from the Origin site.
 	 *
-	 * @action uplink_admin_action_{$slug}
+	 * @action stellarwp/uplink/{$prefix}/uplink_admin_action_{$slug}
 	 *
 	 * @throws \RuntimeException
 	 */

--- a/src/Uplink/Auth/Admin/Connect_Controller.php
+++ b/src/Uplink/Auth/Admin/Connect_Controller.php
@@ -64,7 +64,7 @@ final class Connect_Controller {
 	/**
 	 * Store the token data passed back from the Origin site.
 	 *
-	 * @action admin_action_{Config::get_hook_prefix_underscored()}_{$slug}
+	 * @action admin_action_{$slug}
 	 *
 	 * @throws \RuntimeException
 	 */

--- a/src/Uplink/Auth/Admin/Connect_Controller.php
+++ b/src/Uplink/Auth/Admin/Connect_Controller.php
@@ -64,7 +64,7 @@ final class Connect_Controller {
 	/**
 	 * Store the token data passed back from the Origin site.
 	 *
-	 * @action admin_init
+	 * @action admin_action_{Config::get_hook_prefix_underscored()}_{$slug}
 	 *
 	 * @throws \RuntimeException
 	 */

--- a/src/Uplink/Auth/Admin/Connect_Controller.php
+++ b/src/Uplink/Auth/Admin/Connect_Controller.php
@@ -64,7 +64,7 @@ final class Connect_Controller {
 	/**
 	 * Store the token data passed back from the Origin site.
 	 *
-	 * @action stellarwp/uplink/{$prefix}/uplink_admin_action_{$slug}
+	 * @action stellarwp/uplink/{$prefix}/admin_action_{$slug}
 	 *
 	 * @throws \RuntimeException
 	 */

--- a/src/Uplink/Auth/Admin/Connect_Controller.php
+++ b/src/Uplink/Auth/Admin/Connect_Controller.php
@@ -64,7 +64,7 @@ final class Connect_Controller {
 	/**
 	 * Store the token data passed back from the Origin site.
 	 *
-	 * @action admin_action_{$slug}
+	 * @action uplink_admin_action_{$slug}
 	 *
 	 * @throws \RuntimeException
 	 */

--- a/src/Uplink/Auth/Admin/Disconnect_Controller.php
+++ b/src/Uplink/Auth/Admin/Disconnect_Controller.php
@@ -59,7 +59,7 @@ final class Disconnect_Controller {
 	/**
 	 * Disconnect (delete) a token if the user is allowed to.
 	 *
-	 * @action admin_action_{Config::get_hook_prefix_underscored()}_{$slug}
+	 * @action admin_action_{$slug}
 	 *
 	 * @throws \RuntimeException
 	 *

--- a/src/Uplink/Auth/Admin/Disconnect_Controller.php
+++ b/src/Uplink/Auth/Admin/Disconnect_Controller.php
@@ -59,7 +59,7 @@ final class Disconnect_Controller {
 	/**
 	 * Disconnect (delete) a token if the user is allowed to.
 	 *
-	 * @action admin_init
+	 * @action admin_action_{Config::get_hook_prefix_underscored()}_{$slug}
 	 *
 	 * @throws \RuntimeException
 	 *

--- a/src/Uplink/Auth/Admin/Disconnect_Controller.php
+++ b/src/Uplink/Auth/Admin/Disconnect_Controller.php
@@ -11,7 +11,6 @@ final class Disconnect_Controller {
 
 	public const ARG    = 'uplink_disconnect';
 	public const SLUG   = 'uplink_slug';
-	public const ACTION = 'action';
 
 	/**
 	 * @var Authorizer
@@ -54,14 +53,13 @@ final class Disconnect_Controller {
 		return wp_nonce_url( add_query_arg( [
 			self::ARG    => true,
 			self::SLUG   => $slug,
-			self::ACTION => $slug,
 		], get_admin_url( get_current_blog_id() ) ), self::ARG );
 	}
 
 	/**
 	 * Disconnect (delete) a token if the user is allowed to.
 	 *
-	 * @action admin_action_{$slug}
+	 * @action uplink_admin_action_{$slug}
 	 *
 	 * @throws \RuntimeException
 	 *

--- a/src/Uplink/Auth/Admin/Disconnect_Controller.php
+++ b/src/Uplink/Auth/Admin/Disconnect_Controller.php
@@ -59,7 +59,7 @@ final class Disconnect_Controller {
 	/**
 	 * Disconnect (delete) a token if the user is allowed to.
 	 *
-	 * @action uplink_admin_action_{$slug}
+	 * @action stellarwp/uplink/{$prefix}/uplink_admin_action_{$slug}
 	 *
 	 * @throws \RuntimeException
 	 *

--- a/src/Uplink/Auth/Admin/Disconnect_Controller.php
+++ b/src/Uplink/Auth/Admin/Disconnect_Controller.php
@@ -9,8 +9,8 @@ use StellarWP\Uplink\Notice\Notice;
 
 final class Disconnect_Controller {
 
-	public const ARG    = 'uplink_disconnect';
-	public const SLUG   = 'uplink_slug';
+	public const ARG  = 'uplink_disconnect';
+	public const SLUG = 'uplink_slug';
 
 	/**
 	 * @var Authorizer

--- a/src/Uplink/Auth/Admin/Disconnect_Controller.php
+++ b/src/Uplink/Auth/Admin/Disconnect_Controller.php
@@ -59,7 +59,7 @@ final class Disconnect_Controller {
 	/**
 	 * Disconnect (delete) a token if the user is allowed to.
 	 *
-	 * @action stellarwp/uplink/{$prefix}/uplink_admin_action_{$slug}
+	 * @action stellarwp/uplink/{$prefix}/admin_action_{$slug}
 	 *
 	 * @throws \RuntimeException
 	 *

--- a/src/Uplink/Auth/Admin/Disconnect_Controller.php
+++ b/src/Uplink/Auth/Admin/Disconnect_Controller.php
@@ -9,8 +9,9 @@ use StellarWP\Uplink\Notice\Notice;
 
 final class Disconnect_Controller {
 
-	public const ARG  = 'uplink_disconnect';
-	public const SLUG = 'uplink_slug';
+	public const ARG    = 'uplink_disconnect';
+	public const SLUG   = 'uplink_slug';
+	public const ACTION = 'action';
 
 	/**
 	 * @var Authorizer
@@ -45,14 +46,15 @@ final class Disconnect_Controller {
 	/**
 	 * Get the disconnect URL to render.
 	 *
-	 * @param  string  $slug The plugin/service slug.
+	 * @param  string  $slug  The plugin/service slug.
 	 *
 	 * @return string
 	 */
 	public function get_url( string $slug ): string {
 		return wp_nonce_url( add_query_arg( [
-			self::ARG  => true,
-			self::SLUG => $slug,
+			self::ARG    => true,
+			self::SLUG   => $slug,
+			self::ACTION => $slug,
 		], get_admin_url( get_current_blog_id() ) ), self::ARG );
 	}
 

--- a/src/Uplink/Auth/Admin/Disconnect_Controller.php
+++ b/src/Uplink/Auth/Admin/Disconnect_Controller.php
@@ -51,8 +51,8 @@ final class Disconnect_Controller {
 	 */
 	public function get_url( string $slug ): string {
 		return wp_nonce_url( add_query_arg( [
-			self::ARG    => true,
-			self::SLUG   => $slug,
+			self::ARG  => true,
+			self::SLUG => $slug,
 		], get_admin_url( get_current_blog_id() ) ), self::ARG );
 	}
 

--- a/src/Uplink/Auth/Provider.php
+++ b/src/Uplink/Auth/Provider.php
@@ -98,20 +98,22 @@ final class Provider extends Abstract_Provider {
 		$this->container->singleton( Connect_Controller::class, Connect_Controller::class );
 
 		add_action( 'admin_init', function() {
-			$prefix = Config::get_hook_prefix_underscored();
-
 			// Register a unique hook for each resource slug, so they don't all fire off at once.
 			foreach ( $this->container->get( Collection::class ) as $resource ) {
-				$hook_name = sprintf( 'admin_action_%s_%s', $prefix, $resource->get_slug() );
+				$hook_name = sprintf( 'admin_action_%s', $resource->get_slug() );
 
 				add_action(
 					$hook_name,
-					[ $this->container->get( Disconnect_Controller::class ), 'maybe_disconnect' ]
+					[ $this->container->get( Disconnect_Controller::class ), 'maybe_disconnect' ],
+					1,
+					0
 				);
 
 				add_action(
 					$hook_name,
-					[ $this->container->get( Connect_Controller::class ), 'maybe_store_token_data' ]
+					[ $this->container->get( Connect_Controller::class ), 'maybe_store_token_data' ],
+					1,
+					0
 				);
 			}
 		} );

--- a/tests/wpunit/Auth/ActionManagerTest.php
+++ b/tests/wpunit/Auth/ActionManagerTest.php
@@ -66,8 +66,8 @@ final class ActionManagerTest extends UplinkTestCase {
 		$plugin_1 = $this->container->get( Collection::class )->offsetGet( $this->slug_1 );
 		$plugin_2 = $this->container->get( Collection::class )->offsetGet( $this->slug_2 );
 
-		$this->assertSame( 'stellarwp/uplink/test/uplink_admin_action_sample-1', $this->action_manager->get_hook_name( $plugin_1 ) );
-		$this->assertSame( 'stellarwp/uplink/test/uplink_admin_action_sample-2', $this->action_manager->get_hook_name( $plugin_2 ) );
+		$this->assertSame( 'stellarwp/uplink/test/admin_action_sample-1', $this->action_manager->get_hook_name( $plugin_1 ) );
+		$this->assertSame( 'stellarwp/uplink/test/admin_action_sample-2', $this->action_manager->get_hook_name( $plugin_2 ) );
 	}
 
 	public function test_it_registers_and_fires_actions(): void {

--- a/tests/wpunit/Auth/ActionManagerTest.php
+++ b/tests/wpunit/Auth/ActionManagerTest.php
@@ -83,9 +83,7 @@ final class ActionManagerTest extends UplinkTestCase {
 
 		foreach ( $collection as $resource ) {
 			$this->assertTrue( has_action( $this->action_manager->get_hook_name( $resource ) ) );
-		}
 
-		foreach ( $collection as $resource ) {
 			$_REQUEST[ Disconnect_Controller::SLUG ] = $resource->get_slug();
 
 			// Fire off current_screen, which runs our actions, normally this would run once, but we want to test them all.

--- a/tests/wpunit/Auth/ActionManagerTest.php
+++ b/tests/wpunit/Auth/ActionManagerTest.php
@@ -66,8 +66,8 @@ final class ActionManagerTest extends UplinkTestCase {
 		$plugin_1 = $this->container->get( Collection::class )->offsetGet( $this->slug_1 );
 		$plugin_2 = $this->container->get( Collection::class )->offsetGet( $this->slug_2 );
 
-		$this->assertSame( 'uplink_admin_action_sample-1', $this->action_manager->get_hook_name( $plugin_1 ) );
-		$this->assertSame( 'uplink_admin_action_sample-2', $this->action_manager->get_hook_name( $plugin_2 ) );
+		$this->assertSame( 'stellarwp/uplink/test/uplink_admin_action_sample-1', $this->action_manager->get_hook_name( $plugin_1 ) );
+		$this->assertSame( 'stellarwp/uplink/test/uplink_admin_action_sample-2', $this->action_manager->get_hook_name( $plugin_2 ) );
 	}
 
 	public function test_it_registers_and_fires_actions(): void {

--- a/tests/wpunit/Auth/ActionManagerTest.php
+++ b/tests/wpunit/Auth/ActionManagerTest.php
@@ -1,0 +1,98 @@
+<?php declare( strict_types=1 );
+
+namespace StellarWP\Uplink\Tests\Auth;
+
+use StellarWP\Uplink\Auth\Action_Manager;
+use StellarWP\Uplink\Auth\Admin\Disconnect_Controller;
+use StellarWP\Uplink\Config;
+use StellarWP\Uplink\Register;
+use StellarWP\Uplink\Resources\Collection;
+use StellarWP\Uplink\Tests\Sample_Plugin;
+use StellarWP\Uplink\Tests\UplinkTestCase;
+use StellarWP\Uplink\Uplink;
+
+final class ActionManagerTest extends UplinkTestCase {
+
+	/**
+	 * @var string
+	 */
+	private $slug_1 = 'sample-1';
+
+	/**
+	 * @var string
+	 */
+	private $slug_2 = 'sample-2';
+
+	/**
+	 * @var Action_Manager
+	 */
+	private $action_manager;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		Config::set_token_auth_prefix( 'kadence_' );
+
+		// Run init again to reload providers.
+		Uplink::init();
+
+		// Register 2 sample plugins as a developer would in their plugin.
+		Register::plugin(
+			$this->slug_1,
+			'Lib Sample 1',
+			'1.0.10',
+			'uplink/index.php',
+			Sample_Plugin::class
+		);
+
+		Register::plugin(
+			$this->slug_2,
+			'Lib Sample 2',
+			'1.0.10',
+			'uplink/index.php',
+			Sample_Plugin::class
+		);
+
+		$this->action_manager = $this->container->get( Action_Manager::class );
+	}
+
+	protected function tearDown(): void {
+		unset( $_REQUEST[ Disconnect_Controller::SLUG ] );
+
+		parent::tearDown();
+	}
+
+	public function test_it_gets_the_correct_hook_name(): void {
+		$plugin_1 = $this->container->get( Collection::class )->offsetGet( $this->slug_1 );
+		$plugin_2 = $this->container->get( Collection::class )->offsetGet( $this->slug_2 );
+
+		$this->assertSame( 'uplink_admin_action_sample-1', $this->action_manager->get_hook_name( $plugin_1 ) );
+		$this->assertSame( 'uplink_admin_action_sample-2', $this->action_manager->get_hook_name( $plugin_2 ) );
+	}
+
+	public function test_it_registers_and_fires_actions(): void {
+		$collection = $this->container->get( Collection::class );
+
+		foreach ( $collection as $resource ) {
+			$this->assertFalse( has_action( $this->action_manager->get_hook_name( $resource ) ) );
+			$this->assertSame( 0, did_action( $this->action_manager->get_hook_name( $resource ) ) );
+		}
+
+		// Fire off admin_init, which registers our custom resource actions.
+		do_action( 'admin_init' );
+
+		foreach ( $collection as $resource ) {
+			$this->assertTrue( has_action( $this->action_manager->get_hook_name( $resource ) ) );
+		}
+
+		foreach ( $collection as $resource ) {
+			$_REQUEST[ Disconnect_Controller::SLUG ] = $resource->get_slug();
+
+			// Fire off current_screen, which runs our actions, normally this would run once, but we want to test them all.
+			do_action( 'current_screen', null );
+
+			$this->assertSame( 1, did_action( $this->action_manager->get_hook_name( $resource ) ) );
+		}
+	}
+
+}

--- a/tests/wpunit/Auth/Admin/ConnectControllerTest.php
+++ b/tests/wpunit/Auth/Admin/ConnectControllerTest.php
@@ -5,6 +5,7 @@ namespace StellarWP\Uplink\Tests\Auth\Admin;
 use stdClass;
 use StellarWP\Uplink\API\Client;
 use StellarWP\Uplink\API\Validation_Response;
+use StellarWP\Uplink\Auth\Action_Manager;
 use StellarWP\Uplink\Auth\Admin\Connect_Controller;
 use StellarWP\Uplink\Auth\Nonce;
 use StellarWP\Uplink\Auth\Token\Contracts\Token_Manager;
@@ -92,7 +93,7 @@ final class ConnectControllerTest extends UplinkTestCase {
 		do_action( 'admin_init' );
 
 		// Fire off the specification action tied to this slug.
-		do_action( sprintf( 'admin_action_%s', $this->slug ) );
+		do_action( $this->container->get( Action_Manager::class )->get_hook_name( $plugin ) );
 
 		$this->assertSame( $token, $token_manager->get() );
 	}
@@ -142,7 +143,7 @@ final class ConnectControllerTest extends UplinkTestCase {
 		do_action( 'admin_init' );
 
 		// Fire off the specification action tied to this slug.
-		do_action( sprintf( 'admin_action_%s', $this->slug ) );
+		do_action( $this->container->get( Action_Manager::class )->get_hook_name( $plugin ) );
 
 		$this->assertSame( $token, $token_manager->get() );
 		$this->assertSame( $plugin->get_license_key( is_multisite() ? 'network' : 'local' ), $license );
@@ -175,7 +176,7 @@ final class ConnectControllerTest extends UplinkTestCase {
 		do_action( 'admin_init' );
 
 		// Fire off the specification action tied to this slug.
-		do_action( sprintf( 'admin_action_%s', $this->slug ) );
+		do_action( $this->container->get( Action_Manager::class )->get_hook_name( $plugin ) );
 
 		$this->assertNull( $token_manager->get() );
 	}
@@ -208,7 +209,7 @@ final class ConnectControllerTest extends UplinkTestCase {
 		do_action( 'admin_init' );
 
 		// Fire off the specification action tied to this slug.
-		do_action( sprintf( 'admin_action_%s', $this->slug ) );
+		do_action( $this->container->get( Action_Manager::class )->get_hook_name( $plugin ) );
 
 		$this->assertNull( $token_manager->get() );
 	}
@@ -240,7 +241,7 @@ final class ConnectControllerTest extends UplinkTestCase {
 		do_action( 'admin_init' );
 
 		// Fire off the specification action tied to this slug.
-		do_action( sprintf( 'admin_action_%s', $this->slug ) );
+		do_action( sprintf( 'uplink_admin_action_%s', $this->slug ) );
 
 		$this->assertNull( $token_manager->get() );
 	}
@@ -276,7 +277,7 @@ final class ConnectControllerTest extends UplinkTestCase {
 		do_action( 'admin_init' );
 
 		// Fire off the specification action tied to this slug.
-		do_action( sprintf( 'admin_action_%s', $this->slug ) );
+		do_action( $this->container->get( Action_Manager::class )->get_hook_name( $plugin ) );
 
 		$this->assertSame( $token, $token_manager->get() );
 		$this->assertEmpty( $plugin->get_license_key( is_multisite() ? 'network' : 'local' ) );
@@ -326,7 +327,7 @@ final class ConnectControllerTest extends UplinkTestCase {
 		do_action( 'admin_init' );
 
 		// Fire off the specification action tied to this slug.
-		do_action( sprintf( 'admin_action_%s', $this->slug ) );
+		do_action( $this->container->get( Action_Manager::class )->get_hook_name( $plugin ) );
 
 		$this->assertSame( $token, $token_manager->get() );
 		$this->assertEmpty( $plugin->get_license_key( is_multisite() ? 'network' : 'local' ) );
@@ -389,7 +390,7 @@ final class ConnectControllerTest extends UplinkTestCase {
 		do_action( 'admin_init' );
 
 		// Fire off the specification action tied to this slug.
-		do_action( sprintf( 'admin_action_%s', $this->slug ) );
+		do_action( $this->container->get( Action_Manager::class )->get_hook_name( $plugin ) );
 
 		$this->assertSame( $token, $token_manager->get() );
 		$this->assertSame( $plugin->get_license_key( 'network' ), $license );
@@ -455,7 +456,7 @@ final class ConnectControllerTest extends UplinkTestCase {
 		do_action( 'admin_init' );
 
 		// Fire off the specification action tied to this slug.
-		do_action( sprintf( 'admin_action_%s', $this->slug ) );
+		do_action( $this->container->get( Action_Manager::class )->get_hook_name( $plugin ) );
 
 		$this->assertSame( $token, $token_manager->get() );
 		$this->assertSame( $plugin->get_license_key( 'network' ), $license );

--- a/tests/wpunit/Auth/Admin/ConnectControllerTest.php
+++ b/tests/wpunit/Auth/Admin/ConnectControllerTest.php
@@ -241,7 +241,7 @@ final class ConnectControllerTest extends UplinkTestCase {
 		do_action( 'admin_init' );
 
 		// Fire off the specification action tied to this slug.
-		do_action( sprintf( 'uplink_admin_action_%s', $this->slug ) );
+		do_action( $this->container->get( Action_Manager::class )->get_hook_name( $plugin ) );
 
 		$this->assertNull( $token_manager->get() );
 	}

--- a/tests/wpunit/Auth/Admin/ConnectControllerTest.php
+++ b/tests/wpunit/Auth/Admin/ConnectControllerTest.php
@@ -88,11 +88,11 @@ final class ConnectControllerTest extends UplinkTestCase {
 
 		$this->assertTrue( $screen->in_admin() );
 
-		// Fire off the admin_init action to register our admin_action_$hook_prefix_$slug actions.
+		// Fire off the admin_init action to register our admin_action_$slug actions.
 		do_action( 'admin_init' );
 
 		// Fire off the specification action tied to this slug.
-		do_action( sprintf( 'admin_action_%s_%s', Config::get_hook_prefix_underscored(), $this->slug ) );
+		do_action( sprintf( 'admin_action_%s', $this->slug ) );
 
 		$this->assertSame( $token, $token_manager->get() );
 	}
@@ -138,11 +138,11 @@ final class ConnectControllerTest extends UplinkTestCase {
 
 		$this->assertTrue( $screen->in_admin() );
 
-		// Fire off the admin_init action to register our admin_action_$hook_prefix_$slug actions.
+		// Fire off the admin_init action to register our admin_action_$slug actions.
 		do_action( 'admin_init' );
 
 		// Fire off the specification action tied to this slug.
-		do_action( sprintf( 'admin_action_%s_%s', Config::get_hook_prefix_underscored(), $this->slug ) );
+		do_action( sprintf( 'admin_action_%s', $this->slug ) );
 
 		$this->assertSame( $token, $token_manager->get() );
 		$this->assertSame( $plugin->get_license_key( is_multisite() ? 'network' : 'local' ), $license );
@@ -171,11 +171,11 @@ final class ConnectControllerTest extends UplinkTestCase {
 
 		$this->assertTrue( $screen->in_admin() );
 
-		// Fire off the admin_init action to register our admin_action_$hook_prefix_$slug actions.
+		// Fire off the admin_init action to register our admin_action_$slug actions.
 		do_action( 'admin_init' );
 
 		// Fire off the specification action tied to this slug.
-		do_action( sprintf( 'admin_action_%s_%s', Config::get_hook_prefix_underscored(), $this->slug ) );
+		do_action( sprintf( 'admin_action_%s', $this->slug ) );
 
 		$this->assertNull( $token_manager->get() );
 	}
@@ -204,11 +204,11 @@ final class ConnectControllerTest extends UplinkTestCase {
 
 		$this->assertTrue( $screen->in_admin() );
 
-		// Fire off the admin_init action to register our admin_action_$hook_prefix_$slug actions.
+		// Fire off the admin_init action to register our admin_action_$slug actions.
 		do_action( 'admin_init' );
 
 		// Fire off the specification action tied to this slug.
-		do_action( sprintf( 'admin_action_%s_%s', Config::get_hook_prefix_underscored(), $this->slug ) );
+		do_action( sprintf( 'admin_action_%s', $this->slug ) );
 
 		$this->assertNull( $token_manager->get() );
 	}
@@ -236,11 +236,11 @@ final class ConnectControllerTest extends UplinkTestCase {
 
 		$this->assertTrue( $screen->in_admin() );
 
-		// Fire off the admin_init action to register our admin_action_$hook_prefix_$slug actions.
+		// Fire off the admin_init action to register our admin_action_$slug actions.
 		do_action( 'admin_init' );
 
 		// Fire off the specification action tied to this slug.
-		do_action( sprintf( 'admin_action_%s_%s', Config::get_hook_prefix_underscored(), $this->slug ) );
+		do_action( sprintf( 'admin_action_%s', $this->slug ) );
 
 		$this->assertNull( $token_manager->get() );
 	}
@@ -272,11 +272,11 @@ final class ConnectControllerTest extends UplinkTestCase {
 
 		$this->assertTrue( $screen->in_admin() );
 
-		// Fire off the admin_init action to register our admin_action_$hook_prefix_$slug actions.
+		// Fire off the admin_init action to register our admin_action_$slug actions.
 		do_action( 'admin_init' );
 
 		// Fire off the specification action tied to this slug.
-		do_action( sprintf( 'admin_action_%s_%s', Config::get_hook_prefix_underscored(), $this->slug ) );
+		do_action( sprintf( 'admin_action_%s', $this->slug ) );
 
 		$this->assertSame( $token, $token_manager->get() );
 		$this->assertEmpty( $plugin->get_license_key( is_multisite() ? 'network' : 'local' ) );
@@ -322,11 +322,11 @@ final class ConnectControllerTest extends UplinkTestCase {
 
 		$this->assertTrue( $screen->in_admin() );
 
-		// Fire off the admin_init action to register our admin_action_$hook_prefix_$slug actions.
+		// Fire off the admin_init action to register our admin_action_$slug actions.
 		do_action( 'admin_init' );
 
 		// Fire off the specification action tied to this slug.
-		do_action( sprintf( 'admin_action_%s_%s', Config::get_hook_prefix_underscored(), $this->slug ) );
+		do_action( sprintf( 'admin_action_%s', $this->slug ) );
 
 		$this->assertSame( $token, $token_manager->get() );
 		$this->assertEmpty( $plugin->get_license_key( is_multisite() ? 'network' : 'local' ) );
@@ -385,11 +385,11 @@ final class ConnectControllerTest extends UplinkTestCase {
 		$this->assertTrue( $screen->in_admin( 'network' ) );
 		$this->assertTrue( $screen->in_admin() );
 
-		// Fire off the admin_init action to register our admin_action_$hook_prefix_$slug actions.
+		// Fire off the admin_init action to register our admin_action_$slug actions.
 		do_action( 'admin_init' );
 
 		// Fire off the specification action tied to this slug.
-		do_action( sprintf( 'admin_action_%s_%s', Config::get_hook_prefix_underscored(), $this->slug ) );
+		do_action( sprintf( 'admin_action_%s', $this->slug ) );
 
 		$this->assertSame( $token, $token_manager->get() );
 		$this->assertSame( $plugin->get_license_key( 'network' ), $license );
@@ -451,11 +451,11 @@ final class ConnectControllerTest extends UplinkTestCase {
 		$this->assertFalse( $screen->in_admin( 'network' ) );
 		$this->assertTrue( $screen->in_admin() );
 
-		// Fire off the admin_init action to register our admin_action_$hook_prefix_$slug actions.
+		// Fire off the admin_init action to register our admin_action_$slug actions.
 		do_action( 'admin_init' );
 
 		// Fire off the specification action tied to this slug.
-		do_action( sprintf( 'admin_action_%s_%s', Config::get_hook_prefix_underscored(), $this->slug ) );
+		do_action( sprintf( 'admin_action_%s', $this->slug ) );
 
 		$this->assertSame( $token, $token_manager->get() );
 		$this->assertSame( $plugin->get_license_key( 'network' ), $license );

--- a/tests/wpunit/Auth/Admin/ConnectControllerTest.php
+++ b/tests/wpunit/Auth/Admin/ConnectControllerTest.php
@@ -88,8 +88,11 @@ final class ConnectControllerTest extends UplinkTestCase {
 
 		$this->assertTrue( $screen->in_admin() );
 
-		// Fire off the action the Connect_Controller is running under.
+		// Fire off the admin_init action to register our admin_action_$hook_prefix_$slug actions.
 		do_action( 'admin_init' );
+
+		// Fire off the specification action tied to this slug.
+		do_action( sprintf( 'admin_action_%s_%s', Config::get_hook_prefix_underscored(), $this->slug ) );
 
 		$this->assertSame( $token, $token_manager->get() );
 	}
@@ -135,8 +138,11 @@ final class ConnectControllerTest extends UplinkTestCase {
 
 		$this->assertTrue( $screen->in_admin() );
 
-		// Fire off the action the Connect_Controller is running under.
+		// Fire off the admin_init action to register our admin_action_$hook_prefix_$slug actions.
 		do_action( 'admin_init' );
+
+		// Fire off the specification action tied to this slug.
+		do_action( sprintf( 'admin_action_%s_%s', Config::get_hook_prefix_underscored(), $this->slug ) );
 
 		$this->assertSame( $token, $token_manager->get() );
 		$this->assertSame( $plugin->get_license_key( is_multisite() ? 'network' : 'local' ), $license );
@@ -165,8 +171,11 @@ final class ConnectControllerTest extends UplinkTestCase {
 
 		$this->assertTrue( $screen->in_admin() );
 
-		// Fire off the action the Connect_Controller is running under.
+		// Fire off the admin_init action to register our admin_action_$hook_prefix_$slug actions.
 		do_action( 'admin_init' );
+
+		// Fire off the specification action tied to this slug.
+		do_action( sprintf( 'admin_action_%s_%s', Config::get_hook_prefix_underscored(), $this->slug ) );
 
 		$this->assertNull( $token_manager->get() );
 	}
@@ -195,8 +204,11 @@ final class ConnectControllerTest extends UplinkTestCase {
 
 		$this->assertTrue( $screen->in_admin() );
 
-		// Fire off the action the Connect_Controller is running under.
+		// Fire off the admin_init action to register our admin_action_$hook_prefix_$slug actions.
 		do_action( 'admin_init' );
+
+		// Fire off the specification action tied to this slug.
+		do_action( sprintf( 'admin_action_%s_%s', Config::get_hook_prefix_underscored(), $this->slug ) );
 
 		$this->assertNull( $token_manager->get() );
 	}
@@ -224,8 +236,11 @@ final class ConnectControllerTest extends UplinkTestCase {
 
 		$this->assertTrue( $screen->in_admin() );
 
-		// Fire off the action the Connect_Controller is running under.
+		// Fire off the admin_init action to register our admin_action_$hook_prefix_$slug actions.
 		do_action( 'admin_init' );
+
+		// Fire off the specification action tied to this slug.
+		do_action( sprintf( 'admin_action_%s_%s', Config::get_hook_prefix_underscored(), $this->slug ) );
 
 		$this->assertNull( $token_manager->get() );
 	}
@@ -257,8 +272,11 @@ final class ConnectControllerTest extends UplinkTestCase {
 
 		$this->assertTrue( $screen->in_admin() );
 
-		// Fire off the action the Connect_Controller is running under.
+		// Fire off the admin_init action to register our admin_action_$hook_prefix_$slug actions.
 		do_action( 'admin_init' );
+
+		// Fire off the specification action tied to this slug.
+		do_action( sprintf( 'admin_action_%s_%s', Config::get_hook_prefix_underscored(), $this->slug ) );
 
 		$this->assertSame( $token, $token_manager->get() );
 		$this->assertEmpty( $plugin->get_license_key( is_multisite() ? 'network' : 'local' ) );
@@ -304,8 +322,11 @@ final class ConnectControllerTest extends UplinkTestCase {
 
 		$this->assertTrue( $screen->in_admin() );
 
-		// Fire off the action the Connect_Controller is running under.
+		// Fire off the admin_init action to register our admin_action_$hook_prefix_$slug actions.
 		do_action( 'admin_init' );
+
+		// Fire off the specification action tied to this slug.
+		do_action( sprintf( 'admin_action_%s_%s', Config::get_hook_prefix_underscored(), $this->slug ) );
 
 		$this->assertSame( $token, $token_manager->get() );
 		$this->assertEmpty( $plugin->get_license_key( is_multisite() ? 'network' : 'local' ) );
@@ -364,8 +385,11 @@ final class ConnectControllerTest extends UplinkTestCase {
 		$this->assertTrue( $screen->in_admin( 'network' ) );
 		$this->assertTrue( $screen->in_admin() );
 
-		// Fire off the action the Connect_Controller is running under.
+		// Fire off the admin_init action to register our admin_action_$hook_prefix_$slug actions.
 		do_action( 'admin_init' );
+
+		// Fire off the specification action tied to this slug.
+		do_action( sprintf( 'admin_action_%s_%s', Config::get_hook_prefix_underscored(), $this->slug ) );
 
 		$this->assertSame( $token, $token_manager->get() );
 		$this->assertSame( $plugin->get_license_key( 'network' ), $license );
@@ -427,8 +451,11 @@ final class ConnectControllerTest extends UplinkTestCase {
 		$this->assertFalse( $screen->in_admin( 'network' ) );
 		$this->assertTrue( $screen->in_admin() );
 
-		// Fire off the action the Connect_Controller is running under.
+		// Fire off the admin_init action to register our admin_action_$hook_prefix_$slug actions.
 		do_action( 'admin_init' );
+
+		// Fire off the specification action tied to this slug.
+		do_action( sprintf( 'admin_action_%s_%s', Config::get_hook_prefix_underscored(), $this->slug ) );
 
 		$this->assertSame( $token, $token_manager->get() );
 		$this->assertSame( $plugin->get_license_key( 'network' ), $license );


### PR DESCRIPTION
Fixes a bug in Uplink where multiple instances of Uplink with interfere with each other when connection/disconnecting tokens, causing multiple notices to display. We now register a unique action for each Resource Slug, so only the relevant notice for that specific connect/disconnect request would execute and display.

Companion PR: https://github.com/stellarwp/uplink-origin/pull/50