### PR TITLE
remove unneeded custom update messaging

### DIFF
--- a/src/Uplink/Admin/Plugins_Page.php
+++ b/src/Uplink/Admin/Plugins_Page.php
@@ -51,47 +51,6 @@ class Plugins_Page {
 
 			if ( ! empty( $resource->update->license_error ) ) {
 				$messages[] = $resource->update->license_error;
-			} elseif ( current_user_can( 'update_plugins' ) ) {
-				if ( empty( $resource->update->new_version ) ) {
-					continue;
-				}
-
-				// A plugin update is available
-				$update_now = sprintf(
-					esc_html__( 'Update now to version %s.', '%TEXTDOMAIN%' ),
-					$resource->update->new_version
-				);
-
-				$href = wp_nonce_url(
-					self_admin_url( 'update.php?action=upgrade-plugin&plugin=' ) . $plugin_file,
-					'upgrade-plugin_' . $plugin_file
-				);
-
-				$update_now_link = sprintf(
-					' <a href="%1$s" class="update-link">%2$s</a>',
-					$href,
-					$update_now
-				);
-
-				if ( ! empty ( $resource->update->upgrade_notice ) ) {
-					$update_message = sprintf(
-						esc_html__( '%1$s. %2$s', '%TEXTDOMAIN%' ),
-						$resource->update->upgrade_notice,
-						$update_now_link
-					);
-				} else {
-					$update_message = sprintf(
-						esc_html__( 'There is a new version of %1$s available. %2$s', '%TEXTDOMAIN%' ),
-						$plugin->get_name(),
-						$update_now_link
-					);
-				}
-
-
-				$messages[] = sprintf(
-					'<p>%s</p>',
-					$update_message
-				);
 			}
 
 			if ( empty( $messages ) ) {
@@ -200,18 +159,6 @@ class Plugins_Page {
 		</script>
 		<?php
 		endforeach;
-	}
-
-	/**
-	 * Prevent the default inline update-available messages from appearing, as we
-	 * have implemented our own
-	 *
-	 * @return void
-	 */
-	public function remove_default_inline_update_msg(): void {
-		foreach ( $this->get_plugins() as $plugin ) {
-			remove_action( "after_plugin_row_{$plugin->get_path()}", 'wp_plugin_update_row' );
-		}
 	}
 
 	/**

--- a/src/Uplink/Admin/Provider.php
+++ b/src/Uplink/Admin/Provider.php
@@ -45,7 +45,6 @@ class Provider extends Abstract_Provider {
 		add_action( 'admin_enqueue_scripts', [ $this, 'register_assets' ], 10, 0 );
 		add_action( 'admin_enqueue_scripts', [ $this, 'store_admin_notices' ], 10, 1 );
 		add_action( 'admin_notices', [ $this, 'admin_notices' ], 10, 0 );
-		add_action( 'load-plugins.php', [ $this, 'remove_default_update_message' ], 50, 0 );
 	}
 
 	/**
@@ -144,17 +143,6 @@ class Provider extends Abstract_Provider {
 	 */
 	public function store_admin_notices( $page ): void {
 		$this->container->get( Plugins_Page::class )->store_admin_notices( (string) $page );
-	}
-
-	/**
-	 * Remove the default inline update message for a plugin.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return void
-	 */
-	public function remove_default_update_message(): void {
-		$this->container->get( Plugins_Page::class )->remove_default_inline_update_msg();
 	}
 
 	/**


### PR DESCRIPTION
I'm proposing we remove the unneeded custom update messaging so that updates use core to handle the update on the plugins page.

Here is a video: https://share.getcloudapp.com/rRuBPRoE