### PR TITLE
[BUGFIX]: Type error in filter_upgrader_pre_download()

### DIFF
--- a/src/Uplink/Admin/Package_Handler.php
+++ b/src/Uplink/Admin/Package_Handler.php
@@ -5,6 +5,7 @@ namespace StellarWP\Uplink\Admin;
 use StellarWP\Uplink\API;
 use StellarWP\Uplink\Config;
 use StellarWP\Uplink\Resources;
+use WP_Error;
 use WP_Upgrader;
 
 class Package_Handler {
@@ -17,17 +18,17 @@ class Package_Handler {
 	/**
 	 * Filters the package download step to store the downloaded file with a shorter file name.
 	 *
-	 * @param bool|\WP_Error $reply    Whether to bail without returning the package.
-	 *                                 Default false.
-	 * @param string         $package  The package file name or URL.
-	 * @param WP_Upgrader    $upgrader The WP_Upgrader instance.
-	 * @param array          $hook_extra Extra arguments passed to hooked filters.
+	 * @param  bool|WP_Error  $reply        Whether to bail without returning the package.
+	 *                                      Default false.
+	 * @param  string|null    $package      The package file name or URL.
+	 * @param  WP_Upgrader    $upgrader     The WP_Upgrader instance.
+	 * @param  array          $hook_extra   Extra arguments passed to hooked filters.
 	 *
-	 * @return mixed
+	 * @return string|bool|WP_Error
 	 */
-	public function filter_upgrader_pre_download( $reply, string $package, WP_Upgrader $upgrader, $hook_extra ) {
+	public function filter_upgrader_pre_download( $reply, $package, WP_Upgrader $upgrader, $hook_extra ) {
 		if ( empty( $package ) || 'invalid_license' === $package ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'download_failed',
 				__( 'Failed to update plugin. Check your license details first.', '%TEXTDOMAIN%' ),
 				''
@@ -149,7 +150,7 @@ class Package_Handler {
 	 * @param string $package The URI of the package. If this is the full path to an
 	 *                        existing local file, it will be returned untouched.
 	 *
-	 * @return string|bool|\WP_Error The full path to the downloaded package file, or a WP_Error object.
+	 * @return string|bool|WP_Error The full path to the downloaded package file, or a WP_Error object.
 	 */
 	protected function download( string $package ) {
 		if ( empty( $this->filesystem ) ) {
@@ -174,7 +175,7 @@ class Package_Handler {
 		$download_file = download_url( $package );
 
 		if ( is_wp_error( $download_file ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'download_failed',
 				$this->upgrader->strings['download_failed'],
 				$download_file->get_error_message()

--- a/src/Uplink/Admin/Provider.php
+++ b/src/Uplink/Admin/Provider.php
@@ -152,11 +152,11 @@ class Provider extends Abstract_Provider {
 	 *
 	 * @param  bool|\WP_Error  $reply       Whether to bail without returning the package.
 	 *                                      Default false.
-	 * @param  string          $package     The package file name or URL.
+	 * @param  string|null     $package     The package file name or URL.
 	 * @param  \WP_Upgrader    $upgrader    The WP_Upgrader instance.
 	 * @param  array           $hook_extra  Extra arguments passed to hooked filters.
 	 *
-	 * @return mixed
+	 * @return string|bool|\WP_Error
 	 */
 	public function filter_upgrader_pre_download( $reply, $package, $upgrader, $hook_extra ) {
 		return $this->container->get( Package_Handler::class )->filter_upgrader_pre_download( $reply, $package, $upgrader, $hook_extra );

--- a/tests/wpunit/Admin/Package_HandlerTest.php
+++ b/tests/wpunit/Admin/Package_HandlerTest.php
@@ -35,7 +35,7 @@ final class Package_HandlerTest extends UplinkTestCase {
 		$this->assertWPError( $filtered );
 	}
 
-	public function test_it_return_WP_Error_if_the_package_is_null() {
+	public function test_it_returns_WP_Error_if_the_package_is_null() {
 		$upgrader = $this->prophesize( WP_Upgrader::class );
 
 		$sut      = new Package_Handler();


### PR DESCRIPTION
Reported here: https://wordpress.org/support/topic/kadence-blocks-break-wp-cli-plugin-updates/

```
PHP Fatal error:  Uncaught TypeError: KadenceWP\KadenceBlocks\StellarWP\Uplink\Admin\Package_Handler::filter_upgrader_pre_download(): Argument #2 ($package) must be of type string, null given, called in /wp-content/plugins/kadence-blocks/vendor/vendor-prefixed/stellarwp/uplink/src/Uplink/Admin/Provider.php on line 171 and defined in /wp-content/plugins/kadence-blocks/vendor/vendor-prefixed/stellarwp/uplink/src/Uplink/Admin/Package_Handler.php:33
Stack trace:
#0 /wp-content/plugins/kadence-blocks/vendor/vendor-prefixed/stellarwp/uplink/src/Uplink/Admin/Provider.php(171): KadenceWP\KadenceBlocks\StellarWP\Uplink\Admin\Package_Handler->filter_upgrader_pre_download(false, NULL, Object(Plugin_Upgrader), Array)
#1 /wp-includes/class-wp-hook.php(324): KadenceWP\KadenceBlocks\StellarWP\Uplink\Admin\Provider->filter_upgrader_pre_download(false, NULL, Object(Plugin_Upgrader), Array)
#2 /wp-includes/plugin.php(205): WP_Hook->apply_filters(false, Array)
#3 /wp-admin/includes/class-wp-upgrader.php(318): apply_filters('upgrader_pre_do...', false, NULL, Object(Plugin_Upgrader), Array)
#4 /wp-admin/includes/class-wp-upgrader.php(827): WP_Upgrader->download_package(NULL, true, Array)
#5 /wp-admin/includes/class-plugin-upgrader.php(392): WP_Upgrader->run(Array)
#6 phar:///usr/local/bin/wp/vendor/wp-cli/extension-command/src/WP_CLI/CommandWithUpgrade.php(445): Plugin_Upgrader->bulk_upgrade(Array)
#7 phar:///usr/local/bin/wp/vendor/wp-cli/extension-command/src/Plugin_Command.php(700): WP_CLI\CommandWithUpgrade->update_many(Array, Array)
#8 [internal function]: Plugin_Command->update(Array, Array)
#9 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php(100): call_user_func(Array, Array, Array)
#10 [internal function]: WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}(Array, Array)
#11 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php(497): call_user_func(Object(Closure), Array, Array)
#12 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(441): WP_CLI\Dispatcher\Subcommand->invoke(Array, Array, Array)
#13 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(464): WP_CLI\Runner->run_command(Array, Array)
#14 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1295): WP_CLI\Runner->run_command_and_exit()
#15 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php(28): WP_CLI\Runner->start()
#16 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/bootstrap.php(83): WP_CLI\Bootstrap\LaunchRunner->process(Object(WP_CLI\Bootstrap\BootstrapState))
#17 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/wp-cli.php(32): WP_CLI\bootstrap()
#18 phar:///usr/local/bin/wp/php/boot-phar.php(20): include('phar:///usr/loc...')
#19 /usr/local/bin/wp(4): include('phar:///usr/loc...')
#20 {main}
  thrown in /wp-content/plugins/kadence-blocks/vendor/vendor-prefixed/stellarwp/uplink/src/Uplink/Admin/Package_Handler.php on line 33
  ```