### PR TITLE
Add optional license key to provide in auth url callback

### DIFF
--- a/src/Uplink/Auth/Auth_Url_Builder.php
+++ b/src/Uplink/Auth/Auth_Url_Builder.php
@@ -58,8 +58,8 @@ final class Auth_Url_Builder {
 
 		// Query arguments to combine with $_GET and add to the authorization URL.
 		$args = [
-			'uplink_domain'  => $domain,
-			'uplink_slug'    => $slug,
+			'uplink_domain' => $domain,
+			'uplink_slug'   => $slug,
 		];
 
 		// Optionally include a license key if set.

--- a/src/Uplink/Auth/Auth_Url_Builder.php
+++ b/src/Uplink/Auth/Auth_Url_Builder.php
@@ -17,6 +17,11 @@ final class Auth_Url_Builder {
 	private $auth_url_manager;
 
 	/**
+	 * @var string
+	 */
+	private $license_key;
+
+	/**
 	 * @param  Nonce  $nonce  The Nonce creator.
 	 * @param  Auth_Url  $auth_url_manager  The auth URL manager.
 	 */
@@ -35,11 +40,10 @@ final class Auth_Url_Builder {
 	 *
 	 * @param  string  $slug  The product/service slug.
 	 * @param  string  $domain  An optional domain associated with a license key to pass along.
-	 * @param  string  $license  An optional license key to pass along.
 	 *
 	 * @return string
 	 */
-	public function build( string $slug, string $domain = '', string $license = '' ): string {
+	public function build( string $slug, string $domain = '' ): string {
 		global $pagenow;
 
 		if ( empty( $pagenow ) ) {
@@ -56,8 +60,12 @@ final class Auth_Url_Builder {
 		$args = [
 			'uplink_domain'  => $domain,
 			'uplink_slug'    => $slug,
-			'uplink_license' => $license,
 		];
+
+		// Optionally include a license key if set.
+		if ( ! empty( $this->license_key ) ) {
+			$args['uplink_license'] = $this->license_key;
+		}
 
 		$url = add_query_arg(
 			array_filter( array_merge( $_GET, $args ) ),
@@ -70,5 +78,18 @@ final class Auth_Url_Builder {
 				'uplink_callback' => base64_encode( $this->nonce->create_url( $url ) ),
 			] )
 		);
+	}
+
+	/**
+	 * Optionally set a license key to provide in uplink_callback query arg.
+	 *
+	 * @param string $key The license key to pass in the auth url.
+	 *
+	 * @return self
+	 */
+	public function set_license( string $key ): self {
+		$this->license_key = $key;
+
+		return $this;
 	}
 }

--- a/src/Uplink/Auth/Auth_Url_Builder.php
+++ b/src/Uplink/Auth/Auth_Url_Builder.php
@@ -35,10 +35,11 @@ final class Auth_Url_Builder {
 	 *
 	 * @param  string  $slug  The product/service slug.
 	 * @param  string  $domain  An optional domain associated with a license key to pass along.
+	 * @param  string  $license  An optional license key to pass along.
 	 *
 	 * @return string
 	 */
-	public function build( string $slug, string $domain = '' ): string {
+	public function build( string $slug, string $domain = '', string $license = '' ): string {
 		global $pagenow;
 
 		if ( empty( $pagenow ) ) {
@@ -53,8 +54,9 @@ final class Auth_Url_Builder {
 
 		// Query arguments to combine with $_GET and add to the authorization URL.
 		$args = [
-			'uplink_domain' => $domain,
-			'uplink_slug'   => $slug,
+			'uplink_domain'  => $domain,
+			'uplink_slug'    => $slug,
+			'uplink_license' => $license,
 		];
 
 		$url = add_query_arg(
@@ -69,5 +71,4 @@ final class Auth_Url_Builder {
 			] )
 		);
 	}
-
 }

--- a/src/Uplink/Components/Admin/Authorize_Button_Controller.php
+++ b/src/Uplink/Components/Admin/Authorize_Button_Controller.php
@@ -79,14 +79,15 @@ final class Authorize_Button_Controller extends Controller {
 	public function render( array $args = [] ): void {
 		global $pagenow;
 
-		$slug   = $args['slug'] ?? '';
-		$domain = $args['domain'] ?? '';
+		$slug    = $args['slug'] ?? '';
+		$domain  = $args['domain'] ?? '';
+		$license = $args['license'] ?? '';
 
 		if ( empty ( $slug ) ) {
 			throw new InvalidArgumentException( __( 'The Product slug cannot be empty', '%TEXTDOMAIN%' ) );
 		}
 
-		$url = $this->url_builder->build( $slug, $domain );
+		$url = $this->url_builder->set_license( $license )->build( $slug, $domain );
 
 		if ( ! $url ) {
 			return;

--- a/src/Uplink/Components/Admin/Authorize_Button_Controller.php
+++ b/src/Uplink/Components/Admin/Authorize_Button_Controller.php
@@ -70,7 +70,7 @@ final class Authorize_Button_Controller extends Controller {
 	/**
 	 * Renders the authorize-button view.
 	 *
-	 * @param  array{slug?: string, domain?: string} $args The Product slug and license domain.
+	 * @param  array{slug?: string, domain?: string, license?: string} $args The Product slug and license domain.
 	 *
 	 * @see src/views/admin/authorize-button.php
 	 *

--- a/src/Uplink/functions.php
+++ b/src/Uplink/functions.php
@@ -38,12 +38,13 @@ function get_container(): ContainerInterface {
  * @param string $slug The Product slug to render the button for.
  * @param string $domain An optional domain associated with a license key to pass along.
  */
-function render_authorize_button( string $slug, string $domain = '' ): void {
+function render_authorize_button( string $slug, string $domain = '', string $license = '' ): void {
 	try {
 		get_container()->get( Authorize_Button_Controller::class )
 			->render( [
-				'slug'   => $slug,
-				'domain' => $domain,
+				'slug'    => $slug,
+				'domain'  => $domain,
+				'license' => $license,
 			] );
 	} catch ( Throwable $e ) {
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {

--- a/src/Uplink/functions.php
+++ b/src/Uplink/functions.php
@@ -37,6 +37,7 @@ function get_container(): ContainerInterface {
  *
  * @param string $slug The Product slug to render the button for.
  * @param string $domain An optional domain associated with a license key to pass along.
+ * @param string $license The license that should be authenticated before token generation.
  */
 function render_authorize_button( string $slug, string $domain = '', string $license = '' ): void {
 	try {

--- a/tests/wpunit/Auth/AuthUrlBuilderTest.php
+++ b/tests/wpunit/Auth/AuthUrlBuilderTest.php
@@ -1,0 +1,63 @@
+<?php declare( strict_types=1 );
+
+namespace StellarWP\Uplink\Tests\Auth;
+
+use StellarWP\Uplink\API\V3\Auth\Auth_Url;
+use StellarWP\Uplink\Auth\Auth_Url_Builder;
+use StellarWP\Uplink\Auth\Nonce;
+use StellarWP\Uplink\Config;
+use StellarWP\Uplink\Tests\Traits\With_Uopz;
+use StellarWP\Uplink\Tests\UplinkTestCase;
+use StellarWP\Uplink\Uplink;
+
+final class AuthUrlBuilderTest extends UplinkTestCase {
+
+	use With_Uopz;
+
+	/**
+	 * @var Auth_Url_Builder
+	 */
+	private $auth_url_builder;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		Config::set_token_auth_prefix( 'kadence_' );
+
+		// Run init again to reload all providers.
+		Uplink::init();
+
+		$this->set_class_fn_return( Auth_Url::class, 'get', 'https://theeventscalendar.com/account-auth' );
+		$this->set_class_fn_return( Nonce::class, 'create', 'abcd1234' );
+
+		$this->auth_url_builder = $this->container->get( Auth_Url_Builder::class );
+	}
+
+	public function test_it_builds_url(): void {
+		$url = $this->auth_url_builder->build( 'the-events-calendar', 'theeventscalendar.com' );
+
+		$callback = base64_encode( 'http://wordpress.test/wp-admin/index.php?uplink_domain=theeventscalendar.com&uplink_slug=the-events-calendar&_uplink_nonce=abcd1234' );
+		$expected = 'https://theeventscalendar.com/account-auth?uplink_callback=' . rawurlencode( $callback );
+
+		$this->assertSame( $expected, $url );
+	}
+
+	public function test_it_builds_url_with_license(): void {
+		$url = $this->auth_url_builder->build( 'the-events-calendar', 'theeventscalendar.com', 'some-license-key' );
+
+		$callback = base64_encode( 'http://wordpress.test/wp-admin/index.php?uplink_domain=theeventscalendar.com&uplink_slug=the-events-calendar&uplink_license=some-license-key&_uplink_nonce=abcd1234' );
+		$expected = 'https://theeventscalendar.com/account-auth?uplink_callback=' . rawurlencode( $callback );
+
+		$this->assertSame( $expected, $url );
+	}
+
+	public function test_it_builds_url_with_empty_license(): void {
+		$url = $this->auth_url_builder->build( 'the-events-calendar', 'theeventscalendar.com', '' );
+
+		$callback = base64_encode( 'http://wordpress.test/wp-admin/index.php?uplink_domain=theeventscalendar.com&uplink_slug=the-events-calendar&_uplink_nonce=abcd1234' );
+		$expected = 'https://theeventscalendar.com/account-auth?uplink_callback=' . rawurlencode( $callback );
+
+		$this->assertSame( $expected, $url );
+	}
+
+}

--- a/tests/wpunit/Auth/AuthUrlBuilderTest.php
+++ b/tests/wpunit/Auth/AuthUrlBuilderTest.php
@@ -43,7 +43,7 @@ final class AuthUrlBuilderTest extends UplinkTestCase {
 	}
 
 	public function test_it_builds_url_with_license(): void {
-		$url = $this->auth_url_builder->build( 'the-events-calendar', 'theeventscalendar.com', 'some-license-key' );
+		$url = $this->auth_url_builder->set_license('some-license-key')->build( 'the-events-calendar', 'theeventscalendar.com' );
 
 		$callback = base64_encode( 'http://wordpress.test/wp-admin/index.php?uplink_domain=theeventscalendar.com&uplink_slug=the-events-calendar&uplink_license=some-license-key&_uplink_nonce=abcd1234' );
 		$expected = 'https://theeventscalendar.com/account-auth?uplink_callback=' . rawurlencode( $callback );
@@ -52,7 +52,7 @@ final class AuthUrlBuilderTest extends UplinkTestCase {
 	}
 
 	public function test_it_builds_url_with_empty_license(): void {
-		$url = $this->auth_url_builder->build( 'the-events-calendar', 'theeventscalendar.com', '' );
+		$url = $this->auth_url_builder->set_license('')->build( 'the-events-calendar', 'theeventscalendar.com' );
 
 		$callback = base64_encode( 'http://wordpress.test/wp-admin/index.php?uplink_domain=theeventscalendar.com&uplink_slug=the-events-calendar&_uplink_nonce=abcd1234' );
 		$expected = 'https://theeventscalendar.com/account-auth?uplink_callback=' . rawurlencode( $callback );


### PR DESCRIPTION
When a user is redirected to a site to generate a token, there is no way to generate a token for a specific license key.

This adds an optional fluent method so `uplink_callback` includes a license key to which the auth site can register an associated token.

```php
App::get( Auth_Url_Builder::class )->set_license( 'some-license-key' )->build( 'event-tickets', 'some-domain.com' );
```