### PR TITLE
update the get_license_key function to be able to get from a file

### DIFF
--- a/src/Uplink/Admin/License_Field.php
+++ b/src/Uplink/Admin/License_Field.php
@@ -85,7 +85,7 @@ class License_Field extends Field {
 					'label_for'    => $resource->get_license_object()->get_key_option_name(),
 					'type'         => 'text',
 					'path'         => $resource->get_path(),
-					'value'        => $resource->get_license_key( $network ? 'network' : 'local' ),
+					'value'        => $resource->get_license_key( $network ? 'network' : 'any' ),
 					'placeholder'  => __( 'License Number', '%TEXTDOMAIN%' ),
 					'html'         => $this->get_field_html( $resource ),
 					'html_classes' => 'stellarwp-uplink-license-key-field',

--- a/src/Uplink/functions.php
+++ b/src/Uplink/functions.php
@@ -237,7 +237,7 @@ function get_license_key( string $slug ): string {
 
 	$network = allows_multisite_license( $resource );
 
-	return $resource->get_license_key( $network ? 'network' : 'local' );
+	return $resource->get_license_key( $network ? 'network' : 'any' );
 }
 
 /**


### PR DESCRIPTION
Previously we were only setting this to Local so that the file was not looked at but now we do want to use embed so we need to make this default to either network if in network mode or any so that the file can be checked.