### PR TITLE
Provides a connected hook

### DIFF
--- a/src/Uplink/Auth/Admin/Connect_Controller.php
+++ b/src/Uplink/Auth/Admin/Connect_Controller.php
@@ -170,5 +170,14 @@ final class Connect_Controller {
 				true
 			)
 		);
+
+		/**
+		 * Fires after a plugin has been connected.
+		 *
+		 * @since 2.2.1
+		 *
+		 * @param \StellarWP\Uplink\Resources\Resource $plugin The plugin that was connected.
+		 */
+		do_action( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/' . $slug . '/connected', $plugin );
 	}
 }

--- a/tests/wpunit/Auth/Admin/ConnectControllerTest.php
+++ b/tests/wpunit/Auth/Admin/ConnectControllerTest.php
@@ -82,6 +82,7 @@ final class ConnectControllerTest extends UplinkTestCase {
 		do_action( $this->container->get( Action_Manager::class )->get_hook_name( $this->slug ) );
 
 		$this->assertSame( $token, $this->token_manager->get( $this->plugin ) );
+		$this->assertEquals( 1, did_action( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/' . $this->slug . '/connected' ) );
 	}
 
 	public function test_it_sets_additional_license_key(): void {
@@ -111,6 +112,7 @@ final class ConnectControllerTest extends UplinkTestCase {
 
 		$this->assertSame( $token, $this->token_manager->get( $this->plugin ) );
 		$this->assertSame( $this->plugin->get_license_key(), $license );
+		$this->assertEquals( 1, did_action( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/' . $this->slug . '/connected' ) );
 	}
 
 	public function test_it_does_not_store_with_an_invalid_nonce(): void {
@@ -131,6 +133,7 @@ final class ConnectControllerTest extends UplinkTestCase {
 		$this->admin_init();
 
 		$this->assertNull( $this->token_manager->get( $this->plugin ) );
+		$this->assertEmpty( did_action( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/' . $this->slug . '/connected' ) );
 	}
 
 	public function test_it_does_not_store_an_invalid_token(): void {
@@ -155,6 +158,7 @@ final class ConnectControllerTest extends UplinkTestCase {
 		do_action( $this->container->get( Action_Manager::class )->get_hook_name( $this->slug ) );
 
 		$this->assertNull( $this->token_manager->get( $this->plugin ) );
+		$this->assertEmpty( did_action( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/' . $this->slug . '/connected' ) );
 	}
 
 	public function test_it_does_not_stores_token_or_license_with_a_slug_that_does_not_exist(): void {
@@ -184,6 +188,7 @@ final class ConnectControllerTest extends UplinkTestCase {
 
 		$this->assertNull( $this->token_manager->get( $this->plugin ) );
 		$this->assertEmpty( $this->plugin->get_license_key() );
+		$this->assertEmpty( did_action( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/a-plugin-slug-that-does-not-exist/connected' ) );
 	}
 
 	public function test_it_stores_token_but_not_license_without_a_license(): void {
@@ -218,6 +223,7 @@ final class ConnectControllerTest extends UplinkTestCase {
 
 		$this->assertSame( $token, $this->token_manager->get( $this->plugin ) );
 		$this->assertEmpty( $this->plugin->get_license_key() );
+		$this->assertEquals( 1, did_action( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/' . $this->slug . '/connected' ) );
 	}
 
 	/**
@@ -259,6 +265,7 @@ final class ConnectControllerTest extends UplinkTestCase {
 
 		$this->assertSame( $token, $this->token_manager->get( $this->plugin ) );
 		$this->assertSame( $this->plugin->get_license_key( 'network' ), $license );
+		$this->assertEquals( 1, did_action( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/' . $this->slug . '/connected' ) );
 	}
 
 	/**
@@ -302,6 +309,7 @@ final class ConnectControllerTest extends UplinkTestCase {
 
 		$this->assertSame( $token, $this->token_manager->get( $this->plugin ) );
 		$this->assertSame( $this->plugin->get_license_key( 'network' ), $license );
+		$this->assertEquals( 1, did_action( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/' . $this->slug . '/connected' ) );
 	}
 
 }


### PR DESCRIPTION
Provides a connected hook so that plugins using the service can execute needed actions on a succesfull connection.

e.g.
store timestamp of first connection (or any connection)
redirect to another page
etc
