### PR TITLE
Fix/multiple tokens issues

### DIFF
--- a/src/Uplink/Auth/Provider.php
+++ b/src/Uplink/Auth/Provider.php
@@ -65,8 +65,8 @@ final class Provider extends Abstract_Provider {
 		// Register a unique action for each resource slug.
 		add_action( 'admin_init', [ $action_manager, 'add_actions' ] );
 
-		// Execute the above actions when an uplink_slug query variable and the current_screen hook is fired (which is run after admin_init).
-		add_action( 'current_screen', [ $action_manager, 'do_action' ], 10, 0 );
+		// Execute the above actions when an uplink_slug query variable.
+		add_action( 'admin_init', [ $action_manager, 'do_action' ] );
 	}
 
 }

--- a/src/Uplink/Auth/Provider.php
+++ b/src/Uplink/Auth/Provider.php
@@ -66,7 +66,7 @@ final class Provider extends Abstract_Provider {
 		add_action( 'admin_init', [ $action_manager, 'add_actions' ] );
 
 		// Execute the above actions when an uplink_slug query variable.
-		add_action( 'admin_init', [ $action_manager, 'do_action' ] );
+		add_action( 'admin_init', [ $action_manager, 'do_action' ], 15 );
 	}
 
 }

--- a/src/Uplink/Auth/Provider.php
+++ b/src/Uplink/Auth/Provider.php
@@ -63,10 +63,10 @@ final class Provider extends Abstract_Provider {
 		$action_manager = $this->container->get( Action_Manager::class );
 
 		// Register a unique action for each resource slug.
-		add_action( 'admin_init', [ $action_manager, 'add_actions' ] );
+		add_action( 'admin_init', [ $action_manager, 'add_actions' ], 1 );
 
 		// Execute the above actions when an uplink_slug query variable.
-		add_action( 'admin_init', [ $action_manager, 'do_action' ], 15 );
+		add_action( 'admin_init', [ $action_manager, 'do_action' ], 9 );
 	}
 
 }

--- a/src/Uplink/Components/Admin/Authorize_Button_Controller.php
+++ b/src/Uplink/Components/Admin/Authorize_Button_Controller.php
@@ -40,6 +40,11 @@ final class Authorize_Button_Controller extends Controller {
 	private $resources;
 
 	/**
+	 * @var Disconnect_Controller
+	 */
+	private $disconnect_controller;
+
+	/**
 	 * @param  View  $view  The View Engine to render views.
 	 * @param  Authorizer  $authorizer  Determines if the current user can perform actions.
 	 * @param  Token_Manager  $token_manager  The Token Manager.
@@ -50,14 +55,16 @@ final class Authorize_Button_Controller extends Controller {
 		Authorizer $authorizer,
 		Token_Manager $token_manager,
 		Auth_Url_Builder $url_builder,
-		Collection $resources
+		Collection $resources,
+		Disconnect_Controller $disconnect_controller,
 	) {
 		parent::__construct( $view );
 
-		$this->authorizer    = $authorizer;
-		$this->token_manager = $token_manager;
-		$this->url_builder   = $url_builder;
-		$this->resources     = $resources;
+		$this->authorizer            = $authorizer;
+		$this->token_manager         = $token_manager;
+		$this->url_builder           = $url_builder;
+		$this->resources             = $resources;
+		$this->disconnect_controller = $disconnect_controller;
 	}
 
 	/**
@@ -108,7 +115,7 @@ final class Authorize_Button_Controller extends Controller {
 			$authenticated = true;
 			$target        = '_self';
 			$link_text     = __( 'Disconnect', '%TEXTDOMAIN%' );
-			$url           = wp_nonce_url( add_query_arg( [ Disconnect_Controller::ARG => true, Disconnect_Controller::SLUG => $slug ], get_admin_url( get_current_blog_id() ) ), Disconnect_Controller::ARG );
+			$url           = $this->disconnect_controller->get_url( $plugin );
 			$classes[2]    = 'authorized';
 		}
 

--- a/src/Uplink/Resources/License.php
+++ b/src/Uplink/Resources/License.php
@@ -156,6 +156,7 @@ class License {
 		 * @since 1.0.0
 		 *
 		 * @param string|null $key The license key.
+		 * @param Resource $resource The resource instance.
 		 */
 		$key = apply_filters( 'stellarwp/uplink/' . Config::get_hook_prefix(). '/license_get_key', $this->key, $this->resource );
 		$key = apply_filters( 'stellarwp/uplink/' . Config::get_hook_prefix(). '/' . $this->resource->get_slug() . '/license_get_key', $key, $this->resource );

--- a/src/Uplink/Resources/License.php
+++ b/src/Uplink/Resources/License.php
@@ -157,7 +157,8 @@ class License {
 		 *
 		 * @param string|null $key The license key.
 		 */
-		$key = apply_filters( 'stellarwp/uplink/' . Config::get_hook_prefix(). '/license_get_key', $this->key );
+		$key = apply_filters( 'stellarwp/uplink/' . Config::get_hook_prefix(). '/license_get_key', $this->key, $this->resource );
+		$key = apply_filters( 'stellarwp/uplink/' . Config::get_hook_prefix(). '/' . $this->resource->get_slug() . '/license_get_key', $key, $this->resource );
 
 		return $key ?: '';
 	}

--- a/tests/wpunit/Auth/ActionManagerTest.php
+++ b/tests/wpunit/Auth/ActionManagerTest.php
@@ -83,8 +83,8 @@ final class ActionManagerTest extends UplinkTestCase {
 
 			$_REQUEST[ Disconnect_Controller::SLUG ] = $resource->get_slug();
 
-			// Fire off current_screen, which runs our actions, normally this would run once, but we want to test them all.
-			do_action( 'current_screen', null );
+			// Fire off admin_init again, which runs our actions, normally this would run once, but we want to test them all.
+			do_action( 'admin_init' );
 
 			$this->assertSame( 1, did_action( $this->action_manager->get_hook_name( $resource->get_slug() ) ) );
 		}


### PR DESCRIPTION
Fixes:

- Provides disconnect URL through the Disconnect_Controller so that the cahce key is also present.
- The token value was being retrieved prior the request was processed. So after a successful connection the button would remain `Connect` instead of `Disconnect` and vice versa.

Introduces:

a Filter to make migrating from an old license system to Uplink easier