### PR TITLE
PHPStan fixes and GitHub action updates

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,14 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Configure PHP environment
         uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
           extensions: mbstring, intl
           coverage: none
-      - uses: ramsey/composer-install@v2
+      - uses: ramsey/composer-install@v3
         with:
           composer-options: "--ignore-platform-reqs --optimize-autoloader"
       - name: Run PHPStan static analysis

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,7 +15,6 @@ parameters:
 	level: 5
 	inferPrivatePropertyTypeFromConstructor: true
 	reportUnmatchedIgnoredErrors: false
-	checkGenericClassInNonGenericObjectType: false
 
 	# Paths to be analyzed.
 	paths:
@@ -26,3 +25,4 @@ parameters:
 		- '#^Function add_query_arg invoked with [123] parameters?, 0 required\.$#'
 		# Uses func_get_args()
 		- '#^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$#'
+		- '#Path in require_once\(\).+is not a file or it does not exist#'


### PR DESCRIPTION
### Main Changes
* Bump GitHub action versions
* Remove deprecated PHPStan config item.
* Ignore new PHPStan `require_once` rule, which requires one to `touch` a file before requiring it. See:
    * https://github.com/phpstan/phpstan/issues/11798 
    * https://github.com/phpstan/phpstan-src/pull/3294#issuecomment-2318679523