### PR TITLE
Fix retrieving nonce value to validate key

### DIFF
--- a/src/assets/js/key-admin.js
+++ b/src/assets/js/key-admin.js
@@ -59,13 +59,13 @@
 		let licenseKey = field.val().trim();
 		field.val( licenseKey );
 
-		const nonceField = $($el).find('.wp-nonce-fluent') || $($el).find('.wp-nonce');
+		const nonceValue = $($el).find('.wp-nonce-fluent').val() || $($el).find('.wp-nonce').val();
 
 		const data = {
 			action: window[`stellarwp_config_${action}`]['action'],
 			slug: slug,
 			key: licenseKey,
-			_wpnonce: nonceField.val()
+			_wpnonce: nonceValue
 		};
 
 		$.post(ajaxurl, data, function (response) {


### PR DESCRIPTION
This PR updates the code to retrieve the nonce value to validate the license key.

The first expression will always evaluate to true, even if the element `.wp-nonce-fluent` doesn't exist, since [find](https://api.jquery.com/find/) returns a jQuery object. That way, the request doesn't send the nonce value if the element `.wp-nonce-fluent` doesn't exist

```
$($el).find('.wp-nonce-fluent') || $($el).find('.wp-nonce');
```

