### PR TITLE
fix for cache miss

### DIFF
--- a/src/Uplink/API/V3/Auth/Token_Authorizer_Cache_Decorator.php
+++ b/src/Uplink/API/V3/Auth/Token_Authorizer_Cache_Decorator.php
@@ -59,9 +59,10 @@ final class Token_Authorizer_Cache_Decorator implements Contracts\Token_Authoriz
 		$transient = $this->build_transient( [ $token, $license, $slug, $domain ] );
 		$cached    = get_transient( $transient );
 	
-		if ( is_int( $cached ) ) {
-			// 1 = authorized, 0 = not authorized
-			return (bool) $cached;
+		if ( $cached === 'authorized' ) {
+			return true;
+		} else if ( $cached === 'not_authorized' ) {
+			return false;
 		}
 	
 		$is_authorized = $this->authorizer->is_authorized( $license, $slug, $token, $domain );
@@ -71,7 +72,7 @@ final class Token_Authorizer_Cache_Decorator implements Contracts\Token_Authoriz
 			return false;
 		}
 	
-		set_transient( $transient, $is_authorized ? 1 : 0, $this->expiration );
+		set_transient( $transient, $is_authorized ? 'authorized' : 'not_authorized', $this->expiration );
 	
 		return $is_authorized;
 	}

--- a/tests/wpunit/API/V3/AuthorizerCacheTest.php
+++ b/tests/wpunit/API/V3/AuthorizerCacheTest.php
@@ -36,7 +36,7 @@ final class AuthorizerCacheTest extends UplinkTestCase {
 		$this->assertTrue( $authorized );
 
 		// Cache should now be present.
-		$this->assertSame( 1, get_transient( $transient )  );
+		$this->assertSame( 'authorized', get_transient( $transient )  );
 		$this->assertTrue( $decorator->is_authorized( '1234', 'kadence-blocks-pro', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' ) );
 	}
 
@@ -60,7 +60,7 @@ final class AuthorizerCacheTest extends UplinkTestCase {
 		$this->assertFalse( $authorized );
 
 		// Cache should now be present.
-		$this->assertSame( 0, get_transient( $transient ) );
+		$this->assertSame( 'not_authorized', get_transient( $transient ) );
 		$this->assertFalse( $decorator->is_authorized( '1234', 'kadence-blocks-pro', 'dc2c98d9-9ff8-4409-bfd2-a3cce5b5c840', 'test.com' ) );
 	}
 


### PR DESCRIPTION
After testing the auth cache wasn't working, it appears get_transient returns a string which means we need to use a string instead of 1:0 