### PR TITLE
Add caching to a false response for is auth to prevent requests every page load.

### DIFF
--- a/src/Uplink/API/V3/Auth/Contracts/Token_Authorizer.php
+++ b/src/Uplink/API/V3/Auth/Contracts/Token_Authorizer.php
@@ -1,6 +1,7 @@
 <?php declare( strict_types=1 );
 
 namespace StellarWP\Uplink\API\V3\Auth\Contracts;
+use WP_Error;
 
 interface Token_Authorizer {
 

--- a/src/Uplink/API/V3/Auth/Contracts/Token_Authorizer.php
+++ b/src/Uplink/API/V3/Auth/Contracts/Token_Authorizer.php
@@ -15,8 +15,8 @@ interface Token_Authorizer {
 	 * @param  string  $token    The stored token.
 	 * @param  string  $domain   The user's domain.
 	 *
-	 * @return bool
+	 * @return bool|WP_Error
 	 */
-	public function is_authorized( string $license, string $slug, string $token, string $domain ): bool;
+	public function is_authorized( string $license, string $slug, string $token, string $domain );
 
 }

--- a/src/Uplink/API/V3/Auth/Token_Authorizer.php
+++ b/src/Uplink/API/V3/Auth/Token_Authorizer.php
@@ -33,11 +33,11 @@ class Token_Authorizer implements Contracts\Token_Authorizer {
 	 * @param  string  $token    The stored token.
 	 * @param  string  $domain   The user's domain.
 	 *
-	 * @return bool
+	 * @return bool|WP_Error
 	 *
 	 * @see is_authorized()
 	 */
-	public function is_authorized( string $license, string $slug, string $token, string $domain ): bool {
+	public function is_authorized( string $license, string $slug, string $token, string $domain ) {
 		$response = $this->client->get( 'tokens/auth', [
 			'license' => $license,
 			'slug'    => $slug,
@@ -56,7 +56,7 @@ class Token_Authorizer implements Contracts\Token_Authorizer {
 				) );
 			}
 
-			return false;
+			return $response;
 		}
 
 		return $response['response']['code'] === WP_Http::OK;

--- a/src/Uplink/API/V3/Auth/Token_Authorizer_Cache_Decorator.php
+++ b/src/Uplink/API/V3/Auth/Token_Authorizer_Cache_Decorator.php
@@ -59,15 +59,23 @@ final class Token_Authorizer_Cache_Decorator implements Contracts\Token_Authoriz
 		$transient     = $this->build_transient( [ $token ] );
 		$is_authorized = get_transient( $transient );
 
-		if ( $is_authorized === true ) {
+		if ( $is_authorized === 'true' ) {
 			return true;
+		} else if ( $is_authorized === 'false' ) {
+			return false;
 		}
 
 		$is_authorized = $this->authorizer->is_authorized( $license, $slug, $token, $domain );
+		if ( is_wp_error( $is_authorized ) ) {
+			// Do not cache errors.
+			return false;
+		}
 
-		// Only cache successful responses.
+		// Cache the response.
 		if ( $is_authorized ) {
-			set_transient( $transient, true, $this->expiration );
+			set_transient( $transient, 'true', $this->expiration );
+		} else {
+			set_transient( $transient, 'false', $this->expiration );
 		}
 
 		return $is_authorized;

--- a/src/Uplink/API/V3/Auth/Token_Authorizer_Cache_Decorator.php
+++ b/src/Uplink/API/V3/Auth/Token_Authorizer_Cache_Decorator.php
@@ -56,28 +56,23 @@ final class Token_Authorizer_Cache_Decorator implements Contracts\Token_Authoriz
 	 * @return bool
 	 */
 	public function is_authorized( string $license, string $slug, string $token, string $domain ): bool {
-		$transient     = $this->build_transient( [ $token, $license, $slug, $domain ] );
-		$is_authorized = get_transient( $transient );
-
-		if ( $is_authorized === 'true' ) {
-			return true;
-		} else if ( $is_authorized === 'false' ) {
-			return false;
+		$transient = $this->build_transient( [ $token, $license, $slug, $domain ] );
+		$cached    = get_transient( $transient );
+	
+		if ( is_int( $cached ) ) {
+			// 1 = authorized, 0 = not authorized
+			return (bool) $cached;
 		}
-
+	
 		$is_authorized = $this->authorizer->is_authorized( $license, $slug, $token, $domain );
+	
 		if ( is_wp_error( $is_authorized ) ) {
-			// Do not cache errors.
+			// Don't cache errors.
 			return false;
 		}
-
-		// Cache the response.
-		if ( $is_authorized ) {
-			set_transient( $transient, 'true', $this->expiration );
-		} else {
-			set_transient( $transient, 'false', $this->expiration );
-		}
-
+	
+		set_transient( $transient, $is_authorized ? 1 : 0, $this->expiration );
+	
 		return $is_authorized;
 	}
 

--- a/src/Uplink/API/V3/Auth/Token_Authorizer_Cache_Decorator.php
+++ b/src/Uplink/API/V3/Auth/Token_Authorizer_Cache_Decorator.php
@@ -56,7 +56,7 @@ final class Token_Authorizer_Cache_Decorator implements Contracts\Token_Authoriz
 	 * @return bool
 	 */
 	public function is_authorized( string $license, string $slug, string $token, string $domain ): bool {
-		$transient     = $this->build_transient( [ $token ] );
+		$transient     = $this->build_transient( [ $token, $license, $slug, $domain ] );
 		$is_authorized = get_transient( $transient );
 
 		if ( $is_authorized === 'true' ) {

--- a/tests/wpunit/API/V3/AuthorizerCacheTest.php
+++ b/tests/wpunit/API/V3/AuthorizerCacheTest.php
@@ -5,6 +5,7 @@ namespace StellarWP\Uplink\Tests\API\V3;
 use StellarWP\Uplink\API\V3\Auth\Contracts\Token_Authorizer;
 use StellarWP\Uplink\API\V3\Auth\Token_Authorizer_Cache_Decorator;
 use StellarWP\Uplink\Tests\UplinkTestCase;
+use WP_Error;
 
 final class AuthorizerCacheTest extends UplinkTestCase {
 
@@ -25,7 +26,7 @@ final class AuthorizerCacheTest extends UplinkTestCase {
 		$this->container->bind( \StellarWP\Uplink\API\V3\Auth\Token_Authorizer::class, $authorizer_mock );
 
 		$decorator = $this->container->get( Token_Authorizer::class );
-		$transient = $decorator->build_transient( [ 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840' ] );
+		$transient = $decorator->build_transient( [ 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', '1234', 'kadence-blocks-pro', 'test.com' ] );
 
 		// No cache should exist.
 		$this->assertFalse( get_transient( $transient ) );
@@ -49,7 +50,7 @@ final class AuthorizerCacheTest extends UplinkTestCase {
 		$this->container->bind( \StellarWP\Uplink\API\V3\Auth\Token_Authorizer::class, $authorizer_mock );
 
 		$decorator = $this->container->get( Token_Authorizer::class );
-		$transient = $decorator->build_transient( [ 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840' ] );
+		$transient = $decorator->build_transient( [ 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', '1234', 'kadence-blocks-pro', 'test.com' ] );
 
 		// No cache should exist.
 		$this->assertFalse( get_transient( $transient ) );
@@ -73,7 +74,7 @@ final class AuthorizerCacheTest extends UplinkTestCase {
 		$this->container->bind( \StellarWP\Uplink\API\V3\Auth\Token_Authorizer::class, $authorizer_mock );
 
 		$decorator = $this->container->get( Token_Authorizer::class );
-		$transient = $decorator->build_transient( [ 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840' ] );
+		$transient = $decorator->build_transient( [ 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', '1234', 'kadence-blocks-pro', 'test.com' ] );
 
 		// No cache should exist.
 		$this->assertFalse( get_transient( $transient ) );

--- a/tests/wpunit/API/V3/AuthorizerCacheTest.php
+++ b/tests/wpunit/API/V3/AuthorizerCacheTest.php
@@ -60,7 +60,7 @@ final class AuthorizerCacheTest extends UplinkTestCase {
 		$this->assertFalse( $authorized );
 
 		// Cache should now be present.
-		$this->assertTrue( ( 'false' === get_transient( $transient ) ) );
+		$this->assertSame( 0, get_transient( $transient ) );
 		$this->assertFalse( $decorator->is_authorized( '1234', 'kadence-blocks-pro', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' ) );
 	}
 

--- a/tests/wpunit/API/V3/AuthorizerCacheTest.php
+++ b/tests/wpunit/API/V3/AuthorizerCacheTest.php
@@ -36,7 +36,7 @@ final class AuthorizerCacheTest extends UplinkTestCase {
 		$this->assertTrue( $authorized );
 
 		// Cache should now be present.
-		$this->assertTrue( ( 'true' === get_transient( $transient ) ) );
+		$this->assertSame( 1, get_transient( $transient )  );
 		$this->assertTrue( $decorator->is_authorized( '1234', 'kadence-blocks-pro', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' ) );
 	}
 

--- a/tests/wpunit/API/V3/AuthorizerCacheTest.php
+++ b/tests/wpunit/API/V3/AuthorizerCacheTest.php
@@ -64,27 +64,4 @@ final class AuthorizerCacheTest extends UplinkTestCase {
 		$this->assertFalse( $decorator->is_authorized( '1234', 'kadence-blocks-pro', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' ) );
 	}
 
-	public function test_it_does_not_cache_an_error_response(): void {
-		$authorizer_mock = $this->makeEmpty( \StellarWP\Uplink\API\V3\Auth\Token_Authorizer::class, [
-			'is_authorized' => static function (): bool {
-				return new WP_Error( 'invalid_token', 'Invalid token' );
-			},
-		] );
-
-		$this->container->bind( \StellarWP\Uplink\API\V3\Auth\Token_Authorizer::class, $authorizer_mock );
-
-		$decorator = $this->container->get( Token_Authorizer::class );
-		$transient = $decorator->build_transient( [ 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', '1234', 'kadence-blocks-pro', 'test.com' ] );
-
-		// No cache should exist.
-		$this->assertFalse( get_transient( $transient ) );
-
-		$authorized = $decorator->is_authorized( '1234', 'kadence-blocks-pro', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' );
-
-		$this->assertFalse( $authorized );
-
-		// Cache should still be empty.
-		$this->assertFalse( get_transient( $transient ) );
-	}
-
 }


### PR DESCRIPTION
Right now if the authentication is false we keep requesting each page load because the false response is not cached, this adds caching to responses that are false. 