### PR TITLE
Make authorized checks require a plugin slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ if ( ! $token || ! $license_key || ! $domain ) {
 	return; // or, log/show errors.
 }
 
-$is_authorized = \StellarWP\Uplink\is_authorized( $license_key, $token, $domain );
+$is_authorized = \StellarWP\Uplink\is_authorized( $license_key, 'my-plugin-slug', $token, $domain );
 
 echo $is_authorized ? esc_html__( 'authorized' ) : esc_html__( 'not authorized' );
 ```

--- a/src/Uplink/API/V3/Auth/Contracts/Token_Authorizer.php
+++ b/src/Uplink/API/V3/Auth/Contracts/Token_Authorizer.php
@@ -11,11 +11,12 @@ interface Token_Authorizer {
 	 * @see \StellarWP\Uplink\API\V3\Auth\Token_Authorizer
 	 *
 	 * @param  string  $license  The license key.
+	 * @param  string  $slug     The plugin/service slug.
 	 * @param  string  $token    The stored token.
 	 * @param  string  $domain   The user's domain.
 	 *
 	 * @return bool
 	 */
-	public function is_authorized( string $license, string $token, string $domain ): bool;
+	public function is_authorized( string $license, string $slug, string $token, string $domain ): bool;
 
 }

--- a/src/Uplink/API/V3/Auth/Token_Authorizer.php
+++ b/src/Uplink/API/V3/Auth/Token_Authorizer.php
@@ -28,17 +28,19 @@ class Token_Authorizer implements Contracts\Token_Authorizer {
 	/**
 	 * Manually check if a license is authorized.
 	 *
-	 * @see is_authorized()
-	 *
 	 * @param  string  $license  The license key.
-	 * @param  string  $token  The stored token.
-	 * @param  string  $domain  The user's domain.
+	 * @param  string  $slug     The plugin/service slug.
+	 * @param  string  $token    The stored token.
+	 * @param  string  $domain   The user's domain.
 	 *
 	 * @return bool
+	 *
+	 * @see is_authorized()
 	 */
-	public function is_authorized( string $license, string $token, string $domain ): bool {
+	public function is_authorized( string $license, string $slug, string $token, string $domain ): bool {
 		$response = $this->client->get( 'tokens/auth', [
 			'license' => $license,
+			'slug'    => $slug,
 			'token'   => $token,
 			'domain'  => $domain,
 		] );

--- a/src/Uplink/API/V3/Auth/Token_Authorizer_Cache_Decorator.php
+++ b/src/Uplink/API/V3/Auth/Token_Authorizer_Cache_Decorator.php
@@ -76,12 +76,23 @@ final class Token_Authorizer_Cache_Decorator implements Contracts\Token_Authoriz
 	/**
 	 * Build a transient key.
 	 *
-	 * @param  array<int, string>  ...$args
+	 * @param  array<int, string>  $args
 	 *
 	 * @return string
 	 */
-	public function build_transient( array ...$args ): string {
-		return self::TRANSIENT_PREFIX . hash( 'sha256', json_encode( $args ) );
+	public function build_transient( array $args ): string {
+		return self::TRANSIENT_PREFIX . $this->build_transient_no_prefix( $args );
+	}
+
+	/**
+	 * Build a transient key without the prefix.
+	 *
+	 * @param  array  $args
+	 *
+	 * @return string
+	 */
+	public function build_transient_no_prefix( array $args ): string {
+		return hash( 'sha256', json_encode( $args ) );
 	}
 
 }

--- a/src/Uplink/API/V3/Auth/Token_Authorizer_Cache_Decorator.php
+++ b/src/Uplink/API/V3/Auth/Token_Authorizer_Cache_Decorator.php
@@ -56,7 +56,7 @@ final class Token_Authorizer_Cache_Decorator implements Contracts\Token_Authoriz
 	 * @return bool
 	 */
 	public function is_authorized( string $license, string $slug, string $token, string $domain ): bool {
-		$transient     = $this->build_transient( [ $license, $slug, $token, $domain ] );
+		$transient     = $this->build_transient( [ $license, $token, $domain ] );
 		$is_authorized = get_transient( $transient );
 
 		if ( $is_authorized === true ) {

--- a/src/Uplink/API/V3/Auth/Token_Authorizer_Cache_Decorator.php
+++ b/src/Uplink/API/V3/Auth/Token_Authorizer_Cache_Decorator.php
@@ -56,7 +56,7 @@ final class Token_Authorizer_Cache_Decorator implements Contracts\Token_Authoriz
 	 * @return bool
 	 */
 	public function is_authorized( string $license, string $slug, string $token, string $domain ): bool {
-		$transient     = $this->build_transient( [ $license, $token, $domain ] );
+		$transient     = $this->build_transient( [ $token ] );
 		$is_authorized = get_transient( $transient );
 
 		if ( $is_authorized === true ) {

--- a/src/Uplink/API/V3/Auth/Token_Authorizer_Cache_Decorator.php
+++ b/src/Uplink/API/V3/Auth/Token_Authorizer_Cache_Decorator.php
@@ -49,20 +49,21 @@ final class Token_Authorizer_Cache_Decorator implements Contracts\Token_Authoriz
 	 * @see Token_Authorizer
 	 *
 	 * @param  string  $license  The license key.
+	 * @param  string  $slug     The plugin/service slug.
 	 * @param  string  $token    The stored token.
 	 * @param  string  $domain   The user's domain.
 	 *
 	 * @return bool
 	 */
-	public function is_authorized( string $license, string $token, string $domain ): bool {
-		$transient     = $this->build_transient( [ $license, $token, $domain ] );
+	public function is_authorized( string $license, string $slug, string $token, string $domain ): bool {
+		$transient     = $this->build_transient( [ $license, $slug, $token, $domain ] );
 		$is_authorized = get_transient( $transient );
 
 		if ( $is_authorized === true ) {
 			return true;
 		}
 
-		$is_authorized = $this->authorizer->is_authorized( $license, $token, $domain );
+		$is_authorized = $this->authorizer->is_authorized( $license, $slug, $token, $domain );
 
 		// Only cache successful responses.
 		if ( $is_authorized ) {

--- a/src/Uplink/Auth/Admin/Disconnect_Controller.php
+++ b/src/Uplink/Auth/Admin/Disconnect_Controller.php
@@ -76,7 +76,7 @@ final class Disconnect_Controller {
 			return '';
 		}
 
-		$cache_key = $this->cache->build_transient( [ $token ] );
+		$cache_key = $this->cache->build_transient_no_prefix( [ $token ] );
 
 		return wp_nonce_url( add_query_arg( [
 			self::ARG       => true,

--- a/src/Uplink/Auth/Admin/Disconnect_Controller.php
+++ b/src/Uplink/Auth/Admin/Disconnect_Controller.php
@@ -2,15 +2,19 @@
 
 namespace StellarWP\Uplink\Auth\Admin;
 
+use StellarWP\Uplink\API\V3\Auth\Token_Authorizer_Cache_Decorator;
 use StellarWP\Uplink\Auth\Authorizer;
 use StellarWP\Uplink\Auth\Token\Disconnector;
+use StellarWP\Uplink\Auth\Token\Token_Factory;
 use StellarWP\Uplink\Notice\Notice_Handler;
 use StellarWP\Uplink\Notice\Notice;
+use StellarWP\Uplink\Resources\Resource;
 
 final class Disconnect_Controller {
 
-	public const ARG  = 'uplink_disconnect';
-	public const SLUG = 'uplink_slug';
+	public const ARG       = 'uplink_disconnect';
+	public const SLUG      = 'uplink_slug';
+	public const CACHE_KEY = 'uplink_cache';
 
 	/**
 	 * @var Authorizer
@@ -28,31 +32,56 @@ final class Disconnect_Controller {
 	private $notice;
 
 	/**
-	 * @param  Authorizer  $authorizer  The authorizer.
-	 * @param  Disconnector  $disconnect  Disconnects a Token, if the user has the capability.
-	 * @param  Notice_Handler  $notice  Handles storing and displaying notices.
+	 * @var Token_Factory
+	 */
+	private $token_factory;
+
+	/**
+	 * @var Token_Authorizer_Cache_Decorator
+	 */
+	private $cache;
+
+	/**
+	 * @param  Authorizer                        $authorizer     The authorizer.
+	 * @param  Disconnector                      $disconnect     Disconnects a Token, if the user has the capability.
+	 * @param  Notice_Handler                    $notice         Handles storing and displaying notices.
+	 * @param  Token_Factory                     $token_factory  The token factory.
+	 * @param  Token_Authorizer_Cache_Decorator  $cache          The token cache.
 	 */
 	public function __construct(
 		Authorizer $authorizer,
 		Disconnector $disconnect,
-		Notice_Handler $notice
+		Notice_Handler $notice,
+		Token_Factory $token_factory,
+		Token_Authorizer_Cache_Decorator $cache
 	) {
-		$this->authorizer = $authorizer;
-		$this->disconnect = $disconnect;
-		$this->notice     = $notice;
+		$this->authorizer    = $authorizer;
+		$this->disconnect    = $disconnect;
+		$this->notice        = $notice;
+		$this->token_factory = $token_factory;
+		$this->cache         = $cache;
 	}
 
 	/**
 	 * Get the disconnect URL to render.
 	 *
-	 * @param  string  $slug  The plugin/service slug.
+	 * @param  Resource  $plugin  The plugin/service.
 	 *
 	 * @return string
 	 */
-	public function get_url( string $slug ): string {
+	public function get_url( Resource $plugin ): string {
+		$token = $this->token_factory->make( $plugin )->get();
+
+		if ( ! $token ) {
+			return '';
+		}
+
+		$cache_key = $this->cache->build_transient( [ $token ] );
+
 		return wp_nonce_url( add_query_arg( [
-			self::ARG  => true,
-			self::SLUG => $slug,
+			self::ARG       => true,
+			self::SLUG      => $plugin->get_slug(),
+			self::CACHE_KEY => $cache_key,
 		], get_admin_url( get_current_blog_id() ) ), self::ARG );
 	}
 
@@ -66,7 +95,7 @@ final class Disconnect_Controller {
 	 * @return void
 	 */
 	public function maybe_disconnect(): void {
-		if ( empty( $_GET[ self::ARG ] ) || empty( $_GET['_wpnonce'] ) || empty( $_GET[ self::SLUG ] ) ) {
+		if ( empty( $_GET[ self::ARG ] ) || empty( $_GET['_wpnonce'] ) || empty( $_GET[ self::SLUG ] ) || empty( $_GET[ self::CACHE_KEY ] ) ) {
 			return;
 		}
 
@@ -75,7 +104,7 @@ final class Disconnect_Controller {
 		}
 
 		if ( wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), self::ARG ) ) {
-			if ( $this->authorizer->can_auth() && $this->disconnect->disconnect( $_GET[ self::SLUG ] ) ) {
+			if ( $this->authorizer->can_auth() && $this->disconnect->disconnect( $_GET[ self::SLUG ], $_GET[ self::CACHE_KEY ] ) ) {
 				$this->notice->add(
 					new Notice( Notice::SUCCESS,
 						__( 'Token disconnected.', '%TEXTDOMAIN%' ),

--- a/src/Uplink/Auth/Token/Disconnector.php
+++ b/src/Uplink/Auth/Token/Disconnector.php
@@ -31,16 +31,26 @@ final class Disconnector {
 	/**
 	 * Delete a token if the current user is allowed to.
 	 *
-	 * @param  string  $slug  The plugin or service slug.
+	 * @param  string  $slug       The plugin or service slug.
+	 * @param  string  $cache_key  The token cache key.
+	 *
+	 * @return bool
 	 */
-	public function disconnect( string $slug ): bool {
+	public function disconnect( string $slug, string $cache_key ): bool {
 		$plugin = $this->resources->offsetGet( $slug );
 
 		if ( ! $plugin ) {
 			return false;
 		}
 
-		return $this->token_manager_factory->make( $plugin )->delete();
+		$result = $this->token_manager_factory->make( $plugin )->delete();
+
+		if ( $result ) {
+			// Delete the authorization cache.
+			delete_transient( $cache_key );
+		}
+
+		return $result;
 	}
 
 }

--- a/src/Uplink/Auth/Token/Disconnector.php
+++ b/src/Uplink/Auth/Token/Disconnector.php
@@ -2,6 +2,7 @@
 
 namespace StellarWP\Uplink\Auth\Token;
 
+use StellarWP\Uplink\API\V3\Auth\Token_Authorizer_Cache_Decorator;
 use StellarWP\Uplink\Resources\Collection;
 
 final class Disconnector {
@@ -47,7 +48,7 @@ final class Disconnector {
 
 		if ( $result ) {
 			// Delete the authorization cache.
-			delete_transient( $cache_key );
+			delete_transient( Token_Authorizer_Cache_Decorator::TRANSIENT_PREFIX . $cache_key );
 		}
 
 		return $result;

--- a/src/Uplink/Components/Admin/Authorize_Button_Controller.php
+++ b/src/Uplink/Components/Admin/Authorize_Button_Controller.php
@@ -116,7 +116,7 @@ final class Authorize_Button_Controller extends Controller {
 			$authenticated = true;
 			$target        = '_self';
 			$link_text     = __( 'Disconnect', '%TEXTDOMAIN%' );
-			$url           = $this->disconnect_controller->get_url( $slug );
+			$url           = $this->disconnect_controller->get_url( $plugin );
 			$classes[1]    = 'authorized';
 		}
 

--- a/src/Uplink/functions.php
+++ b/src/Uplink/functions.php
@@ -116,7 +116,7 @@ function is_authorized_by_resource( string $slug ): bool {
 			return false;
 		}
 
-		return is_authorized( $license, $token, $domain );
+		return is_authorized( $license, $slug, $token, $domain );
 	} catch ( Throwable $e ) {
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			error_log( "An Authorization error occurred: {$e->getMessage()} {$e->getFile()}:{$e->getLine()} {$e->getTraceAsString()}" );

--- a/src/Uplink/functions.php
+++ b/src/Uplink/functions.php
@@ -298,7 +298,13 @@ function get_license_domain(): string {
  * @return string
  */
 function get_disconnect_url( string $slug ): string {
-	return get_container()->get( Disconnect_Controller::class )->get_url( $slug );
+	$resource = get_resource( $slug );
+
+	if ( ! $resource ) {
+		return '';
+	}
+
+	return get_container()->get( Disconnect_Controller::class )->get_url( $resource );
 }
 
 /**

--- a/src/Uplink/functions.php
+++ b/src/Uplink/functions.php
@@ -78,16 +78,17 @@ function get_authorization_token( string $slug ): ?string {
  * @note This response may be cached.
  *
  * @param  string  $license  The license key.
- * @param  string  $token  The stored token.
- * @param  string  $domain  The user's license domain.
+ * @param  string  $slug     The plugin/service slug.
+ * @param  string  $token    The stored token.
+ * @param  string  $domain   The user's license domain.
  *
  * @return bool
  */
-function is_authorized( string $license, string $token, string $domain ): bool {
+function is_authorized( string $license, string $slug, string $token, string $domain ): bool {
 	try {
 		return get_container()
 			->get( Token_Authorizer::class )
-			->is_authorized( $license, $token, $domain );
+			->is_authorized( $license, $slug, $token, $domain );
 	} catch ( Throwable $e ) {
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			error_log( "An Authorization error occurred: {$e->getMessage()} {$e->getFile()}:{$e->getLine()} {$e->getTraceAsString()}" );

--- a/tests/wpunit/API/V3/AuthorizerCacheTest.php
+++ b/tests/wpunit/API/V3/AuthorizerCacheTest.php
@@ -25,7 +25,7 @@ final class AuthorizerCacheTest extends UplinkTestCase {
 		$this->container->bind( \StellarWP\Uplink\API\V3\Auth\Token_Authorizer::class, $authorizer_mock );
 
 		$decorator = $this->container->get( Token_Authorizer::class );
-		$transient = $decorator->build_transient( [ '1234', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' ] );
+		$transient = $decorator->build_transient( [ 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840' ] );
 
 		// No cache should exist.
 		$this->assertFalse( get_transient( $transient ) );
@@ -49,7 +49,7 @@ final class AuthorizerCacheTest extends UplinkTestCase {
 		$this->container->bind( \StellarWP\Uplink\API\V3\Auth\Token_Authorizer::class, $authorizer_mock );
 
 		$decorator = $this->container->get( Token_Authorizer::class );
-		$transient = $decorator->build_transient( [ '1234', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' ] );
+		$transient = $decorator->build_transient( [ 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840' ] );
 
 		// No cache should exist.
 		$this->assertFalse( get_transient( $transient ) );

--- a/tests/wpunit/API/V3/AuthorizerCacheTest.php
+++ b/tests/wpunit/API/V3/AuthorizerCacheTest.php
@@ -25,18 +25,18 @@ final class AuthorizerCacheTest extends UplinkTestCase {
 		$this->container->bind( \StellarWP\Uplink\API\V3\Auth\Token_Authorizer::class, $authorizer_mock );
 
 		$decorator = $this->container->get( Token_Authorizer::class );
-		$transient = $decorator->build_transient( [ '1234', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' ] );
+		$transient = $decorator->build_transient( [ '1234', 'kadence-blocks-pro', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' ] );
 
 		// No cache should exist.
 		$this->assertFalse( get_transient( $transient ) );
 
-		$authorized = $decorator->is_authorized( '1234', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' );
+		$authorized = $decorator->is_authorized( '1234', 'kadence-blocks-pro', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' );
 
 		$this->assertTrue( $authorized );
 
 		// Cache should now be present.
 		$this->assertTrue( get_transient( $transient ) );
-		$this->assertTrue( $decorator->is_authorized( '1234', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' ) );
+		$this->assertTrue( $decorator->is_authorized( '1234', 'kadence-blocks-pro', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' ) );
 	}
 
 	public function test_it_does_not_cache_an_invalid_token_response(): void {
@@ -49,12 +49,12 @@ final class AuthorizerCacheTest extends UplinkTestCase {
 		$this->container->bind( \StellarWP\Uplink\API\V3\Auth\Token_Authorizer::class, $authorizer_mock );
 
 		$decorator = $this->container->get( Token_Authorizer::class );
-		$transient = $decorator->build_transient( [ '1234', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' ] );
+		$transient = $decorator->build_transient( [ '1234', 'kadence-blocks-pro', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' ] );
 
 		// No cache should exist.
 		$this->assertFalse( get_transient( $transient ) );
 
-		$authorized = $decorator->is_authorized( '1234', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' );
+		$authorized = $decorator->is_authorized( '1234', 'kadence-blocks-pro', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' );
 
 		$this->assertFalse( $authorized );
 

--- a/tests/wpunit/API/V3/AuthorizerCacheTest.php
+++ b/tests/wpunit/API/V3/AuthorizerCacheTest.php
@@ -25,7 +25,7 @@ final class AuthorizerCacheTest extends UplinkTestCase {
 		$this->container->bind( \StellarWP\Uplink\API\V3\Auth\Token_Authorizer::class, $authorizer_mock );
 
 		$decorator = $this->container->get( Token_Authorizer::class );
-		$transient = $decorator->build_transient( [ '1234', 'kadence-blocks-pro', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' ] );
+		$transient = $decorator->build_transient( [ '1234', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' ] );
 
 		// No cache should exist.
 		$this->assertFalse( get_transient( $transient ) );
@@ -49,7 +49,7 @@ final class AuthorizerCacheTest extends UplinkTestCase {
 		$this->container->bind( \StellarWP\Uplink\API\V3\Auth\Token_Authorizer::class, $authorizer_mock );
 
 		$decorator = $this->container->get( Token_Authorizer::class );
-		$transient = $decorator->build_transient( [ '1234', 'kadence-blocks-pro', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' ] );
+		$transient = $decorator->build_transient( [ '1234', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' ] );
 
 		// No cache should exist.
 		$this->assertFalse( get_transient( $transient ) );

--- a/tests/wpunit/API/V3/AuthorizerTest.php
+++ b/tests/wpunit/API/V3/AuthorizerTest.php
@@ -40,7 +40,7 @@ final class AuthorizerTest extends UplinkTestCase {
 
 		$this->container->bind( Client_V3::class, $clientMock );
 
-		$authorizer = $this->container->get( Token_Authorizer::class )->is_authorized( '1234', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' );
+		$authorizer = $this->container->get( Token_Authorizer::class )->is_authorized( '1234', 'kadence-blocks-pro', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' );
 
 		$this->assertTrue( $authorizer );
 	}
@@ -59,7 +59,7 @@ final class AuthorizerTest extends UplinkTestCase {
 
 		$this->container->bind( Client_V3::class, $clientMock );
 
-		$authorizer = $this->container->get( Token_Authorizer::class )->is_authorized( 'invalid-license-key', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' );
+		$authorizer = $this->container->get( Token_Authorizer::class )->is_authorized( 'invalid-license-key', 'kadence-blocks-pro', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' );
 
 		$this->assertFalse( $authorizer );
 	}
@@ -78,7 +78,7 @@ final class AuthorizerTest extends UplinkTestCase {
 
 		$this->container->bind( Client_V3::class, $clientMock );
 
-		$authorizer = $this->container->get( Token_Authorizer::class )->is_authorized( '1234', 'invalid', 'test.com' );
+		$authorizer = $this->container->get( Token_Authorizer::class )->is_authorized( '1234', 'kadence-blocks-pro', 'invalid', 'test.com' );
 
 		$this->assertFalse( $authorizer );
 	}


### PR DESCRIPTION
### Main Changes
- is_authorized() now requires a slug.
- Token authorization caching now just uses a hashed token as the transient key.
- Successfully disconnecting a token now removes the authorization cache.

Licensing Companion PR: https://github.com/stellarwp/licensing/pull/72