### PR TITLE
Chore: phpstan updates

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,14 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Configure PHP environment
         uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
           extensions: mbstring, intl
           coverage: none
-      - uses: ramsey/composer-install@v2
+      - uses: ramsey/composer-install@v3
         with:
           composer-options: "--ignore-platform-reqs --optimize-autoloader"
       - name: Run PHPStan static analysis

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,7 +15,6 @@ parameters:
 	level: 5
 	inferPrivatePropertyTypeFromConstructor: true
 	reportUnmatchedIgnoredErrors: false
-	checkGenericClassInNonGenericObjectType: false
 
 	# Paths to be analyzed.
 	paths:
@@ -26,3 +25,4 @@ parameters:
 		- '#^Function add_query_arg invoked with [123] parameters?, 0 required\.$#'
 		# Uses func_get_args()
 		- '#^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$#'
+		- '#Path in require_once\(\).+is not a file or it does not exist#'

--- a/src/Uplink/Auth/Admin/Connect_Controller.php
+++ b/src/Uplink/Auth/Admin/Connect_Controller.php
@@ -95,7 +95,7 @@ final class Connect_Controller {
 
 		if ( ! Nonce::verify( $args[ self::NONCE ] ?? '' ) ) {
 			if ( ! function_exists( 'is_plugin_active' ) ) {
-				require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+				require_once ABSPATH . 'wp-admin/includes/plugin.php';
 			}
 
 			// The Litespeed plugin allows completely disabling transients for some reason...


### PR DESCRIPTION
- Ignore new require_once errors, they are super strict and require you to `touch ` file.
- Bump action versions