### PR TITLE
fix check for data in status

### DIFF
--- a/src/Uplink/API/Validation_Response.php
+++ b/src/Uplink/API/Validation_Response.php
@@ -278,7 +278,7 @@ class Validation_Response {
 		$plugin = $this->response->plugin ?? '';
 
 		if ( empty( $id ) ) {
-			$id = 'stellarwp/plugins/' . $this->response->slug;
+			$id = 'stellarwp/plugins/' . $this->resource->get_slug();
 		}
 
 		if ( empty( $plugin ) ) {

--- a/src/Uplink/API/Validation_Response.php
+++ b/src/Uplink/API/Validation_Response.php
@@ -278,7 +278,7 @@ class Validation_Response {
 		$plugin = $this->response->plugin ?? '';
 
 		if ( empty( $id ) ) {
-			$id = 'stellarwp/plugins/' . $this->resource->get_slug();
+			$id = 'stellarwp/plugins/' . $this->response->slug ?? $this->resource->get_slug();
 		}
 
 		if ( empty( $plugin ) ) {

--- a/src/Uplink/API/Validation_Response.php
+++ b/src/Uplink/API/Validation_Response.php
@@ -276,9 +276,10 @@ class Validation_Response {
 
 		$id     = $this->response->id ?? '';
 		$plugin = $this->response->plugin ?? '';
+		$slug   = $this->response->slug ?? $this->resource->get_slug();
 
 		if ( empty( $id ) ) {
-			$id = 'stellarwp/plugins/' . $this->response->slug ?? $this->resource->get_slug();
+			$id = 'stellarwp/plugins/' . $slug;
 		}
 
 		if ( empty( $plugin ) ) {
@@ -287,7 +288,7 @@ class Validation_Response {
 
 		$update->id          = $id;
 		$update->plugin      = $plugin;
-		$update->slug        = $this->response->slug ?? '';
+		$update->slug        = $slug;
 		$update->new_version = $this->response->version ?? '';
 		$update->url         = $this->response->homepage ?? '';
 		$update->tested      = $this->response->tested ?? '';

--- a/src/Uplink/API/Validation_Response.php
+++ b/src/Uplink/API/Validation_Response.php
@@ -276,10 +276,13 @@ class Validation_Response {
 
 		$id     = $this->response->id ?? '';
 		$plugin = $this->response->plugin ?? '';
-		$slug   = $this->response->slug ?? $this->resource->get_slug();
+		$slug   = $this->response->slug ?? '';
 
 		if ( empty( $id ) ) {
-			$id = 'stellarwp/plugins/' . $slug;
+			$id = sprintf(
+				'stellarwp/plugins/%s',
+				empty( $slug ) ? $this->resource->get_slug() : $slug
+			);
 		}
 
 		if ( empty( $plugin ) ) {

--- a/src/Uplink/API/Validation_Response.php
+++ b/src/Uplink/API/Validation_Response.php
@@ -274,8 +274,19 @@ class Validation_Response {
 			return $this->handle_api_errors();
 		}
 
-		$update->id          = $this->response->id ?? '';
-		$update->plugin      = $this->response->plugin ?? '';
+		$id     = $this->response->id ?? '';
+		$plugin = $this->response->plugin ?? '';
+
+		if ( empty( $id ) ) {
+			$id = 'stellarwp/plugins/' . $this->response->slug;
+		}
+
+		if ( empty( $plugin ) ) {
+			$plugin = $this->resource->get_path();
+		}
+
+		$update->id          = $id;
+		$update->plugin      = $plugin;
 		$update->slug        = $this->response->slug ?? '';
 		$update->new_version = $this->response->version ?? '';
 		$update->url         = $this->response->homepage ?? '';

--- a/src/Uplink/Resources/Plugin.php
+++ b/src/Uplink/Resources/Plugin.php
@@ -61,25 +61,19 @@ class Plugin extends Resource {
 
 		// Prevent an empty class from being saved in the $transient.
 		if ( isset( $status->update->version ) ) {
+			$product_path = $this->get_path();
+
 			if ( version_compare( $this->get_version_from_response( $results ), $this->get_installed_version(), '>' ) ) {
 				/** @var \stdClass $transient */
 				if ( ! isset( $transient->response ) ) {
 					$transient->response = [];
 				}
 
-				$transient->response[ $this->get_path() ] = $results->get_update_details();
-				// Stellar License never sends an ID, so we need to add it.
-				if ( empty( $transient->response[ $this->get_path() ]->id ) ) {
-					$transient->response[ $this->get_path() ]->id = 'stellarwp/plugins/' . $this->get_slug();
-				}
-				// Stellar License never sends a plugin, so we need to add it.
-				if ( empty( $transient->response[ $this->get_path() ]->plugin ) ) {
-					$transient->response[ $this->get_path() ]->plugin = $this->get_path();
-				}
+				$transient->response[ $product_path ] = $results->get_update_details();
 
 				// Clear the no_update property if it exists.
-				if ( isset( $transient->no_update[ $this->get_path() ] ) ) {
-					unset( $transient->no_update[ $this->get_path() ] );
+				if ( isset( $transient->no_update[ $product_path ] ) ) {
+					unset( $transient->no_update[ $product_path ] );
 				}
 
 				if ( 'expired' === $results->get_result() ) {
@@ -87,9 +81,10 @@ class Plugin extends Resource {
 				}
 			} else {
 				// Clean up any stale update info.
-				if ( isset( $transient->response[ $this->get_path() ] ) ) {
-					unset( $transient->response[ $this->get_path() ] );
+				if ( isset( $transient->response[ $product_path ] ) ) {
+					unset( $transient->response[ $product_path ] );
 				}
+
 				/**
 				 * If the plugin is up to date, we need to add it to the `no_update` property so that enable auto updates can appear correctly in the UI.
 				 *
@@ -100,15 +95,8 @@ class Plugin extends Resource {
 				if ( ! isset( $transient->no_update ) ) {
 					$transient->no_update = [];
 				}
-				$transient->no_update[ $this->get_path() ] = $results->get_update_details();
-				// Stellar License never sends an ID, so we need to add it.
-				if ( empty( $transient->no_update[ $this->get_path() ]->id ) ) {
-					$transient->no_update[ $this->get_path() ]->id = 'stellarwp/plugins/' . $this->get_slug();
-				}
-				// Stellar License never sends a plugin, so we need to add it.
-				if ( empty( $transient->no_update[ $this->get_path() ]->plugin ) ) {
-					$transient->no_update[ $this->get_path() ]->plugin = $this->get_path();
-				}
+
+				$transient->no_update[ $product_path ] = $results->get_update_details();
 			}
 
 			// In order to show relevant issues on plugins page parse response data and add it to transient
@@ -117,7 +105,7 @@ class Plugin extends Resource {
 				if ( ! isset( $transient->response ) ) {
 					$transient->response = [];
 				}
-				$transient->response[ $this->get_path() ] = $results->handle_api_errors();
+				$transient->response[ $product_path ] = $results->handle_api_errors();
 			}
 
 		}

--- a/tests/wpunit/API/Validation_ResponseTest.php
+++ b/tests/wpunit/API/Validation_ResponseTest.php
@@ -38,7 +38,7 @@ class Validation_ResponseTest extends UplinkTestCase {
 		$result = new Validation_Response( 'aaa11', 'local', $this->get_dummy_valid_response(), $this->resource );
 		$update = $result->get_update_details();
 
-		$this->assertEquals( '', $update->id );
+		$this->assertEquals( 'stellarwp/plugins/sample', $update->id );
 		$this->assertEquals( '', $update->plugin );
 		$this->assertEquals( 'sample', $update->slug );
 		$this->assertEquals( '1.0.10', $update->new_version );


### PR DESCRIPTION
Also, add in missing data WordPress expects

This fixes an issue where an unlicensed product or a free product could get an empty class in the plugin update $transient, and that would cause the product to be missing the "slug" value in the plugins table, making it so that you couldn't delete the plugin until the plugins transient was cleared. 