### PR TITLE
Add license key to auth button

### DIFF
--- a/src/Uplink/Admin/Ajax.php
+++ b/src/Uplink/Admin/Ajax.php
@@ -58,9 +58,10 @@ class Ajax {
 
 		$results  = $plugin->validate_license( $submission['key'] );
 		$message  = is_plugin_active_for_network( $plugin->get_path() ) ? $results->get_network_message()->get() : $results->get_message()->get();
-		$auth_url = Config::get_container()->get( Auth_Url_Builder::class )
-		                                   ->set_license( $submission['key'] )
-		                                   ->build( $submission['slug'], get_site_url() );
+		$auth_url = Config::get_container()
+			->get( Auth_Url_Builder::class )
+			->set_license( $submission['key'] )
+			->build( $submission['slug'], get_site_url() );
 
 		wp_send_json( [
 			'status'  => absint( $results->is_valid() ),

--- a/src/Uplink/Admin/Ajax.php
+++ b/src/Uplink/Admin/Ajax.php
@@ -3,6 +3,7 @@
 namespace StellarWP\Uplink\Admin;
 
 use StellarWP\ContainerContract\ContainerInterface;
+use StellarWP\Uplink\Auth\Auth_Url_Builder;
 use StellarWP\Uplink\Config;
 use StellarWP\Uplink\Resources\Collection;
 use StellarWP\Uplink\Utils;
@@ -57,10 +58,22 @@ class Ajax {
 
 		$results = $plugin->validate_license( $submission['key'] );
 		$message = is_plugin_active_for_network( $plugin->get_path() ) ? $results->get_network_message()->get() : $results->get_message()->get();
+		try {
+			$auth_url = Config::get_container()->get( Auth_Url_Builder::class )
+			                                   ->set_license( $submission['key'] )
+			                                   ->build( $submission['slug'], get_site_url() );
+		} catch ( Throwable $e ) {
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				error_log( "Error building auth URL: {$e->getMessage()} {$e->getFile()}:{$e->getLine()} {$e->getTraceAsString()}" );
+			}
+
+			$auth_url = '';
+		}
 
 		wp_send_json( [
 			'status'  => absint( $results->is_valid() ),
 			'message' => $message,
+			'auth_url' => $auth_url,
 		] );
 	}
 

--- a/src/Uplink/Admin/Ajax.php
+++ b/src/Uplink/Admin/Ajax.php
@@ -56,19 +56,11 @@ class Ajax {
 			] );
 		}
 
