### PR TITLE
Feature: add grace period to licensed product data

### DIFF
--- a/src/Uplink/Licensing/License_Manager.php
+++ b/src/Uplink/Licensing/License_Manager.php
@@ -235,6 +235,10 @@ final class License_Manager {
 	/**
 	 * Fetch the product catalog from the API and cache the result.
 	 *
+	 * After a successful fetch, the last active date is updated for every
+	 * product that reports a valid license. This anchors the grace period
+	 * to the most recent confirmed-good state.
+	 *
 	 * @since 3.0.0
 	 *
 	 * @param string $key    License key.
@@ -255,6 +259,15 @@ final class License_Manager {
 		$collection = Product_Collection::from_array( $result );
 
 		$this->repository->set_products( $collection );
+
+		$current_time = time();
+
+		foreach ( $collection as $product ) {
+			/** @var Product_Entry $product */
+			if ( $product->is_valid() ) {
+				$this->repository->set_last_active_date( $product->get_product_slug(), $current_time );
+			}
+		}
 
 		return $collection;
 	}

--- a/src/Uplink/Licensing/Repositories/License_Repository.php
+++ b/src/Uplink/Licensing/Repositories/License_Repository.php
@@ -49,6 +49,8 @@ final class License_Repository {
 	 *
 	 * Stored as an associative array keyed by product slug.
 	 *
+	 * TODO: Decide where to store this data. See discussion in https://github.com/stellarwp/uplink/pull/162/changes#r2906722318
+	 *
 	 * @since 3.0.0
 	 *
 	 * @var string

--- a/src/Uplink/Licensing/Repositories/License_Repository.php
+++ b/src/Uplink/Licensing/Repositories/License_Repository.php
@@ -45,6 +45,17 @@ final class License_Repository {
 	public const PRODUCTS_TRANSIENT_KEY = 'stellarwp_uplink_licensing_products';
 
 	/**
+	 * Option name for the map of per-product last-active timestamps.
+	 *
+	 * Stored as an associative array keyed by product slug.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string
+	 */
+	public const LAST_ACTIVE_DATES_OPTION_NAME = 'stellarwp_uplink_product_last_active_dates';
+
+	/**
 	 * Default cache duration in seconds (12 hours).
 	 *
 	 * @since 3.0.0
@@ -298,9 +309,12 @@ final class License_Repository {
 	}
 
 	/**
-	 * Whether a product has a valid, active license in the cached catalog.
+	 * Whether a product has a valid, active license.
 	 *
-	 * TODO: Add grace period concept to allow for some time after license expiration to still consider the license active.
+	 * Returns true when the cached catalog shows the product as valid, or when
+	 * the product is within the grace period after its last confirmed active date.
+	 * This prevents platform fees from being charged immediately after a license
+	 * expires or when a network issue prevents reaching the licensing server.
 	 *
 	 * @since 3.0.0
 	 *
@@ -309,8 +323,89 @@ final class License_Repository {
 	 * @return bool
 	 */
 	public function is_product_active( string $slug ): bool {
-		$product = $this->get_product( $slug );
+		if ( $this->is_product_valid( $slug ) ) {
+			return true;
+		}
 
-		return $product !== null && $product->is_valid();
+		return $this->is_in_grace_period( $slug );
+	}
+
+	/**
+	 * Get the timestamp of the last time a product was confirmed active.
+	 *
+	 * Returns null when no active date has been recorded for the slug.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $slug Product slug.
+	 *
+	 * @return int|null Unix timestamp (UTC), or null if never recorded.
+	 */
+	public function get_last_active_date( string $slug ): ?int {
+		$raw_dates = get_option( self::LAST_ACTIVE_DATES_OPTION_NAME, [] );
+
+		/** @var array<string, int> $dates */
+		$dates = is_array( $raw_dates ) ? $raw_dates : [];
+
+		return $dates[ $slug ] ?? null;
+	}
+
+	/**
+	 * Record the current time as the last active date for a product.
+	 *
+	 * Called whenever a fetch confirms the product has a valid license so that
+	 * the grace period is anchored to the most recent known-good state.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $slug      Product slug.
+	 * @param int    $timestamp Unix timestamp (UTC) to record.
+	 *
+	 * @return void
+	 */
+	public function set_last_active_date( string $slug, int $timestamp ): void {
+		$raw_dates = get_option( self::LAST_ACTIVE_DATES_OPTION_NAME, [] );
+
+		/** @var array<string, int> $dates */
+		$dates = is_array( $raw_dates ) ? $raw_dates : [];
+
+		$dates[ $slug ] = $timestamp;
+		update_option( self::LAST_ACTIVE_DATES_OPTION_NAME, $dates, false );
+	}
+
+	/**
+	 * The grace period in seconds after the last active date during which
+	 * a product is still considered active.
+	 *
+	 * 30 days gives customers and the licensing server reasonable time to
+	 * recover from network issues or an unintentional lapse in renewal.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return int
+	 */
+	public function get_grace_period_in_seconds(): int {
+		return 30 * DAY_IN_SECONDS;
+	}
+
+	/**
+	 * Whether a product is within the grace period after its last active date.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $slug Product slug.
+	 *
+	 * @return bool
+	 */
+	private function is_in_grace_period( string $slug ): bool {
+		$last_active = $this->get_last_active_date( $slug );
+
+		if ( $last_active === null ) {
+			return false;
+		}
+
+		$current_time = time();
+
+		return $current_time <= $last_active + $this->get_grace_period_in_seconds();
 	}
 }

--- a/src/Uplink/Licensing/Repositories/License_Repository.php
+++ b/src/Uplink/Licensing/Repositories/License_Repository.php
@@ -384,7 +384,7 @@ final class License_Repository {
 	 *
 	 * @return int
 	 */
-	public function get_grace_period_in_seconds(): int {
+	private function get_grace_period_in_seconds(): int {
 		return 30 * DAY_IN_SECONDS;
 	}
 

--- a/src/Uplink/Licensing/Repositories/License_Repository.php
+++ b/src/Uplink/Licensing/Repositories/License_Repository.php
@@ -53,7 +53,7 @@ final class License_Repository {
 	 *
 	 * @var string
 	 */
-	public const LAST_ACTIVE_DATES_OPTION_NAME = 'stellarwp_uplink_product_last_active_dates';
+	public const PRODUCTS_LAST_ACTIVE_DATES_OPTION_NAME = 'stellarwp_uplink_licensing_products_last_active_dates';
 
 	/**
 	 * Default cache duration in seconds (12 hours).
@@ -342,7 +342,7 @@ final class License_Repository {
 	 * @return int|null Unix timestamp (UTC), or null if never recorded.
 	 */
 	public function get_last_active_date( string $slug ): ?int {
-		$raw_dates = get_option( self::LAST_ACTIVE_DATES_OPTION_NAME, [] );
+		$raw_dates = get_option( self::PRODUCTS_LAST_ACTIVE_DATES_OPTION_NAME, [] );
 
 		/** @var array<string, int> $dates */
 		$dates = is_array( $raw_dates ) ? $raw_dates : [];
@@ -364,13 +364,13 @@ final class License_Repository {
 	 * @return void
 	 */
 	public function set_last_active_date( string $slug, int $timestamp ): void {
-		$raw_dates = get_option( self::LAST_ACTIVE_DATES_OPTION_NAME, [] );
+		$raw_dates = get_option( self::PRODUCTS_LAST_ACTIVE_DATES_OPTION_NAME, [] );
 
 		/** @var array<string, int> $dates */
 		$dates = is_array( $raw_dates ) ? $raw_dates : [];
 
 		$dates[ $slug ] = $timestamp;
-		update_option( self::LAST_ACTIVE_DATES_OPTION_NAME, $dates, false );
+		update_option( self::PRODUCTS_LAST_ACTIVE_DATES_OPTION_NAME, $dates, false );
 	}
 
 	/**

--- a/tests/wpunit/Licensing/Repositories/License_RepositoryTest.php
+++ b/tests/wpunit/Licensing/Repositories/License_RepositoryTest.php
@@ -512,7 +512,7 @@ final class License_RepositoryTest extends UplinkTestCase {
 	}
 
 	// -------------------------------------------------------------------------
-	// is_product_active() — grace period behaviour
+	// is_product_active() — grace period tests
 	// -------------------------------------------------------------------------
 
 	public function test_is_product_active_returns_true_when_product_is_valid(): void {

--- a/tests/wpunit/Licensing/Repositories/License_RepositoryTest.php
+++ b/tests/wpunit/Licensing/Repositories/License_RepositoryTest.php
@@ -20,13 +20,13 @@ final class License_RepositoryTest extends UplinkTestCase {
 		parent::setUp();
 		$this->repository = new License_Repository();
 		delete_option( License_Repository::KEY_OPTION_NAME );
-		delete_option( License_Repository::LAST_ACTIVE_DATES_OPTION_NAME );
+		delete_option( License_Repository::PRODUCTS_LAST_ACTIVE_DATES_OPTION_NAME );
 		delete_transient( License_Repository::PRODUCTS_TRANSIENT_KEY );
 	}
 
 	protected function tearDown(): void {
 		delete_option( License_Repository::KEY_OPTION_NAME );
-		delete_option( License_Repository::LAST_ACTIVE_DATES_OPTION_NAME );
+		delete_option( License_Repository::PRODUCTS_LAST_ACTIVE_DATES_OPTION_NAME );
 		delete_transient( License_Repository::PRODUCTS_TRANSIENT_KEY );
 		parent::tearDown();
 	}

--- a/tests/wpunit/Licensing/Repositories/License_RepositoryTest.php
+++ b/tests/wpunit/Licensing/Repositories/License_RepositoryTest.php
@@ -20,11 +20,13 @@ final class License_RepositoryTest extends UplinkTestCase {
 		parent::setUp();
 		$this->repository = new License_Repository();
 		delete_option( License_Repository::KEY_OPTION_NAME );
+		delete_option( License_Repository::LAST_ACTIVE_DATES_OPTION_NAME );
 		delete_transient( License_Repository::PRODUCTS_TRANSIENT_KEY );
 	}
 
 	protected function tearDown(): void {
 		delete_option( License_Repository::KEY_OPTION_NAME );
+		delete_option( License_Repository::LAST_ACTIVE_DATES_OPTION_NAME );
 		delete_transient( License_Repository::PRODUCTS_TRANSIENT_KEY );
 		parent::tearDown();
 	}
@@ -473,5 +475,116 @@ final class License_RepositoryTest extends UplinkTestCase {
 		$this->repository->delete_key();
 
 		$this->assertFalse( $fired );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_last_active_date() / set_last_active_date()
+	// -------------------------------------------------------------------------
+
+	public function test_get_last_active_date_returns_null_when_not_set(): void {
+		$this->assertNull( $this->repository->get_last_active_date( 'give' ) );
+	}
+
+	public function test_set_and_get_last_active_date_round_trip(): void {
+		$timestamp = time();
+
+		$this->repository->set_last_active_date( 'give', $timestamp );
+
+		$this->assertSame( $timestamp, $this->repository->get_last_active_date( 'give' ) );
+	}
+
+	public function test_last_active_date_is_stored_per_slug(): void {
+		$now = time();
+
+		$this->repository->set_last_active_date( 'give', $now );
+		$this->repository->set_last_active_date( 'tec', $now - 1000 );
+
+		$this->assertSame( $now, $this->repository->get_last_active_date( 'give' ) );
+		$this->assertSame( $now - 1000, $this->repository->get_last_active_date( 'tec' ) );
+		$this->assertNull( $this->repository->get_last_active_date( 'unknown' ) );
+	}
+
+	public function test_set_last_active_date_overwrites_previous_value(): void {
+		$this->repository->set_last_active_date( 'give', 1000 );
+		$this->repository->set_last_active_date( 'give', 2000 );
+
+		$this->assertSame( 2000, $this->repository->get_last_active_date( 'give' ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// is_product_active() — grace period behaviour
+	// -------------------------------------------------------------------------
+
+	public function test_is_product_active_returns_true_when_product_is_valid(): void {
+		$this->repository->set_products(
+			Product_Collection::from_array(
+				[
+					Product_Entry::from_array(
+						[
+							'product_slug'      => 'give',
+							'tier'              => 'give-pro',
+							'status'            => 'active',
+							'expires'           => '2026-12-31 23:59:59',
+							'validation_status' => 'valid',
+						]
+					),
+				]
+			)
+		);
+
+		$this->assertTrue( $this->repository->is_product_active( 'give' ) );
+	}
+
+	public function test_is_product_active_returns_false_when_no_catalog_and_no_last_active_date(): void {
+		$this->assertFalse( $this->repository->is_product_active( 'give' ) );
+	}
+
+	public function test_is_product_active_returns_true_within_grace_period(): void {
+		// Record an active date 1 day ago — well within the 30-day grace window.
+		$one_day_ago = time() - DAY_IN_SECONDS;
+		$this->repository->set_last_active_date( 'give', $one_day_ago );
+
+		// No catalog cached — simulates an expired/unavailable license server response.
+		$this->assertTrue( $this->repository->is_product_active( 'give' ) );
+	}
+
+	public function test_is_product_active_returns_false_after_grace_period_expires(): void {
+		// Record an active date 31 days ago — past the 30-day grace window.
+		$thirty_one_days_ago = time() - ( 31 * DAY_IN_SECONDS );
+		$this->repository->set_last_active_date( 'give', $thirty_one_days_ago );
+
+		$this->assertFalse( $this->repository->is_product_active( 'give' ) );
+	}
+
+	public function test_is_product_active_returns_true_when_product_is_valid_even_without_last_active_date(): void {
+		$this->repository->set_products(
+			Product_Collection::from_array(
+				[
+					Product_Entry::from_array(
+						[
+							'product_slug'      => 'give',
+							'tier'              => 'give-pro',
+							'status'            => 'active',
+							'expires'           => '2026-12-31 23:59:59',
+							'validation_status' => 'valid',
+						]
+					),
+				]
+			)
+		);
+
+		// No last active date recorded — but catalog says valid, so still active.
+		$this->assertTrue( $this->repository->is_product_active( 'give' ) );
+	}
+
+	public function test_grace_period_is_per_slug(): void {
+		$one_day_ago     = time() - DAY_IN_SECONDS;
+		$thirty_one_days = time() - ( 31 * DAY_IN_SECONDS );
+
+		$this->repository->set_last_active_date( 'give', $one_day_ago );
+		$this->repository->set_last_active_date( 'tec', $thirty_one_days );
+
+		$this->assertTrue( $this->repository->is_product_active( 'give' ) );
+		$this->assertFalse( $this->repository->is_product_active( 'tec' ) );
 	}
 }


### PR DESCRIPTION
Resolves: [SCON-277]

## Description

This adds the concept of a _grace period_ to licensed product data.  This will ensure licensed services will remain active between scenarios like network issues and license renewal/expiration lapse.

This was achieved by adding an option that stores the last known active licensed product dates every time a valid license is detected.  Then, we compare those dates against the current date and our defined grace period (currently 30 days).

From a product consumer standpoint, using `stellarwp_uplink_is_product_license_active('give')` will return true if either the product license is currently active or within the grace period.

[SCON-277]: https://stellarwp.atlassian.net/browse/SCON-277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