### PR TITLE
Storage System to replace Transients

### DIFF
--- a/src/Uplink/API/V3/Provider.php
+++ b/src/Uplink/API/V3/Provider.php
@@ -9,6 +9,7 @@ use StellarWP\Uplink\API\V3\Auth\Token_Authorizer_Cache_Decorator;
 use StellarWP\Uplink\API\V3\Contracts\Client_V3;
 use StellarWP\Uplink\Config;
 use StellarWP\Uplink\Contracts\Abstract_Provider;
+use StellarWP\Uplink\Storage\Contracts\Storage;
 use WP_Http;
 
 final class Provider extends Abstract_Provider {
@@ -74,6 +75,7 @@ final class Provider extends Abstract_Provider {
 				static function ( $c ) use ( $expiration ): Token_Authorizer {
 					return new Token_Authorizer_Cache_Decorator(
 						$c->get( Auth\Token_Authorizer::class ),
+						$c->get( Storage::class ),
 						$expiration
 					);
 				}

--- a/src/Uplink/Auth/Admin/Connect_Controller.php
+++ b/src/Uplink/Auth/Admin/Connect_Controller.php
@@ -6,9 +6,11 @@ use StellarWP\Uplink\Auth\Authorizer;
 use StellarWP\Uplink\Auth\Nonce;
 use StellarWP\Uplink\Auth\Token\Connector;
 use StellarWP\Uplink\Auth\Token\Exceptions\InvalidTokenException;
+use StellarWP\Uplink\Config;
 use StellarWP\Uplink\Notice\Notice_Handler;
 use StellarWP\Uplink\Notice\Notice;
 use StellarWP\Uplink\Resources\Collection;
+use StellarWP\Uplink\Storage\Drivers\Transient_Storage;
 
 /**
  * Handles storing token data after successfully redirecting
@@ -99,7 +101,7 @@ final class Connect_Controller {
 			}
 
 			// The Litespeed plugin allows completely disabling transients for some reason...
-			if ( is_plugin_active( 'litespeed-cache/litespeed-cache.php' ) ) {
+			if ( Config::get_storage_driver() === Transient_Storage::class && is_plugin_active( 'litespeed-cache/litespeed-cache.php' ) ) {
 				$this->notice->add( new Notice( Notice::ERROR,
 					sprintf(
 						__( 'The Litespeed plugin was detected, ensure "Store Transients" is set to ON and try again. See the <a href="%s" target="_blank">Litespeed documentation</a> for more information.', '%TEXTDOMAIN%' ),

--- a/src/Uplink/Auth/Admin/Connect_Controller.php
+++ b/src/Uplink/Auth/Admin/Connect_Controller.php
@@ -41,17 +41,23 @@ final class Connect_Controller {
 	 */
 	private $authorizer;
 
+	/**
+	 * @var Nonce
+	 */
+	private $nonce;
 
 	public function __construct(
 		Connector $connector,
 		Notice_Handler $notice,
 		Collection $collection,
-		Authorizer $authorizer
+		Authorizer $authorizer,
+		Nonce $nonce
 	) {
 		$this->connector  = $connector;
 		$this->notice     = $notice;
 		$this->collection = $collection;
 		$this->authorizer = $authorizer;
+		$this->nonce      = $nonce;
 	}
 
 	/**
@@ -87,7 +93,7 @@ final class Connect_Controller {
 		}
 
 
-		if ( ! Nonce::verify( $args[ self::NONCE ] ?? '' ) ) {
+		if ( ! $this->nonce->verify( $args[ self::NONCE ] ?? '' ) ) {
 			if ( ! function_exists( 'is_plugin_active' ) ) {
 				require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 			}

--- a/src/Uplink/Auth/Nonce.php
+++ b/src/Uplink/Auth/Nonce.php
@@ -44,7 +44,7 @@ final class Nonce {
 			return false;
 		}
 
-		return $nonce === $this->storage->get( ( Config::get_hook_prefix_underscored() . self::NONCE_SUFFIX ) );
+		return $nonce === $this->storage->get( Config::get_hook_prefix_underscored() . self::NONCE_SUFFIX );
 	}
 
 	/**

--- a/src/Uplink/Auth/Provider.php
+++ b/src/Uplink/Auth/Provider.php
@@ -7,6 +7,7 @@ use StellarWP\Uplink\Auth\Admin\Connect_Controller;
 use StellarWP\Uplink\Auth\Token\Contracts\Token_Manager;
 use StellarWP\Uplink\Config;
 use StellarWP\Uplink\Contracts\Abstract_Provider;
+use StellarWP\Uplink\Storage\Contracts\Storage;
 
 final class Provider extends Abstract_Provider {
 
@@ -47,7 +48,9 @@ final class Provider extends Abstract_Provider {
 		$expiration = apply_filters( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/auth/nonce_expiration', 2100 );
 		$expiration = absint( $expiration );
 
-		$this->container->singleton( Nonce::class, new Nonce( $expiration ) );
+		$this->container->singleton( Nonce::class, static function( $c ) use ( $expiration ) {
+			return new Nonce( $c->get( Storage::class ), $expiration );
+		} );
 	}
 
 	/**

--- a/src/Uplink/Auth/Token/Disconnector.php
+++ b/src/Uplink/Auth/Token/Disconnector.php
@@ -5,6 +5,7 @@ namespace StellarWP\Uplink\Auth\Token;
 use StellarWP\Uplink\API\V3\Auth\Token_Authorizer_Cache_Decorator;
 use StellarWP\Uplink\Auth\Token\Contracts\Token_Manager;
 use StellarWP\Uplink\Resources\Collection;
+use StellarWP\Uplink\Storage\Contracts\Storage;
 
 final class Disconnector {
 
@@ -19,14 +20,21 @@ final class Disconnector {
 	private $resources;
 
 	/**
+	 * @var Storage
+	 */
+	private $storage;
+
+	/**
 	 * @param  Token_Manager  $token_manager  The Token Manager.
 	 */
 	public function __construct(
 		Token_Manager $token_manager,
-		Collection $resources
+		Collection $resources,
+		Storage $storage
 	) {
 		$this->token_manager = $token_manager;
 		$this->resources     = $resources;
+		$this->storage       = $storage;
 	}
 
 	/**
@@ -48,7 +56,7 @@ final class Disconnector {
 
 		if ( $result ) {
 			// Delete the authorization cache.
-			delete_transient( Token_Authorizer_Cache_Decorator::TRANSIENT_PREFIX . $cache_key );
+			$this->storage->delete( Token_Authorizer_Cache_Decorator::TRANSIENT_PREFIX . $cache_key );
 		}
 
 		return $result;

--- a/src/Uplink/Config.php
+++ b/src/Uplink/Config.php
@@ -48,9 +48,9 @@ class Config {
 	/**
 	 * The storage driver FQCN to use.
 	 *
-	 * @var class-string<Storage>|null
+	 * @var class-string<Storage>
 	 */
-	protected static $storage_driver = null;
+	protected static $storage_driver = Option_Storage::class;
 
 	/**
 	 * Get the container.

--- a/src/Uplink/Config.php
+++ b/src/Uplink/Config.php
@@ -48,9 +48,9 @@ class Config {
 	/**
 	 * The storage driver FQCN to use.
 	 *
-	 * @var class-string<Storage>
+	 * @var class-string<Storage>|null
 	 */
-	protected static $storage_driver = '';
+	protected static $storage_driver = null;
 
 	/**
 	 * Get the container.

--- a/src/Uplink/Config.php
+++ b/src/Uplink/Config.php
@@ -6,6 +6,8 @@ use InvalidArgumentException;
 use RuntimeException;
 use StellarWP\ContainerContract\ContainerInterface;
 use StellarWP\Uplink\Auth\Token\Contracts\Token_Manager;
+use StellarWP\Uplink\Storage\Contracts\Storage;
+use StellarWP\Uplink\Storage\Drivers\Option_Storage;
 use StellarWP\Uplink\Utils\Sanitize;
 
 class Config {
@@ -42,6 +44,13 @@ class Config {
 	 * @var int
 	 */
 	protected static $auth_cache_expiration = self::DEFAULT_AUTH_CACHE;
+
+	/**
+	 * The storage driver FQCN to use.
+	 *
+	 * @var class-string<Storage>
+	 */
+	protected static $storage_driver = '';
 
 	/**
 	 * Get the container.
@@ -206,6 +215,28 @@ class Config {
 	 */
 	public static function get_auth_cache_expiration(): int {
 		return static::$auth_cache_expiration;
+	}
+
+	/**
+	 * Set the underlying storage driver.
+	 *
+	 * @param  class-string<Storage>  $class_name The FQCN to a storage driver.
+	 *
+	 * @return void
+	 */
+	public static function set_storage_driver( string $class_name ): void {
+		static::$storage_driver = $class_name;
+	}
+
+	/**
+	 * Get the underlying storage driver.
+	 *
+	 * @return class-string<Storage>
+	 */
+	public static function get_storage_driver(): string {
+		$driver = static::$storage_driver;
+
+		return $driver ?: Option_Storage::class;
 	}
 
 }

--- a/src/Uplink/Notice/Notice_Handler.php
+++ b/src/Uplink/Notice/Notice_Handler.php
@@ -2,6 +2,8 @@
 
 namespace StellarWP\Uplink\Notice;
 
+use StellarWP\Uplink\Storage\Contracts\Storage;
+
 /**
  * An improved admin notice system for general messages.
  *
@@ -9,7 +11,7 @@ namespace StellarWP\Uplink\Notice;
  */
 final class Notice_Handler {
 
-	public const TRANSIENT = 'stellarwp_uplink_notices';
+	public const STORAGE_KEY = 'stellarwp_uplink_notices';
 
 	/**
 	 * Handles rendering notices.
@@ -19,13 +21,22 @@ final class Notice_Handler {
 	private $controller;
 
 	/**
+	 * @var Storage
+	 */
+	private $storage;
+
+	/**
 	 * @var Notice[]
 	 */
 	private $notices;
 
-	public function __construct( Notice_Controller $controller ) {
-		$this->notices    = $this->all();
+	public function __construct(
+		Notice_Controller $controller,
+		Storage $storage
+	) {
 		$this->controller = $controller;
+		$this->storage    = $storage;
+		$this->notices    = $this->all();
 	}
 
 	/**
@@ -65,7 +76,7 @@ final class Notice_Handler {
 	 * @return Notice[]
 	 */
 	private function all(): array {
-		return array_filter( (array) get_transient( self::TRANSIENT ) );
+		return array_filter( (array) $this->storage->get( self::STORAGE_KEY ) );
 	}
 
 	/**
@@ -74,7 +85,7 @@ final class Notice_Handler {
 	 * @return bool
 	 */
 	private function save(): bool {
-		return (bool) set_transient( self::TRANSIENT, $this->notices, 300 );
+		return $this->storage->set( self::STORAGE_KEY, $this->notices, 300 );
 	}
 
 	/**
@@ -83,7 +94,7 @@ final class Notice_Handler {
 	 * @return bool
 	 */
 	private function clear(): bool {
-		return (bool) delete_transient( self::TRANSIENT );
+		return $this->storage->delete( self::STORAGE_KEY );
 	}
 
 }

--- a/src/Uplink/Notice/Provider.php
+++ b/src/Uplink/Notice/Provider.php
@@ -3,6 +3,7 @@
 namespace StellarWP\Uplink\Notice;
 
 use StellarWP\Uplink\Contracts\Abstract_Provider;
+use StellarWP\Uplink\Storage\Contracts\Storage;
 
 final class Provider extends Abstract_Provider {
 
@@ -12,7 +13,7 @@ final class Provider extends Abstract_Provider {
 	public function register(): void {
 		$this->container->singleton( Notice_Controller::class, Notice_Controller::class );
 		$this->container->singleton( Notice_Handler::class, static function ( $c ): Notice_Handler {
-			return new Notice_Handler( $c->get( Notice_Controller::class ) );
+			return new Notice_Handler( $c->get( Notice_Controller::class ), $c->get( Storage::class ) );
 		} );
 
 		add_action( 'admin_notices', [ $this->container->get( Notice_Handler::class ), 'display' ], 12, 0 );

--- a/src/Uplink/Storage/Contracts/Storage.php
+++ b/src/Uplink/Storage/Contracts/Storage.php
@@ -1,0 +1,63 @@
+<?php declare( strict_types=1 );
+
+namespace StellarWP\Uplink\Storage\Contracts;
+
+use Closure;
+use StellarWP\Uplink\Storage\Exceptions\Invalid_Key_Exception;
+
+interface Storage {
+
+	/**
+	 * Put a value in storage.
+	 *
+	 * @param string|int|float|mixed[]|object $key The storage key. Accepts any variable that can be json encoded.
+	 * @param mixed                           $value The value to store.
+	 * @param int                             $expire The storage lifespan in seconds.
+	 *
+	 * @throws Invalid_Key_Exception If passed an invalid storage key.
+	 */
+	public function set( $key, $value, int $expire = 0 ): bool;
+
+	/**
+	 * Get a value from storage.
+	 *
+	 * @param string|int|float|mixed[]|object $key The storage key. Accepts any variable that can be json encoded.
+	 *
+	 * @throws Invalid_Key_Exception If passed an invalid storage key.
+	 *
+	 * @return null|mixed Returns null if we can't find the storage value.
+	 */
+	public function get( $key );
+
+	/**
+	 * Delete a value from storage.
+	 *
+	 * @param string|int|float|mixed[]|object $key The storage key.
+	 *
+	 * @throws Invalid_Key_Exception If passed an invalid storage key.
+	 */
+	public function delete( $key ): bool;
+
+	/**
+	 * Get an item from storage, or execute the given Closure and store the result.
+	 *
+	 * @param string|int|float|mixed[]|object $key      The storage key.
+	 * @param Closure                         $callback The callback used to generate and store the value.
+	 * @param int                             $expire   The storage lifespan in seconds.
+	 *
+	 * @throws Invalid_Key_Exception If passed an invalid storage key.
+	 *
+	 * @return mixed The storage value.
+	 */
+	public function remember( $key, Closure $callback, int $expire = 0 );
+
+	/**
+	 * Retrieve an item from storage and delete it.
+	 *
+	 * @param string|int|float|mixed[]|object $key The storage key.
+	 *
+	 * @throws Invalid_Key_Exception If passed an invalid storage key.
+	 */
+	public function pull( $key );
+
+}

--- a/src/Uplink/Storage/Drivers/Option_Storage.php
+++ b/src/Uplink/Storage/Drivers/Option_Storage.php
@@ -1,0 +1,135 @@
+<?php declare( strict_types=1 );
+
+namespace StellarWP\Uplink\Storage\Drivers;
+
+use Closure;
+use InvalidArgumentException;
+use StellarWP\Uplink\Storage\Contracts\Storage;
+use StellarWP\Uplink\Storage\Exceptions\Invalid_Key_Exception;
+use StellarWP\Uplink\Storage\Traits\With_Key_Formatter;
+
+class Option_Storage implements Storage {
+
+	use With_Key_Formatter;
+
+	/**
+	 * The option name to store in the wp_options table.
+	 *
+	 * @see Config::set_hook_prefix()
+	 *
+	 * @var string
+	 */
+	protected $option_name;
+
+	/**
+	 * @param  string  $option_name  The option name as set via Config::set_token_auth_prefix().
+	 */
+	public function __construct( string $option_name ) {
+		if ( ! $option_name ) {
+			throw new InvalidArgumentException(
+				__( 'You must set a token prefix with StellarWP\Uplink\Config::set_hook_prefix() before using Option Storage.',
+					'%TEXTDOMAIN%' )
+			);
+		}
+
+		$this->option_name = $option_name;
+	}
+
+	/**
+	 * Put a value in storage.
+	 *
+	 * @param  string|int|float|mixed[]|object  $key     The storage key. Accepts any variable that can be json encoded.
+	 * @param  mixed                            $value   The value to store.
+	 * @param  int                              $expire  The storage lifespan in seconds.
+	 *
+	 * @throws Invalid_Key_Exception If passed an invalid storage key.
+	 */
+	public function set( $key, $value, int $expire = 0 ): bool {
+		$data = (array) get_option( $this->option_name, [] );
+
+		$data[ $this->key( $key ) ] = [
+			'value'      => $value,
+			'expiration' => $expire > 0 ? time() + $expire : 0,
+		];
+
+		return update_option( $this->option_name, $data );
+	}
+
+	/**
+	 * Get a value from storage.
+	 *
+	 * @param  string|int|float|mixed[]|object  $key  The storage key. Accepts any variable that can be json encoded.
+	 *
+	 * @throws Invalid_Key_Exception If passed an invalid storage key.
+	 *
+	 * @return null|mixed Returns null if we can't find the storage value.
+	 */
+	public function get( $key ) {
+		$data      = (array) get_option( $this->option_name, [] );
+		$transient = $data[ $this->key( $key ) ] ?? [];
+
+		if ( isset( $transient['expiration'] ) && $transient['expiration'] > 0 && $transient['expiration'] < time() ) {
+			$this->delete( $key );
+
+			return null;
+		}
+
+		return $transient['value'] ?? null;
+	}
+
+	/**
+	 * Delete a value from storage.
+	 *
+	 * @param  string|int|float|mixed[]|object  $key  The storage key.
+	 *
+	 * @throws Invalid_Key_Exception If passed an invalid storage key.
+	 */
+	public function delete( $key ): bool {
+		$data = (array) get_option( $this->option_name, [] );
+
+		unset( $data[ $this->key( $key ) ] );
+
+		return update_option( $this->option_name, $data );
+	}
+
+	/**
+	 * Get an item from storage, or execute the given Closure and store the result.
+	 *
+	 * @param  string|int|float|mixed[]|object  $key       The storage key.
+	 * @param  Closure                          $callback  The callback used to generate and store the value.
+	 * @param  int                              $expire    The storage lifespan in seconds.
+	 *
+	 * @throws Invalid_Key_Exception If passed an invalid storage key.
+	 *
+	 * @return mixed The storage value.
+	 */
+	public function remember( $key, Closure $callback, int $expire = 0 ) {
+		$value = $this->get( $key );
+
+		if ( ! is_null( $value ) ) {
+			return $value;
+		}
+
+		$value = $callback();
+
+		$this->set( $key, $value, $expire );
+
+		return $value;
+	}
+
+	/**
+	 * Retrieve an item from storage and delete it.
+	 *
+	 * @param  string|int|float|mixed[]|object  $key  The storage key.
+	 *
+	 * @throws Invalid_Key_Exception If passed an invalid storage key.
+	 */
+	public function pull( $key ) {
+		$value = $this->get( $key );
+
+		$this->delete( $key );
+
+		return $value;
+	}
+
+}

--- a/src/Uplink/Storage/Drivers/Transient_Storage.php
+++ b/src/Uplink/Storage/Drivers/Transient_Storage.php
@@ -1,0 +1,93 @@
+<?php declare( strict_types=1 );
+
+namespace StellarWP\Uplink\Storage\Drivers;
+
+use Closure;
+use StellarWP\Uplink\Storage\Contracts\Storage;
+use StellarWP\Uplink\Storage\Exceptions\Invalid_Key_Exception;
+use StellarWP\Uplink\Storage\Traits\With_Key_Formatter;
+
+class Transient_Storage implements Storage {
+
+	use With_Key_Formatter;
+
+	/**
+	 * Put a value in storage.
+	 *
+	 * @param string|int|float|mixed[]|object $key The storage key. Accepts any variable that can be json encoded.
+	 * @param mixed                           $value The value to store.
+	 * @param int                             $expire The storage lifespan in seconds.
+	 *
+	 * @throws Invalid_Key_Exception If passed an invalid storage key.
+	 */
+	public function set( $key, $value, int $expire = 0 ): bool {
+		return (bool) set_transient( $this->key( $key ), $value, $expire );
+	}
+
+	/**
+	 * Get a value from storage.
+	 *
+	 * @param string|int|float|mixed[]|object $key The storage key. Accepts any variable that can be json encoded.
+	 *
+	 * @throws Invalid_Key_Exception If passed an invalid storage key.
+	 *
+	 * @return null|mixed Returns null if we can't find the storage value.
+	 */
+	public function get( $key ) {
+		$value = get_transient( $this->key( $key ) );
+
+		return $value !== false ? $value : null;
+	}
+
+	/**
+	 * Delete a value from storage.
+	 *
+	 * @param string|int|float|mixed[]|object $key The storage key.
+	 *
+	 * @throws Invalid_Key_Exception If passed an invalid storage key.
+	 */
+	public function delete( $key ): bool {
+		return (bool) delete_transient( $this->key( $key ) );
+	}
+
+	/**
+	 * Get an item from storage, or execute the given Closure and store the result.
+	 *
+	 * @param string|int|float|mixed[]|object $key      The storage key.
+	 * @param Closure                         $callback The callback used to generate and store the value.
+	 * @param int                             $expire   The storage lifespan in seconds.
+	 *
+	 * @throws Invalid_Key_Exception If passed an invalid storage key.
+	 *
+	 * @return mixed The storage value.
+	 */
+	public function remember( $key, Closure $callback, int $expire = 0 ) {
+		$value = $this->get( $key );
+
+		if ( ! is_null( $value ) ) {
+			return $value;
+		}
+
+		$value = $callback();
+
+		$this->set( $key, $value, $expire );
+
+		return $value;
+	}
+
+	/**
+	 * Retrieve an item from storage and delete it.
+	 *
+	 * @param string|int|float|mixed[]|object $key The storage key.
+	 *
+	 * @throws Invalid_Key_Exception If passed an invalid storage key.
+	 */
+	public function pull( $key ) {
+		$value = $this->get( $key );
+
+		$this->delete( $key );
+
+		return $value;
+	}
+
+}

--- a/src/Uplink/Storage/Exceptions/Invalid_Key_Exception.php
+++ b/src/Uplink/Storage/Exceptions/Invalid_Key_Exception.php
@@ -1,0 +1,12 @@
+<?php declare( strict_types=1 );
+
+namespace StellarWP\Uplink\Storage\Exceptions;
+
+use InvalidArgumentException;
+
+/**
+ * Thrown when a Storage object is passed an invalid key.
+ */
+final class Invalid_Key_Exception extends InvalidArgumentException {
+
+}

--- a/src/Uplink/Storage/Provider.php
+++ b/src/Uplink/Storage/Provider.php
@@ -1,0 +1,28 @@
+<?php declare( strict_types=1 );
+
+namespace StellarWP\Uplink\Storage;
+
+use StellarWP\Uplink\Config;
+use StellarWP\Uplink\Contracts\Abstract_Provider;
+use StellarWP\Uplink\Storage\Contracts\Storage;
+use StellarWP\Uplink\Storage\Drivers\Option_Storage;
+
+final class Provider extends Abstract_Provider {
+
+	/**
+	 * @inheritDoc
+	 */
+	public function register() {
+		$this->container->singleton( Option_Storage::class, function () {
+			$option_name = Config::get_hook_prefix() . '_storage';
+
+			return new Option_Storage( $option_name );
+		} );
+
+		// TODO: allow developers to configure this.
+		$this->container->singleton( Storage::class, static function( $c ): Storage {
+			return $c->get( Option_Storage::class );
+		} );
+	}
+
+}

--- a/src/Uplink/Storage/Provider.php
+++ b/src/Uplink/Storage/Provider.php
@@ -19,9 +19,8 @@ final class Provider extends Abstract_Provider {
 			return new Option_Storage( $option_name );
 		} );
 
-		// TODO: allow developers to configure this.
 		$this->container->singleton( Storage::class, static function( $c ): Storage {
-			return $c->get( Option_Storage::class );
+			return $c->get( Config::get_storage_driver() );
 		} );
 	}
 

--- a/src/Uplink/Storage/Traits/With_Key_Formatter.php
+++ b/src/Uplink/Storage/Traits/With_Key_Formatter.php
@@ -1,0 +1,28 @@
+<?php declare( strict_types=1 );
+
+namespace StellarWP\Uplink\Storage\Traits;
+
+use StellarWP\Uplink\Storage\Contracts\Storage;
+use StellarWP\Uplink\Storage\Exceptions\Invalid_Key_Exception;
+
+/**
+ * @mixin Storage
+ */
+trait With_Key_Formatter {
+
+	/**
+	 * Converts a storage key into a string.
+	 *
+	 * @param string|int|float|mixed[]|object $key The cache key. Accepts any variable that can be json encoded.
+	 *
+	 * @throws Invalid_Key_Exception
+	 */
+	private function key( $key ): string {
+		if ( ! $key ) {
+			throw new Invalid_Key_Exception( 'The cache key cannot be empty' );
+		}
+
+		return is_scalar( $key ) ? (string) $key : md5( (string) wp_json_encode( $key ) );
+	}
+
+}

--- a/src/Uplink/Uplink.php
+++ b/src/Uplink/Uplink.php
@@ -29,6 +29,7 @@ class Uplink {
 		$container->singleton( self::UPLINK_ADMIN_VIEWS_PATH, dirname( __DIR__ ) . '/admin-views' );
 		$container->singleton( self::UPLINK_ASSETS_URI, dirname( plugin_dir_url( __FILE__ ) ) . '/assets' );
 		$container->bind( ContainerInterface::class, $container );
+		$container->singleton( Storage\Provider::class, Storage\Provider::class );
 		$container->singleton( View\Provider::class, View\Provider::class );
 		$container->singleton( API\Client::class, API\Client::class );
 		$container->singleton( API\V3\Provider::class, API\V3\Provider::class );
@@ -39,6 +40,7 @@ class Uplink {
 		$container->singleton( Auth\Provider::class, Auth\Provider::class );
 
 		if ( static::is_enabled() ) {
+			$container->get( Storage\Provider::class )->register();
 			$container->get( View\Provider::class )->register();
 			$container->get( API\V3\Provider::class )->register();
 			$container->get( Notice\Provider::class )->register();

--- a/tests/wpunit/API/V3/AuthUrlTest.php
+++ b/tests/wpunit/API/V3/AuthUrlTest.php
@@ -6,9 +6,21 @@ use StellarWP\Uplink\API\V3\Auth\Auth_Url;
 use StellarWP\Uplink\API\V3\Auth\Auth_Url_Cache_Decorator;
 use StellarWP\Uplink\API\V3\Contracts\Client_V3;
 use StellarWP\Uplink\Auth\Auth_Url_Builder;
+use StellarWP\Uplink\Storage\Contracts\Storage;
 use StellarWP\Uplink\Tests\UplinkTestCase;
 
 final class AuthUrlTest extends UplinkTestCase {
+
+	/**
+	 * @var Storage
+	 */
+	private $storage;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->storage = $this->container->get( Storage::class );
+	}
 
 	public function test_the_cache_decorator_is_enabled(): void {
 		$auth_url = $this->container->get( \StellarWP\Uplink\API\V3\Auth\Contracts\Auth_Url::class );
@@ -97,7 +109,7 @@ final class AuthUrlTest extends UplinkTestCase {
 		$auth_url = $this->container->get( Auth_Url_Cache_Decorator::class )->get( 'kadence-blocks-pro' );
 
 		$this->assertSame( 'https://www.kadencewp.com/account-auth/', $auth_url );
-		$this->assertSame( 'https://www.kadencewp.com/account-auth/', get_transient( Auth_Url_Cache_Decorator::TRANSIENT_PREFIX . 'kadence_blocks_pro' ) );
+		$this->assertSame( 'https://www.kadencewp.com/account-auth/', $this->storage->get( Auth_Url_Cache_Decorator::TRANSIENT_PREFIX . 'kadence_blocks_pro' ) );
 	}
 
 	public function test_it_caches_an_empty_auth_url(): void {
@@ -117,7 +129,7 @@ final class AuthUrlTest extends UplinkTestCase {
 		$auth_url = $this->container->get( Auth_Url_Cache_Decorator::class )->get( 'kadence-blocks-pro' );
 
 		$this->assertSame( '', $auth_url );
-		$this->assertSame( '', get_transient( Auth_Url_Cache_Decorator::TRANSIENT_PREFIX . 'kadence_blocks_pro' ) );
+		$this->assertSame( '', $this->storage->get( Auth_Url_Cache_Decorator::TRANSIENT_PREFIX . 'kadence_blocks_pro' ) );
 	}
 
 }

--- a/tests/wpunit/API/V3/AuthorizerCacheTest.php
+++ b/tests/wpunit/API/V3/AuthorizerCacheTest.php
@@ -4,9 +4,21 @@ namespace StellarWP\Uplink\Tests\API\V3;
 
 use StellarWP\Uplink\API\V3\Auth\Contracts\Token_Authorizer;
 use StellarWP\Uplink\API\V3\Auth\Token_Authorizer_Cache_Decorator;
+use StellarWP\Uplink\Storage\Contracts\Storage;
 use StellarWP\Uplink\Tests\UplinkTestCase;
 
 final class AuthorizerCacheTest extends UplinkTestCase {
+
+	/**
+	 * @var Storage
+	 */
+	private $storage;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->storage = $this->container->get( Storage::class );
+	}
 
 	public function test_it_binds_the_correct_instance_when_auth_cache_is_enabled(): void {
 		$this->assertInstanceOf(
@@ -28,14 +40,14 @@ final class AuthorizerCacheTest extends UplinkTestCase {
 		$transient = $decorator->build_transient( [ '1234', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' ] );
 
 		// No cache should exist.
-		$this->assertFalse( get_transient( $transient ) );
+		$this->assertNull( $this->storage->get( $transient ) );
 
 		$authorized = $decorator->is_authorized( '1234', 'kadence-blocks-pro','dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' );
 
 		$this->assertTrue( $authorized );
 
 		// Cache should now be present.
-		$this->assertTrue( get_transient( $transient ) );
+		$this->assertTrue( $this->storage->get( $transient ) );
 		$this->assertTrue( $decorator->is_authorized( '1234', 'kadence-blocks-pro','dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' ) );
 	}
 
@@ -52,14 +64,14 @@ final class AuthorizerCacheTest extends UplinkTestCase {
 		$transient = $decorator->build_transient( [ '1234', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' ] );
 
 		// No cache should exist.
-		$this->assertFalse( get_transient( $transient ) );
+		$this->assertNull( $this->storage->get( $transient ) );
 
 		$authorized = $decorator->is_authorized( '1234', 'kadence-blocks-pro','dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' );
 
 		$this->assertFalse( $authorized );
 
 		// Cache should still be empty, unfortunately the default is "false" for transients, so this isn't the best test.
-		$this->assertFalse( get_transient( $transient ) );
+		$this->assertNull( $this->storage->get( $transient ) );
 	}
 
 }

--- a/tests/wpunit/Auth/NonceTest.php
+++ b/tests/wpunit/Auth/NonceTest.php
@@ -26,8 +26,8 @@ final class NonceTest extends UplinkTestCase {
 
 		$this->assertNotEmpty( $nonce );
 		$this->assertSame( 16, strlen( $nonce ) );
-		$this->assertFalse( Nonce::verify( '') );
-		$this->assertTrue( Nonce::verify( $nonce ) );
+		$this->assertFalse( $this->nonce->verify( '') );
+		$this->assertTrue( $this->nonce->verify( $nonce ) );
 	}
 
 	public function test_it_creates_a_nonce_url(): void {
@@ -47,8 +47,8 @@ final class NonceTest extends UplinkTestCase {
 
 		$this->assertNotEmpty( $nonce );
 		$this->assertSame( 16, strlen( $nonce ) );
-		$this->assertFalse( Nonce::verify( '') );
-		$this->assertTrue( Nonce::verify( $nonce ) );
+		$this->assertFalse( $this->nonce->verify( '') );
+		$this->assertTrue( $this->nonce->verify( $nonce ) );
 	}
 
 	public function test_it_creates_a_nonce_url_with_extra_query_arguments(): void {
@@ -69,8 +69,8 @@ final class NonceTest extends UplinkTestCase {
 
 		$this->assertNotEmpty( $nonce );
 		$this->assertSame( 16, strlen( $nonce ) );
-		$this->assertFalse( Nonce::verify( '' ) );
-		$this->assertTrue( Nonce::verify( $nonce ) );
+		$this->assertFalse( $this->nonce->verify( '' ) );
+		$this->assertTrue( $this->nonce->verify( $nonce ) );
 	}
 
 }

--- a/tests/wpunit/ConfigTest.php
+++ b/tests/wpunit/ConfigTest.php
@@ -5,6 +5,8 @@ namespace StellarWP\Uplink\Tests;
 use InvalidArgumentException;
 use StellarWP\Uplink\Auth\Token\Contracts\Token_Manager;
 use StellarWP\Uplink\Config;
+use StellarWP\Uplink\Storage\Drivers\Option_Storage;
+use StellarWP\Uplink\Storage\Drivers\Transient_Storage;
 
 final class ConfigTest extends UplinkTestCase {
 
@@ -60,6 +62,16 @@ final class ConfigTest extends UplinkTestCase {
 		Config::set_auth_cache_expiration( DAY_IN_SECONDS );
 
 		$this->assertSame( DAY_IN_SECONDS, Config::get_auth_cache_expiration() );
+	}
+
+	public function test_it_gets_default_storage_driver(): void {
+		$this->assertSame( Option_Storage::class, Config::get_storage_driver() );
+	}
+
+	public function test_it_gets_and_sets_storage_driver(): void {
+		Config::set_storage_driver( Transient_Storage::class );
+
+		$this->assertSame( Transient_Storage::class, Config::get_storage_driver() );
 	}
 
 }

--- a/tests/wpunit/Storage/Drivers/StorageDriverTest.php
+++ b/tests/wpunit/Storage/Drivers/StorageDriverTest.php
@@ -17,12 +17,6 @@ final class StorageDriverTest extends UplinkTestCase {
 	 */
 	private $expire = 10;
 
-	protected function setUp(): void {
-		parent::setUp();
-
-		wp_cache_delete( 'alloptions' );
-	}
-
 	protected function tearDown(): void {
 		parent::tearDown();
 

--- a/tests/wpunit/Storage/Drivers/StorageDriverTest.php
+++ b/tests/wpunit/Storage/Drivers/StorageDriverTest.php
@@ -1,0 +1,146 @@
+<?php declare( strict_types=1 );
+
+namespace StellarWP\Uplink\Tests\Storage\Drivers;
+
+use StellarWP\Uplink\Storage\Contracts\Storage;
+use StellarWP\Uplink\Storage\Drivers\Option_Storage;
+use StellarWP\Uplink\Storage\Drivers\Transient_Storage;
+use StellarWP\Uplink\Storage\Exceptions\Invalid_Key_Exception;
+use StellarWP\Uplink\Tests\UplinkTestCase;
+
+final class StorageDriverTest extends UplinkTestCase {
+
+	/**
+	 * Default expiration.
+	 *
+	 * @var int
+	 */
+	private $expire = 10;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		wp_cache_delete( 'alloptions' );
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+
+		delete_option( 'uplink_test_storage' );
+		delete_transient( 'uplink_test_key' );
+	}
+
+	/**
+	 * Data provider for storage classes.
+	 *
+	 * @return array<array<Storage>>
+	 */
+	public function storageProvider(): array {
+		$drivers = [
+			[ new Transient_Storage() ],
+			[ new Option_Storage( 'uplink_test_storage' ) ],
+		];
+
+		$test_cases = [];
+
+		foreach ( $drivers as $d ) {
+			foreach ( $d as $driver ) {
+				$description                  = sprintf( 'with %s', get_class( $driver ) );
+				$test_cases[ $description ][] = $driver;
+			}
+		}
+
+		return $test_cases;
+	}
+
+	/**
+	 * @dataProvider storageProvider
+	 */
+	public function test_it_sets_and_gets_values( Storage $storage ): void {
+		$key   = 'uplink_test_key';
+		$value = 'test';
+
+		$this->assertTrue( $storage->set( $key, $value, $this->expire ) );
+		$this->assertSame( $value, $storage->get( $key ) );
+	}
+
+	/**
+	 * @dataProvider storageProvider
+	 */
+	public function test_it_deletes_values( Storage $storage ): void {
+		$key   = 'uplink_test_key';
+		$value = 'test';
+
+		$this->assertTrue( $storage->set( $key, $value, $this->expire ) );
+		$this->assertSame( $value, $storage->get( $key ) );
+		$this->assertTrue( $storage->delete( $key ) );
+		$this->assertNull( $storage->get( $key ) );
+	}
+
+	/**
+	 * @dataProvider storageProvider
+	 */
+	public function test_it_remembers_values( Storage $storage ): void {
+		$key   = 'uplink_test_key';
+		$value = 'test';
+
+		$stored_value = $storage->remember( $key, function () use ( $value ) {
+			return $value;
+		}, $this->expire );
+
+		$this->assertSame( $value, $stored_value );
+		$this->assertSame( $value, $storage->get( $key ) );
+	}
+
+	/**
+	 * @dataProvider storageProvider
+	 */
+	public function test_it_pulls_value( Storage $storage ): void {
+		$key   = 'uplink_test_key';
+		$value = 'test';
+
+		$this->assertTrue( $storage->set( $key, $value, $this->expire ) );
+		$pulled_value = $storage->pull( $key );
+
+		$this->assertSame( $value, $pulled_value );
+		$this->assertNull( $storage->get( $key ) );
+	}
+
+	/**
+	 * @dataProvider storageProvider
+	 */
+	public function test_it_throws_exception_with_invalid_string_storage_key( Storage $storage ): void {
+		$this->expectException( Invalid_Key_Exception::class );
+
+		$storage->get( '' );
+	}
+
+	/**
+	 * @dataProvider storageProvider
+	 */
+	public function test_it_throws_exception_with_invalid_array_storage_key( Storage $storage ): void {
+		$this->expectException( Invalid_Key_Exception::class );
+
+		$storage->get( [] );
+	}
+
+	/**
+	 * @dataProvider storageProvider
+	 *
+	 * @env singlesite Some bug here where WP_INSTALLING is defined when using --env multisite
+	 */
+	public function test_it_expires_values( Storage $storage ): void {
+		$key    = 'uplink_test_key';
+		$value  = 'expired';
+		$expire = 1;
+
+		$this->assertTrue( $storage->set( $key, $value, $expire ) );
+
+		codecept_debug( 'Sleeping for 2 seconds...' );
+
+		sleep( 2 );
+
+		$this->assertNull( $storage->get( $key ) );
+	}
+
+}

--- a/tests/wpunit/Storage/Drivers/StorageDriverTest.php
+++ b/tests/wpunit/Storage/Drivers/StorageDriverTest.php
@@ -127,7 +127,10 @@ final class StorageDriverTest extends UplinkTestCase {
 	/**
 	 * @dataProvider storageProvider
 	 *
-	 * @env singlesite Some bug here where WP_INSTALLING is defined when using --env multisite
+	 * Some bug here where WP_INSTALLING is defined when using --env multisite
+	 * causing it to use local object cache.
+	 *
+	 * @env singlesite
 	 */
 	public function test_it_expires_values( Storage $storage ): void {
 		$key    = 'uplink_test_key';

--- a/tests/wpunit/Storage/Drivers/StorageKeyTest.php
+++ b/tests/wpunit/Storage/Drivers/StorageKeyTest.php
@@ -1,0 +1,119 @@
+<?php declare( strict_types=1 );
+
+namespace StellarWP\Uplink\Tests\Storage\Drivers;
+
+use StellarWP\Uplink\Storage\Contracts\Storage;
+use StellarWP\Uplink\Storage\Drivers\Option_Storage;
+use StellarWP\Uplink\Storage\Drivers\Transient_Storage;
+use StellarWP\Uplink\Storage\Exceptions\Invalid_Key_Exception;
+use StellarWP\Uplink\Tests\UplinkTestCase;
+
+final class StorageKeyTest extends UplinkTestCase {
+
+	/**
+	 * @dataProvider compositeProvider
+	 *
+	 * @param  mixed    $key     The storage key.
+	 * @param  mixed    $data    The data to store.
+	 * @param  Storage  $driver  The concrete storage driver.
+	 */
+	public function test_it_stores_various_types_of_data_and_keys( $key, $data, Storage $driver ) {
+		$expire = 10;
+
+		$this->assertTrue( $driver->set( $key, $data, $expire ) );
+		$this->assertEquals( $data, $driver->get( $key ) );
+		$this->assertTrue( $driver->delete( $key ) );
+		$this->assertNull( $driver->get( $key ) );
+	}
+
+	/**
+	 * Data provider for storage classes.
+	 *
+	 * @return array<string, array<Storage>>
+	 */
+	public function storageProvider(): array {
+		return [
+			'option_storage'    => [ new Option_Storage( 'uplink_test_storage' ) ],
+			'Transient Storage' => [ new Transient_Storage() ],
+		];
+	}
+
+	/**
+	 * Date provider for multiple key/data type combinations.
+	 *
+	 * @return array<string, array{0: mixed, 1: mixed}>
+	 */
+	public function keyProvider(): array {
+		$keys = [
+			'string key'  => 'test_string',
+			'integer key' => 12345,
+			'float key'   => 12345.6789,
+			'array key'   => [
+				'some' => 'key',
+				'more' => true,
+				'one'  => 1,
+				'two'  => 2.0,
+			],
+			'object key'  => (object) [
+				'propertyA' => 'valueA',
+				'propertyB' => 'valueB',
+				'propertyC' => (object) [
+					'propertyA' => 'valueA',
+					'propertyB' => 'valueB',
+				],
+				'propertyD' => [
+					'one' => 'one',
+					'two' => 'two',
+				],
+			],
+		];
+
+		$data = [
+			'string data'        => 'Hello World',
+			'integer data'       => 56789,
+			'float data'         => 56789.12345,
+			'boolean data true'  => true,
+			'boolean data false' => false,
+			'array data'         => [
+				'test' => true,
+				'one'  => 1,
+				'two'  => 'two',
+			],
+			'object data'        => (object) [
+				'propertyA' => 'valueA',
+				'propertyB' => 'valueB',
+				'propertyC' => (object) [
+					'propertyA' => 'valueA',
+					'propertyB' => 'valueB',
+				],
+			],
+		];
+
+		$test_cases = [];
+
+		foreach ( $keys as $key_type => $key ) {
+			foreach ( $data as $data_type => $data_value ) {
+				$test_cases[ "$key_type and $data_type" ] = [ $key, $data_value ];
+			}
+		}
+
+		return $test_cases;
+	}
+
+	/**
+	 * @return array<string, array{0: mixed, 1: mixed, 2: Storage}>
+	 */
+	public function compositeProvider(): array {
+		$test_cases = [];
+
+		foreach ( $this->keyProvider() as $key_and_data_description => $key_and_data ) {
+			foreach ( $this->storageProvider() as $driver_type => $driver ) {
+				$description               = "$key_and_data_description with $driver_type";
+				$test_cases[ $description ] = array_merge( $key_and_data, $driver );
+			}
+		}
+
+		return $test_cases;
+	}
+
+}


### PR DESCRIPTION
This replaces all transient calls with a Storage interface, with two underlying drivers:

1. Option_Storage: Uses the options table directly to store data.
2. Transient_Storage: Uses WP transients.

This can be configured by passing a FQCN to Config, e.g. `Config::set_storage_driver( Transient_Storage::class );` 