-		$results = $plugin->validate_license( $submission['key'] );
-		$message = is_plugin_active_for_network( $plugin->get_path() ) ? $results->get_network_message()->get() : $results->get_message()->get();
-		try {
-			$auth_url = Config::get_container()->get( Auth_Url_Builder::class )
-			                                   ->set_license( $submission['key'] )
-			                                   ->build( $submission['slug'], get_site_url() );
-		} catch ( Throwable $e ) {
-			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-				error_log( "Error building auth URL: {$e->getMessage()} {$e->getFile()}:{$e->getLine()} {$e->getTraceAsString()}" );
-			}
-
-			$auth_url = '';
-		}
+		$results  = $plugin->validate_license( $submission['key'] );
+		$message  = is_plugin_active_for_network( $plugin->get_path() ) ? $results->get_network_message()->get() : $results->get_message()->get();
+		$auth_url = Config::get_container()->get( Auth_Url_Builder::class )
+		                                   ->set_license( $submission['key'] )
+		                                   ->build( $submission['slug'], get_site_url() );
 
 		wp_send_json( [
 			'status'  => absint( $results->is_valid() ),

--- a/src/Uplink/Admin/Fields/Field.php
+++ b/src/Uplink/Admin/Fields/Field.php
@@ -237,22 +237,11 @@ class Field {
 
 		$args = [
 			'field' => $this,
+			'resource' => $this->resource,
 			'group' => $this->group->get_name( $this->get_slug() ),
 		];
 
-		if ( $this->resource->is_using_oauth() ) {
-			ob_start();
-
-			if ( $this->resource->oauth_requires_license_key() ) {
-				echo $this->view->render( self::VIEW, $args );
-			}
-
-			UplinkNamespace\render_authorize_button( $this->get_slug() );
-
-			$html = (string) ob_get_clean();
-		} else {
-			$html = $this->view->render( self::VIEW, $args );
-		}
+		$html = $this->view->render( self::VIEW, $args );
 
 		/**
 		 * Filters the field HTML.

--- a/src/Uplink/Auth/Auth_Url_Builder.php
+++ b/src/Uplink/Auth/Auth_Url_Builder.php
@@ -50,6 +50,13 @@ final class Auth_Url_Builder {
 			return '';
 		}
 
+		$callback_url = $pagenow;
+
+		// If building the URL in an ajax context, use the referring URL.
+		if ( wp_parse_url( $pagenow, PHP_URL_PATH ) === 'admin-ajax.php' ) {
+			$callback_url = wp_get_referer();
+		}
+
 		$auth_url = $this->auth_url_manager->get( $slug );
 
 		if ( ! $auth_url ) {
@@ -69,7 +76,7 @@ final class Auth_Url_Builder {
 
 		$url = add_query_arg(
 			array_filter( array_merge( $_GET, $args ) ),
-			admin_url( $pagenow )
+			admin_url( $callback_url )
 		);
 
 		return sprintf( '%s?%s',

--- a/src/Uplink/Auth/Auth_Url_Builder.php
+++ b/src/Uplink/Auth/Auth_Url_Builder.php
@@ -50,7 +50,7 @@ final class Auth_Url_Builder {
 			return '';
 		}
 
-		$callback_url = $pagenow;
+		$callback_url = admin_url( $pagenow );
 
 		// If building the URL in an ajax context, use the referring URL.
 		if ( wp_parse_url( $pagenow, PHP_URL_PATH ) === 'admin-ajax.php' ) {
@@ -76,7 +76,7 @@ final class Auth_Url_Builder {
 
 		$url = add_query_arg(
 			array_filter( array_merge( $_GET, $args ) ),
-			admin_url( $callback_url )
+			$callback_url
 		);
 
 		return sprintf( '%s?%s',

--- a/src/Uplink/Components/Admin/Authorize_Button_Controller.php
+++ b/src/Uplink/Components/Admin/Authorize_Button_Controller.php
@@ -212,6 +212,7 @@ final class Authorize_Button_Controller extends Controller {
 			'target'    => $target,
 			'tag'       => $tag,
 			'classes'   => $this->classes( $classes ),
+			'slug'      => $slug,
 		] );
 	}
 

--- a/src/Uplink/functions.php
+++ b/src/Uplink/functions.php
@@ -120,8 +120,8 @@ function is_user_authorized(): bool {
 function build_auth_url( string $slug, string $domain = '', string $license = ''): string {
 	try {
 		return Config::get_container()->get( Auth_Url_Builder::class )
-		                              ->set_license( $license )
-		                              ->build( $slug, $domain, $license );
+			->set_license( $license )
+			->build( $slug, $domain, $license );
 	} catch ( Throwable $e ) {
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			error_log( "Error building auth URL: {$e->getMessage()} {$e->getFile()}:{$e->getLine()} {$e->getTraceAsString()}" );

--- a/src/Uplink/functions.php
+++ b/src/Uplink/functions.php
@@ -113,13 +113,15 @@ function is_user_authorized(): bool {
  *
  * @param  string  $slug  The Product slug to render the button for.
  * @param  string  $domain  An optional domain associated with a license key to pass along.
+ * @param  string  $license  An optional license key to pass along.
  *
  * @return string
  */
-function build_auth_url( string $slug, string $domain = '' ): string {
+function build_auth_url( string $slug, string $domain = '', string $license = ''): string {
 	try {
 		return Config::get_container()->get( Auth_Url_Builder::class )
-		                              ->build( $slug, $domain );
+		                              ->set_license( $license )
+		                              ->build( $slug, $domain, $license );
 	} catch ( Throwable $e ) {
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			error_log( "Error building auth URL: {$e->getMessage()} {$e->getFile()}:{$e->getLine()} {$e->getTraceAsString()}" );

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1,22 +1,29 @@
 .license-test-results {
-    margin-top: 10px;
+	margin-top: 10px;
 }
 
 .key-validity {
-    display: inline-block;
+	display: inline-block;
 }
 
 .valid-key {
-    color: green;
+	color: green;
 }
 
 .invalid-key {
-    color: red;
+	color: red;
+}
+
+.uplink-authorize-container {
+	display: inline-block;
 }
 
 .uplink-authorize {
-	margin-bottom: 16px !important;
 	transition: border-color 300ms ease-in-out;
+}
+
+.uplink-authorize.button {
+	vertical-align: initial;
 }
 
 .uplink-authorize.not-authorized {

--- a/src/assets/js/key-admin.js
+++ b/src/assets/js/key-admin.js
@@ -3,9 +3,11 @@
 		$( '.stellarwp-uplink-license-key-field' ).each( function() {
 			var $el = $( this );
 			var $field = $el.find( 'input[type="text"]' );
+			var $oauth = $el.parent().next( '.uplink-authorize-container' );
 
 			if ( '' === $field.val().trim() ) {
 				$el.find( '.license-test-results' ).hide();
+				$oauth.hide();
 			}
 
 			obj.validateKey( $el );
@@ -21,9 +23,11 @@
 		const field          = $el.find( 'input[type="text"]' )
 		const action         = $el.data( 'action' );
 		const slug           = $el.data( 'plugin-slug' );
+		const $oauth         = $el.find( 'a.uplink-authorize');
 		let $validityMessage = $el.find( '.key-validity' );
 
 		if ( '' === field.val().trim() ) {
+			$oauth.hide();
 			return;
 		}
 
@@ -53,9 +57,11 @@
 			switch (response.status) {
 				case 1:
 					$validityMessage.addClass('valid-key').removeClass('invalid-key');
+					$oauth.show();
 					break;
 				case 2:
 					$validityMessage.addClass('valid-key service-msg');
+					$oauth.show();
 					break;
 				default:
 					$validityMessage.addClass('invalid-key').removeClass('valid-key');

--- a/src/assets/js/key-admin.js
+++ b/src/assets/js/key-admin.js
@@ -23,7 +23,7 @@
 		const field          = $el.find( 'input[type="text"]' )
 		const action         = $el.data( 'action' );
 		const slug           = $el.data( 'plugin-slug' );
-		const $oauth         = $el.find( 'a.uplink-authorize');
+		const $oauth         = $el.parent().next( '.uplink-authorize-container' ).find( 'a.uplink-authorize');
 		let $validityMessage = $el.find( '.key-validity' );
 
 		if ( '' === field.val().trim() ) {

--- a/src/assets/js/key-admin.js
+++ b/src/assets/js/key-admin.js
@@ -71,16 +71,21 @@
 		$.post(ajaxurl, data, function (response) {
 			$validityMessage.show();
 			$validityMessage.html(response.message);
-			$oauth.attr( 'href', response.auth_url );
 
 			switch (response.status) {
 				case 1:
 					$validityMessage.addClass('valid-key').removeClass('invalid-key');
 					obj.enableAuthorizeButton( $oauth );
+					if ( $oauth.hasClass( 'not-authorized' ) ) {
+						$oauth.attr( 'href', response.auth_url );
+					}
 					break;
 				case 2:
 					$validityMessage.addClass('valid-key service-msg');
 					obj.enableAuthorizeButton( $oauth );
+					if ( $oauth.hasClass( 'not-authorized' ) ) {
+						$oauth.attr( 'href', response.auth_url );
+					}
 					break;
 				default:
 					$validityMessage.addClass('invalid-key').removeClass('valid-key');

--- a/src/views/admin/authorize-button.php
+++ b/src/views/admin/authorize-button.php
@@ -10,12 +10,13 @@
  * @var string $target The link target.
  * @var string $tag The HTML tag to use for the wrapper.
  * @var string $classes The CSS classes for the hyperlink.
+ * @var string $slug The slug of the product the authorize button is for.
  */
 
 defined( 'ABSPATH' ) || exit;
 ?>
 
-<<?php echo esc_html( $tag ) ?> class="uplink-authorize-container">
+<<?php echo esc_html( $tag ) ?> class="uplink-authorize-container" data-slug="<?php echo esc_attr( $slug ); ?>">
 	<a href="<?php echo esc_url( $url ) ?>"
 	   target="<?php echo $target ? esc_attr( $target ) : '' ?>"
 	   <?php echo $classes ? sprintf( 'class="%s"', esc_attr( $classes ) ) : '' ?>

--- a/src/views/admin/authorize-button.php
+++ b/src/views/admin/authorize-button.php
@@ -16,7 +16,7 @@
 defined( 'ABSPATH' ) || exit;
 ?>
 
-<<?php echo esc_html( $tag ) ?> class="uplink-authorize-container" data-slug="<?php echo esc_attr( $slug ); ?>">
+<<?php echo esc_html( $tag ) ?> class="uplink-authorize-container" data-plugin-slug="<?php echo esc_attr( $slug ); ?>">
 	<a href="<?php echo esc_url( $url ) ?>"
 	   target="<?php echo $target ? esc_attr( $target ) : '' ?>"
 	   <?php echo $classes ? sprintf( 'class="%s"', esc_attr( $classes ) ) : '' ?>

--- a/src/views/admin/authorize-button.php
+++ b/src/views/admin/authorize-button.php
@@ -16,10 +16,11 @@
 defined( 'ABSPATH' ) || exit;
 ?>
 
-<<?php echo esc_html( $tag ) ?> class="uplink-authorize-container" data-plugin-slug="<?php echo esc_attr( $slug ); ?>">
+<<?php echo esc_html( $tag ) ?> class="uplink-authorize-container">
 	<a href="<?php echo esc_url( $url ) ?>"
 	   target="<?php echo $target ? esc_attr( $target ) : '' ?>"
 	   <?php echo $classes ? sprintf( 'class="%s"', esc_attr( $classes ) ) : '' ?>
+	   data-plugin-slug="<?php echo esc_attr( $slug ); ?>"
 	>
 		<?php echo esc_html( $link_text ) ?>
 	</a>

--- a/src/views/admin/fields/field.php
+++ b/src/views/admin/fields/field.php
@@ -1,11 +1,13 @@
 <?php declare( strict_types=1 );
 /**
  * @var Field $field The Field object.
+ * @var Resource $resource The Field resource.
  * @var string $group The group name.
  */
 
 use StellarWP\Uplink\Config;
 use StellarWP\Uplink\Admin\Fields\Field;
+use StellarWP\Uplink\Resources\Resource;
 ?>
 
 <?php
@@ -60,6 +62,9 @@ do_action( 'stellarwp/uplink/' . Config::get_hook_prefix(). '/license_field_befo
 						</fieldset>
 						<?php echo $field->get_nonce_field(); ?>
 					</div>
+					<?php if ( $resource->is_using_oauth() ) : ?>
+						<?php \StellarWP\Uplink\render_authorize_button( $resource->slug, $resource->get_home_url(), $resource->license_key); ?>
+					<?php endif; ?>
 				</div>
 <?php if ( $field->should_show_label() ) : ?>
 			</td>

--- a/src/views/admin/fields/field.php
+++ b/src/views/admin/fields/field.php
@@ -23,65 +23,65 @@ do_action( 'stellarwp/uplink/' . Config::get_hook_prefix(). '/license_field_befo
 ?>
 <?php if ( $field->should_show_label() ) : ?>
 	<table class="form-table" role="presentation">
-		<tr class="stellarwp-uplink-license-key-field">
-			<th scope="row">
-				<label for="<?php echo esc_attr( $field->get_field_id() ); ?>"><?php echo esc_html( $field->get_label() ); ?></label>
-			</th>
-			<td>
+	<tr class="stellarwp-uplink-license-key-field">
+	<th scope="row">
+		<label for="<?php echo esc_attr( $field->get_field_id() ); ?>"><?php echo esc_html( $field->get_label() ); ?></label>
+	</th>
+	<td>
 <?php endif; ?>
-				<div class="stellarwp-uplink__license-field">
-					<div
-						class="<?php echo esc_attr( $field->get_classes() ); ?>"
-						id="<?php echo esc_attr( $field->get_product() ); ?>"
-						data-slug="<?php echo esc_attr( $field->get_product() ); ?>"
-						data-plugin="<?php echo esc_attr( $field->get_product() ); ?>"
-						data-plugin-slug="<?php echo esc_attr( $field->get_product_slug() ); ?>"
-						data-action="<?php echo esc_attr( $field->get_nonce_action() ); ?>"
-					>
-						<fieldset class="stellarwp-uplink__settings-group">
-							<?php settings_fields( $group ); ?>
+	<div class="stellarwp-uplink__license-field">
+		<div
+			class="<?php echo esc_attr( $field->get_classes() ); ?>"
+			id="<?php echo esc_attr( $field->get_product() ); ?>"
+			data-slug="<?php echo esc_attr( $field->get_product() ); ?>"
+			data-plugin="<?php echo esc_attr( $field->get_product() ); ?>"
+			data-plugin-slug="<?php echo esc_attr( $field->get_product_slug() ); ?>"
+			data-action="<?php echo esc_attr( $field->get_nonce_action() ); ?>"
+		>
+			<fieldset class="stellarwp-uplink__settings-group">
+				<?php settings_fields( $group ); ?>
 
-							<?php
-							/**
-							 * Fires before the license key input is printed on the page.
-							 *
-							 * @since TBD
-							 *
-							 * @param string $slug The slug of the field.
-							 */
-							do_action( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/license_field_before_input', $field->get_slug() );
-							?>
+				<?php
+				/**
+				 * Fires before the license key input is printed on the page.
+				 *
+				 * @since TBD
+				 *
+				 * @param string $slug The slug of the field.
+				 */
+				do_action( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/license_field_before_input', $field->get_slug() );
+				?>
 
-							<input
-								type="text"
-								name="<?php echo esc_attr( $field->get_field_name() ); ?>"
-								value="<?php echo esc_attr( $field->get_field_value() ); ?>"
-								placeholder="<?php echo esc_attr( $field->get_placeholder() ); ?>"
-								class="regular-text stellarwp-uplink__settings-field"
-							/>
-							<?php echo $field->get_key_status_html(); ?>
-						</fieldset>
-						<?php echo $field->get_nonce_field(); ?>
-						<?php if ( $resource->is_using_oauth() ) : ?>
-							<?php
-							try {
-								Config::get_container()->get( Authorize_Button_Controller::class )->render( [
-									'slug' => $field->get_slug(),
-									'domain' => get_site_url(),
-									'license' => $resource->license_key ?? '',
-								] );
-							} catch ( Throwable $e ) {
-								if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-									error_log( "Unable to render authorize button: {$e->getMessage()} {$e->getFile()}:{$e->getLine()} {$e->getTraceAsString()}" );
-								}
-							}
-							?>
-						<?php endif; ?>
-					</div>
-				</div>
+				<input
+					type="text"
+					name="<?php echo esc_attr( $field->get_field_name() ); ?>"
+					value="<?php echo esc_attr( $field->get_field_value() ); ?>"
+					placeholder="<?php echo esc_attr( $field->get_placeholder() ); ?>"
+					class="regular-text stellarwp-uplink__settings-field"
+				/>
+				<?php if ( $resource->is_using_oauth() ) : ?>
+					<?php
+					try {
+						Config::get_container()->get( Authorize_Button_Controller::class )->render( [
+							'slug' => $field->get_slug(),
+							'domain' => get_site_url(),
+							'license' => $resource->license_key ?? '',
+						] );
+					} catch ( Throwable $e ) {
+						if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+							error_log( "Unable to render authorize button: {$e->getMessage()} {$e->getFile()}:{$e->getLine()} {$e->getTraceAsString()}" );
+						}
+					}
+					?>
+				<?php endif; ?>
+				<?php echo $field->get_key_status_html(); ?>
+			</fieldset>
+			<?php echo $field->get_nonce_field(); ?>
+		</div>
+	</div>
 <?php if ( $field->should_show_label() ) : ?>
-			</td>
-		</tr>
+	</td>
+	</tr>
 	</table>
 <?php endif; ?>
 <?php

--- a/src/views/admin/fields/field.php
+++ b/src/views/admin/fields/field.php
@@ -62,22 +62,22 @@ do_action( 'stellarwp/uplink/' . Config::get_hook_prefix(). '/license_field_befo
 							<?php echo $field->get_key_status_html(); ?>
 						</fieldset>
 						<?php echo $field->get_nonce_field(); ?>
-					</div>
-					<?php if ( $resource->is_using_oauth() ) : ?>
-						<?php
-						try {
-							Config::get_container()->get( Authorize_Button_Controller::class )->render( [
-								'slug' => $field->get_slug(),
-								'domain' => get_site_url(),
-								'license' => $resource->license_key,
-							] );
-						} catch ( Throwable $e ) {
-							if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-								error_log( "Unable to render authorize button: {$e->getMessage()} {$e->getFile()}:{$e->getLine()} {$e->getTraceAsString()}" );
+						<?php if ( $resource->is_using_oauth() ) : ?>
+							<?php
+							try {
+								Config::get_container()->get( Authorize_Button_Controller::class )->render( [
+									'slug' => $field->get_slug(),
+									'domain' => get_site_url(),
+									'license' => $resource->license_key,
+								] );
+							} catch ( Throwable $e ) {
+								if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+									error_log( "Unable to render authorize button: {$e->getMessage()} {$e->getFile()}:{$e->getLine()} {$e->getTraceAsString()}" );
+								}
 							}
-						}
-						?>
-					<?php endif; ?>
+							?>
+						<?php endif; ?>
+					</div>
 				</div>
 <?php if ( $field->should_show_label() ) : ?>
 			</td>

--- a/src/views/admin/fields/field.php
+++ b/src/views/admin/fields/field.php
@@ -68,7 +68,7 @@ do_action( 'stellarwp/uplink/' . Config::get_hook_prefix(). '/license_field_befo
 								Config::get_container()->get( Authorize_Button_Controller::class )->render( [
 									'slug' => $field->get_slug(),
 									'domain' => get_site_url(),
-									'license' => $resource->license_key,
+									'license' => $resource->license_key ?? '',
 								] );
 							} catch ( Throwable $e ) {
 								if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {

--- a/src/views/admin/fields/field.php
+++ b/src/views/admin/fields/field.php
@@ -8,6 +8,7 @@
 use StellarWP\Uplink\Config;
 use StellarWP\Uplink\Admin\Fields\Field;
 use StellarWP\Uplink\Resources\Resource;
+use function StellarWP\Uplink\render_authorize_button;
 ?>
 
 <?php
@@ -63,7 +64,7 @@ do_action( 'stellarwp/uplink/' . Config::get_hook_prefix(). '/license_field_befo
 						<?php echo $field->get_nonce_field(); ?>
 					</div>
 					<?php if ( $resource->is_using_oauth() ) : ?>
-						<?php \StellarWP\Uplink\render_authorize_button( $resource->slug, $resource->get_home_url(), $resource->license_key); ?>
+						<?php render_authorize_button( $resource->slug, get_site_url(), $resource->license_key ?? '' ); ?>
 					<?php endif; ?>
 				</div>
 <?php if ( $field->should_show_label() ) : ?>

--- a/src/views/admin/fields/field.php
+++ b/src/views/admin/fields/field.php
@@ -8,7 +8,7 @@
 use StellarWP\Uplink\Config;
 use StellarWP\Uplink\Admin\Fields\Field;
 use StellarWP\Uplink\Resources\Resource;
-use function StellarWP\Uplink\render_authorize_button;
+use StellarWP\Uplink\Components\Admin\Authorize_Button_Controller;
 ?>
 
 <?php
@@ -64,7 +64,19 @@ do_action( 'stellarwp/uplink/' . Config::get_hook_prefix(). '/license_field_befo
 						<?php echo $field->get_nonce_field(); ?>
 					</div>
 					<?php if ( $resource->is_using_oauth() ) : ?>
-						<?php render_authorize_button( $resource->slug, get_site_url(), $resource->license_key ?? '' ); ?>
+						<?php
+						try {
+							Config::get_container()->get( Authorize_Button_Controller::class )->render( [
+								'slug' => $field->get_slug(),
+								'domain' => get_site_url(),
+								'license' => $resource->license_key,
+							] );
+						} catch ( Throwable $e ) {
+							if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+								error_log( "Unable to render authorize button: {$e->getMessage()} {$e->getFile()}:{$e->getLine()} {$e->getTraceAsString()}" );
+							}
+						}
+						?>
 					<?php endif; ?>
 				</div>
 <?php if ( $field->should_show_label() ) : ?>

--- a/tests/wpunit/Admin/Fields/FieldTest.php
+++ b/tests/wpunit/Admin/Fields/FieldTest.php
@@ -266,7 +266,7 @@ class FieldTest extends UplinkTestCase {
 		update_option( 'test_storage', [
 			'stellarwp_auth_url_service_oauth_with_license_key_field_1' => [
 				'expiration' => 0,
-				'value'      => 'https://licensing.stellarwp.com/account-auth?uplink_domain=&uplink_slug=service-oauth-with-license-key-field-1&_uplink_nonce=535281edcd',
+				'value'      => 'https://licensing.stellarwp.com/account-auth',
 			]
 		] );
 		$collection = $this->container->get( Collection::class );

--- a/tests/wpunit/Admin/Fields/__snapshots__/FieldTest__it_should_render_correct_html_for_oauth_resource_with_license_key__0.snapshot.html
+++ b/tests/wpunit/Admin/Fields/__snapshots__/FieldTest__it_should_render_correct_html_for_oauth_resource_with_license_key__0.snapshot.html
@@ -1,37 +1,38 @@
 
-				<div class="stellarwp-uplink__license-field">
-					<div
-						class="stellarwp-uplink-license-key-field"
-						id="/var/www/html/wp-content/plugins/uplink/tests/service-oauth-with-license-key-field-1.php"
-						data-slug="/var/www/html/wp-content/plugins/uplink/tests/service-oauth-with-license-key-field-1.php"
-						data-plugin="/var/www/html/wp-content/plugins/uplink/tests/service-oauth-with-license-key-field-1.php"
-						data-plugin-slug="service-oauth-with-license-key-field-1"
-						data-action="test"
-					>
-						<fieldset class="stellarwp-uplink__settings-group">
-							<input type='hidden' name='option_page' value='stellarwp_uplink_group_service-oauth-with-license-key-field-1' /><input type="hidden" name="action" value="update" /><input type="hidden" id="_wpnonce" name="_wpnonce" value="535281edcd" /><input type="hidden" name="_wp_http_referer" value="" />
-							
-							<input
-								type="text"
-								name=""
-								value=""
-								placeholder="License key"
-								class="regular-text stellarwp-uplink__settings-field"
-							/>
-							<p class="tooltip description">
+	<div class="stellarwp-uplink__license-field">
+		<div
+			class="stellarwp-uplink-license-key-field"
+			id="/var/www/html/wp-content/plugins/uplink/tests/service-oauth-with-license-key-field-1.php"
+			data-slug="/var/www/html/wp-content/plugins/uplink/tests/service-oauth-with-license-key-field-1.php"
+			data-plugin="/var/www/html/wp-content/plugins/uplink/tests/service-oauth-with-license-key-field-1.php"
+			data-plugin-slug="service-oauth-with-license-key-field-1"
+			data-action="test"
+		>
+			<fieldset class="stellarwp-uplink__settings-group">
+				<input type='hidden' name='option_page' value='stellarwp_uplink_group_service-oauth-with-license-key-field-1' /><input type="hidden" name="action" value="update" /><input type="hidden" id="_wpnonce" name="_wpnonce" value="535281edcd" /><input type="hidden" name="_wp_http_referer" value="" />
+				
+				<input
+					type="text"
+					name=""
+					value=""
+					placeholder="License key"
+					class="regular-text stellarwp-uplink__settings-field"
+				/>
+									
+<div class="uplink-authorize-container">
+	<a href="https://licensing.stellarwp.com/account-auth?uplink_callback=aHR0cDovL3dvcmRwcmVzcy50ZXN0L3dwLWFkbWluL2luZGV4LnBocD91cGxpbmtfZG9tYWluPWh0dHAlM0ElMkYlMkZ3b3JkcHJlc3MudGVzdCZ1cGxpbmtfc2x1Zz1zZXJ2aWNlLW9hdXRoLXdpdGgtbGljZW5zZS1rZXktZmllbGQtMSZfdXBsaW5rX25vbmNlPTUzNTI4MWVkY2Q1MzUyODFlZA%3D%3D"
+	   target="_blank"
+	   class="button uplink-authorize not-authorized"	   data-plugin-slug="service-oauth-with-license-key-field-1"
+	>
+		Connect	</a>
+</div>
+
+								<p class="tooltip description">
 	A valid license key is required for support and updates</p>
 <div class="license-test-results">
 	<img src="http://wordpress.test/wp-admin/images/wpspin_light.gif" class="ajax-loading-license" alt="Loading" style="display: none"/>
 	<div class="key-validity"></div>
 </div>
-						</fieldset>
-						<input type="hidden" class="wp-nonce-fluent" name="stellarwp-uplink-license-key-nonce__service-oauth-with-license-key-field-1" value="535281edcd" />					</div>
-				</div>
-
-<div class="uplink-authorize-container">
-	<a href="https://licensing.stellarwp.com/account-auth?uplink_domain=&#038;uplink_slug=service-oauth-with-license-key-field-1&#038;_uplink_nonce=535281edcd?uplink_callback=aHR0cDovL3dvcmRwcmVzcy50ZXN0L3dwLWFkbWluL2luZGV4LnBocD91cGxpbmtfc2x1Zz1zZXJ2aWNlLW9hdXRoLXdpdGgtbGljZW5zZS1rZXktZmllbGQtMSZfdXBsaW5rX25vbmNlPTUzNTI4MWVkY2Q1MzUyODFlZA%3D%3D"
-	   target="_blank"
-	   class="button uplink-authorize not-authorized"	>
-		Connect	</a>
-</div>
-
+			</fieldset>
+			<input type="hidden" class="wp-nonce-fluent" name="stellarwp-uplink-license-key-nonce__service-oauth-with-license-key-field-1" value="535281edcd" />		</div>
+	</div>


### PR DESCRIPTION
When a site needs to connect to the licensing server to generate a token or connect securely with an external service, a license key should be passed with the request. This attaches the license key to the auth button and adjusts a little of the functionality to make the UX more fluid for the user.

This also fixes some styling of the button so that it displays to the right of the license field that is used for authentication.

**No License Key Present**

![CleanShot 2024-09-13 at 09 45 14@2x](https://github.com/user-attachments/assets/524f5204-d6fa-4bab-b17e-c9c928f4e5b7)

**License Key Invalid**

![CleanShot 2024-09-13 at 09 46 04@2x](https://github.com/user-attachments/assets/8cf00f85-28c8-4f0e-8b68-0c8c2a09a327)

**License Key Valid**

![CleanShot 2024-09-13 at 09 46 44@2x](https://github.com/user-attachments/assets/0cdc7db0-ca87-4d12-98e3-daddfb53d466)

**Site Connected**

![CleanShot 2024-09-13 at 09 47 48@2x](https://github.com/user-attachments/assets/b2ec93b6-4b3a-46f8-bf8d-ad4aa5a9f996)
