### PR TITLE
Bugfix: Creation of dynamic property warning in PHP 8.2

### DIFF
--- a/src/Uplink/Admin/Package_Handler.php
+++ b/src/Uplink/Admin/Package_Handler.php
@@ -17,7 +17,7 @@ class Package_Handler {
 	public $upgrader;
 
 	/**
-	 * @var WP_Filesystem_Base
+	 * @var WP_Filesystem_Base|null
 	 */
 	public $filesystem;
 

--- a/src/Uplink/Admin/Package_Handler.php
+++ b/src/Uplink/Admin/Package_Handler.php
@@ -7,6 +7,7 @@ use StellarWP\Uplink\Config;
 use StellarWP\Uplink\Resources;
 use WP_Error;
 use WP_Upgrader;
+use WP_Filesystem_Base;
 
 class Package_Handler {
 

--- a/src/Uplink/Admin/Package_Handler.php
+++ b/src/Uplink/Admin/Package_Handler.php
@@ -16,6 +16,11 @@ class Package_Handler {
 	public $upgrader;
 
 	/**
+	 * @var WP_Filesystem_Base
+	 */
+	public $filesystem;
+
+	/**
 	 * Filters the package download step to store the downloaded file with a shorter file name.
 	 *
 	 * @param  bool|WP_Error  $reply        Whether to bail without returning the package.


### PR DESCRIPTION
A customer reported that they received this warning in Rollbar. This PR aims to fix this problem. 


```
E_DEPRECATED: Creation of dynamic property Iconic_PC_NS\StellarWP\Uplink\Admin\Package_Handler::$filesystem is deprecated
(/var/www/[ultimatehackingkeyboard.com/wordpress/wp-content/plugins/iconic-woo-product-configurator-premium/vendor-prefixed/stellarwp/uplink/src/Uplink/Admin/Package_Handler.php:175](http://ultimatehackingkeyboard.com/wordpress/wp-content/plugins/iconic-woo-product-configurator-premium/vendor-prefixed/stellarwp/uplink/src/Uplink/Admin/Package_Handler.php:175))
```