### PR TITLE
Prevent fatal during update prevention when $source is a WP_Error rather than a string

### DIFF
--- a/src/Uplink/Admin/Provider.php
+++ b/src/Uplink/Admin/Provider.php
@@ -190,11 +190,7 @@ class Provider extends Abstract_Provider {
 	 */
 	public function filter_upgrader_source_selection_for_update_prevention( $source, $remote_source, $upgrader, $extras ) {
 		if ( is_wp_error( $source ) ) {
-			return new \WP_Error(
-				'stellarwp-uplink-updater-failed-prevention',
-				esc_html__( 'Your update failed due to an unknown error.', '%TEXTDOMAIN%' ),
-				[]
-			);
+			return source;
 		}
 
 		return $this->container->get( Update_Prevention::class )->filter_upgrader_source_selection( $source, $remote_source, $upgrader, $extras );

--- a/src/Uplink/Admin/Provider.php
+++ b/src/Uplink/Admin/Provider.php
@@ -189,6 +189,14 @@ class Provider extends Abstract_Provider {
 	 * @return string|\WP_Error
 	 */
 	public function filter_upgrader_source_selection_for_update_prevention( $source, $remote_source, $upgrader, $extras ) {
+		if ( is_wp_error( $source ) ) {
+			return new \WP_Error(
+				'stellarwp-uplink-updater-failed-prevention',
+				esc_html__( 'Your update failed due to an unknown error.', '%TEXTDOMAIN%' ),
+				[]
+			);
+		}
+
 		return $this->container->get( Update_Prevention::class )->filter_upgrader_source_selection( $source, $remote_source, $upgrader, $extras );
 	}
 }

--- a/src/Uplink/Admin/Provider.php
+++ b/src/Uplink/Admin/Provider.php
@@ -181,10 +181,10 @@ class Provider extends Abstract_Provider {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string       $source        File source location.
-	 * @param mixed        $remote_source Remote file source location.
-	 * @param \WP_Upgrader $upgrader      WP_Upgrader instance.
-	 * @param array        $extras        Extra arguments passed to hooked filters.
+	 * @param string|\WP_Error $source        File source location or a WP_Error.
+	 * @param mixed            $remote_source Remote file source location.
+	 * @param \WP_Upgrader     $upgrader      WP_Upgrader instance.
+	 * @param array            $extras        Extra arguments passed to hooked filters.
 	 *
 	 * @return string|\WP_Error
 	 */

--- a/src/Uplink/Admin/Provider.php
+++ b/src/Uplink/Admin/Provider.php
@@ -190,7 +190,7 @@ class Provider extends Abstract_Provider {
 	 */
 	public function filter_upgrader_source_selection_for_update_prevention( $source, $remote_source, $upgrader, $extras ) {
 		if ( is_wp_error( $source ) ) {
-			return source;
+			return $source;
 		}
 
 		return $this->container->get( Update_Prevention::class )->filter_upgrader_source_selection( $source, $remote_source, $upgrader, $extras );


### PR DESCRIPTION
Iconic support encountered a ticket where a customer has attempted to upgrade to WC `8.5.0` and received a fatal error from Uplink:

![image](https://github.com/stellarwp/uplink/assets/3214928/ac53bdce-0564-4e7f-8ec4-b42030d2d91c)

The issue is that the `filter_upgrader_source_selection_for_update_prevention` method is not checking to see if `$source` is a `WP_Error`. In this case, we believe that the underlying error is being thrown by WC thanks to an [issue ](https://github.com/woocommerce/woocommerce/issues/43406) in this new release.

They have rolled back to a previous stable version in order to resolve their issue, but it would be good to defend against similar circumstances in the future.

This change simply adds a defensive check and returns a `WP_Error` with a generic message (text TBC). Given that this method is already expected to return either a string or a WP_Error, this doesn't introduce any unpredictable behaviour.