### PR TITLE
refactor: licensing endpoint

### DIFF
--- a/.plans/tasks/scon-304-endpoint-products.md
+++ b/.plans/tasks/scon-304-endpoint-products.md
@@ -1,7 +1,7 @@
 ---
 ticket: SCON-304
 url: https://stellarwp.atlassian.net/browse/SCON-304
-status: todo
+status: in-progress
 ---
 
 # Include products in the license REST response
@@ -12,35 +12,34 @@ The `GET /stellarwp/uplink/v1/license` endpoint only returns `{ key: string | nu
 
 The frontend needs this data to support upcoming work around license validity, grace periods, and product-level status. Without it, the UI can't show which tier the user is on, whether a subscription is expiring, or make decisions about feature validity on the client side.
 
-## Proposed solution
+## Solution
 
-Expand the `GET /license` response to include the full `Product_Collection` alongside the key. The response shape should look something like:
+### GET /license
 
-```json
-{
-  "key": "LWSW-...",
-  "products": [
-    {
-      "product_slug": "give",
-      "tier": "pro",
-      "pending_tier": null,
-      "status": "active",
-      "expires": "2026-12-31 00:00:00",
-      "activations": {
-        "site_limit": 0,
-        "active_count": 1,
-        "over_limit": false
-      },
-      "installed_here": true,
-      "validation_status": "VALID",
-      "is_valid": true
-    }
-  ]
-}
-```
+Returns `{ key, products[] }`. Products come from the cached `Product_Collection` (originally fetched from the v4 `/products` endpoint). When no license key is stored, `products` is an empty array.
 
-When no license key is stored, `products` should be an empty array.
+### POST /license
 
-The `POST /license` and `DELETE /license` responses should also include the products array so the frontend state stays in sync after activation or removal without needing a separate fetch.
+Accepts `key` (required) and `network` (optional). Fetches the product catalog from the v4 API to verify the key is recognized, then stores it. Does not activate any product or consume a seat. Returns `{ key }` on success.
 
-The frontend store, types, and resolvers will need to be updated to consume and store the products data. That can happen in the same PR or as a follow-up.
+After a successful POST, the frontend invalidates the GET `/license` resolver to refetch the product list.
+
+### POST /license/validate
+
+Accepts `product_slug` (required). Operates on the stored license key. Calls the v4 validate endpoint, which may consume an activation seat. Returns the `Validation_Result` (status, license, subscription, activation). On success, clears the cached product list so the next GET reflects the new activation state.
+
+This is a separate endpoint because storing a key and consuming a seat are different concerns. The user may want to enter/change their key without immediately activating a product.
+
+### DELETE /license
+
+Returns `204 No Content` with no body. This only removes the locally stored key. It does not free activation seats on the licensing service.
+
+### Frontend
+
+The store has three async operations, each with their own loading/error state:
+
+- `storeLicense(key)` - POST /license
+- `validateProduct(productSlug)` - POST /license/validate
+- `deleteLicense()` - DELETE /license
+
+The `getLicense` resolver fetches `{ key, products[] }` from GET and populates the store.

--- a/docs/licensing-v4-api.md
+++ b/docs/licensing-v4-api.md
@@ -1,0 +1,147 @@
+# Licensing Service V4 API
+
+Reference for the two v4 endpoints that the `Licensing_Client` contract abstracts.
+
+## GET /stellarwp/v4/products
+
+Fetches all products (subscriptions) under a license key. When a domain is provided, includes per-product validation status and installation state.
+
+### Request
+
+| Parameter | Type   | Required | Description                                     |
+| --------- | ------ | -------- | ----------------------------------------------- |
+| key       | string | yes      | License key (e.g. `LWSW-...`)                   |
+| domain    | string | no       | Site domain. Adds validation status per product |
+
+### Response (200)
+
+```json
+{
+    "products": [
+        {
+            "product_slug": "kadence",
+            "tier": "professional",
+            "pending_tier": null,
+            "status": "active",
+            "expires": "2027-02-18 00:00:00",
+            "activations": {
+                "site_limit": 5,
+                "active_count": 2,
+                "over_limit": false
+            },
+            "installed_here": true,
+            "validation_status": "valid",
+            "is_valid": true
+        }
+    ]
+}
+```
+
+The `installed_here`, `validation_status`, and `is_valid` fields are only present when a domain is provided in the request.
+
+`pending_tier` is non-null when the subscription has a scheduled downgrade.
+
+`site_limit: 0` means unlimited activations (`over_limit` is always false).
+
+### Error responses
+
+| HTTP | Code               | Meaning                     |
+| ---- | ------------------ | --------------------------- |
+| 404  | `not_found`        | License key not recognized  |
+| 403  | `license_inactive` | License is suspended/banned |
+| 500  | `unknown_error`    | Unexpected server error     |
+
+---
+
+## POST /stellarwp/v4/licenses/validate
+
+Validates a license for a specific product on a domain. Automatically creates an activation record on first call for a new domain (if the license is valid and has available seats).
+
+### Request
+
+| Parameter    | Type   | Required | Description        |
+| ------------ | ------ | -------- | ------------------ |
+| key          | string | yes      | License key        |
+| product_slug | string | yes      | Product identifier |
+| domain       | string | yes      | Domain to validate |
+
+### Response (200)
+
+```json
+{
+    "status": "valid",
+    "is_valid": true,
+    "license": {
+        "key": "LWSW-TEST-TEST-TEST-TEST-TEST",
+        "status": "active"
+    },
+    "subscription": {
+        "product_slug": "kadence",
+        "tier": "kadence-agency",
+        "site_limit": 5,
+        "expiration_date": "2027-02-18 00:00:00",
+        "status": "active"
+    },
+    "activation": {
+        "domain": "example.com",
+        "activated_at": "2026-02-18 00:00:00"
+    }
+}
+```
+
+The `activation` object is null when the domain has no activation record (status will be `not_activated`).
+
+### Error responses
+
+| HTTP | Code          | Meaning                    |
+| ---- | ------------- | -------------------------- |
+| 404  | `invalid_key` | License key not recognized |
+
+---
+
+## Validation statuses
+
+The validation pipeline runs these checks in order, stopping at the first failure.
+
+| Status               | `is_valid` | Meaning                                                |
+| -------------------- | ---------- | ------------------------------------------------------ |
+| `valid`              | true       | License active, subscription current, domain activated |
+| `not_activated`      | false      | Subscription valid but domain has no activation        |
+| `expired`            | false      | Subscription past its expiration date                  |
+| `suspended`          | false      | Subscription suspended                                 |
+| `cancelled`          | false      | Subscription cancelled                                 |
+| `out_of_activations` | false      | All seats consumed, new domain cannot activate         |
+| `no_subscription`    | false      | License exists but no subscription for this product    |
+| `license_suspended`  | false      | License-level suspension (all products affected)       |
+| `license_banned`     | false      | License permanently banned (all products affected)     |
+| `invalid_key`        | false      | License key not recognized                             |
+
+### Pipeline order
+
+1. **Check subscription** - does a subscription exist for this product?
+2. **Check expiration** - is the subscription past its expiration date?
+3. **Check status** - is the subscription suspended or cancelled?
+4. **Check seat limit** - are all activation seats consumed? (skipped for unlimited or existing activations)
+5. **Default** - `valid` if an active activation exists, `not_activated` otherwise
+
+---
+
+## License and subscription statuses
+
+These are distinct from validation statuses. They describe the state of the license or subscription record itself.
+
+### License status
+
+| Status      | Meaning                                                        |
+| ----------- | -------------------------------------------------------------- |
+| `active`    | Normal operation                                               |
+| `suspended` | Temporarily suspended (maps to `license_suspended` validation) |
+| `banned`    | Permanently banned (maps to `license_banned` validation)       |
+
+### Subscription status
+
+| Status      | Meaning               |
+| ----------- | --------------------- |
+| `active`    | Normal operation      |
+| `suspended` | Temporarily suspended |
+| `cancelled` | Permanently cancelled |

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -58,8 +58,8 @@ When the site calls `validate()` for a single product, Licensing returns a more 
 
 ```json
 {
- "key": "LWSW-...",
- "status": "active"
+    "key": "LWSW-...",
+    "status": "active"
 }
 ```
 
@@ -67,11 +67,11 @@ When the site calls `validate()` for a single product, Licensing returns a more 
 
 ```json
 {
- "product_slug": "give",
- "tier": "give-pro",
- "site_limit": 3,
- "expiration_date": "2026-12-31 23:59:59",
- "status": "active"
+    "product_slug": "give",
+    "tier": "give-pro",
+    "site_limit": 3,
+    "expiration_date": "2026-12-31 23:59:59",
+    "status": "active"
 }
 ```
 
@@ -79,8 +79,8 @@ When the site calls `validate()` for a single product, Licensing returns a more 
 
 ```json
 {
- "domain": "example.com",
- "activated_at": "2024-03-04 12:34:56"
+    "domain": "example.com",
+    "activated_at": "2024-03-04 12:34:56"
 }
 ```
 
@@ -194,28 +194,44 @@ License_Manager::get()
 ```
 License_Manager::validate_and_store($key, $domain)
 ├─ validate LWSW- prefix format
-├─ License_Manager::get_products($key, $domain)
-│  ├─ check license state option (collection key)
-│  ├─ if miss → Licensing_Client::get_products()
-│  └─ persist result to license state option
+├─ Licensing_Client::get_products($key, $domain)
 ├─ if API error → return WP_Error
-├─ License_Repository::store($key)
-└─ return true
+├─ persist Product_Collection to license state option
+├─ License_Repository::store_key($key)
+└─ return Product_Entry[] (the fetched product list)
+```
+
+### Product Validation
+
+Validation is separate from key storage. Storing a key verifies it and fetches its products, but does not consume any seats. Validation explicitly requests a seat for a specific product on this domain.
+
+```
+License_Manager::validate_product($domain, $product_slug)
+├─ get stored key (return WP_Error if none)
+├─ Licensing_Client::validate($key, $domain, $product_slug)
+├─ if API error → return WP_Error
+├─ delete cached products (so next read reflects new activation state)
+└─ return Validation_Result
 ```
 
 ### Periodic Status Check
 
 ```
-License_Manager::get_products($key, $domain)
+License_Manager::get_products($domain)
+├─ get stored key (return WP_Error if none)
 ├─ License_Repository::get_products()
 │  └─ read license state option
-├─ if collection present → return Product_Collection
-├─ if only last_error present → return WP_Error
-├─ if null → Licensing_Client::get_products()
-│  ├─ on success → update collection + last_success_at, clear last_error
-│  └─ on failure → update last_error + last_failure_at, preserve existing collection
+├─ if Product_Collection present → return it
+├─ fetch_and_cache($key, $domain)
+│  ├─ Licensing_Client::get_products()
+│  ├─ on success → persist Product_Collection, update last_active dates
+│  └─ on failure → persist WP_Error
 └─ return Product_Collection|WP_Error
 ```
+
+## REST API
+
+See [rest/license.md](rest/license.md) for the endpoint reference.
 
 ## Relationship to Catalog and Features
 

--- a/docs/rest/license.md
+++ b/docs/rest/license.md
@@ -1,0 +1,106 @@
+# License Endpoints
+
+All endpoints require the `manage_options` capability.
+
+## GET /stellarwp/uplink/v1/license
+
+Returns the stored unified license key and its associated products. Products come from the cached `Product_Collection` (fetched from the Licensing API). When no key is stored, `products` is an empty array.
+
+### Response (200)
+
+```json
+{
+    "key": "LWSW-...",
+    "products": [
+        {
+            "product_slug": "give",
+            "tier": "give-pro",
+            "pending_tier": null,
+            "status": "active",
+            "expires": "2026-12-31 00:00:00",
+            "activations": {
+                "site_limit": 0,
+                "active_count": 1,
+                "over_limit": false
+            },
+            "installed_here": true,
+            "validation_status": "valid",
+            "is_valid": true
+        }
+    ]
+}
+```
+
+When no key exists, returns `{ "key": null, "products": [] }`.
+
+## POST /stellarwp/uplink/v1/license
+
+Validates a license key against the Licensing API and stores it. Verifies the key is recognized (has products) and caches the product list, but does not activate any product or consume a seat.
+
+### Parameters
+
+| Parameter | Type    | Required | Description                             |
+| --------- | ------- | -------- | --------------------------------------- |
+| `key`     | string  | yes      | License key (must have `LWSW-` prefix)  |
+| `network` | boolean | no       | Store at network level (multisite only) |
+
+### Response (200)
+
+```json
+{
+    "key": "LWSW-..."
+}
+```
+
+### Errors
+
+| HTTP | Code                              | Meaning                       |
+| ---- | --------------------------------- | ----------------------------- |
+| 400  | (validation)                      | Missing key or invalid format |
+| 422  | `stellarwp-uplink-invalid-key`    | Key not recognized by API     |
+| 500  | `stellarwp-uplink-store-failed`   | Key could not be persisted    |
+
+## POST /stellarwp/uplink/v1/license/validate
+
+Validates a product on this domain using the stored license key. Calls the Licensing API validate endpoint, which may consume an activation seat on first call for a new domain. On success, the cached product list is refreshed so the next GET reflects the new activation state.
+
+Non-valid statuses from the licensing API (`expired`, `out_of_activations`, `suspended`, etc.) are returned as errors. They do not consume a seat or change any state.
+
+### Parameters
+
+| Parameter      | Type   | Required | Description             |
+| -------------- | ------ | -------- | ----------------------- |
+| `product_slug` | string | yes      | The product to validate |
+
+### Response
+
+Returns `201 Created` with no body.
+
+### Errors
+
+| HTTP | Code                                   | Meaning                          |
+| ---- | -------------------------------------- | -------------------------------- |
+| 400  | (validation)                           | Missing product_slug             |
+| 422  | `stellarwp-uplink-invalid-key`         | No license key is stored         |
+| 422  | `stellarwp-uplink-product-not-found`   | Product not found under this key |
+| 422  | `stellarwp-uplink-expired`             | Subscription has expired         |
+| 422  | `stellarwp-uplink-suspended`           | Subscription is suspended        |
+| 422  | `stellarwp-uplink-cancelled`           | Subscription is cancelled        |
+| 422  | `stellarwp-uplink-out-of-activations`  | All activation seats are in use  |
+| 422  | `stellarwp-uplink-license-suspended`   | License is suspended             |
+| 422  | `stellarwp-uplink-license-banned`      | License is banned                |
+| 422  | `stellarwp-uplink-no-subscription`     | No subscription for this product |
+
+## DELETE /stellarwp/uplink/v1/license
+
+Removes the locally stored license key. Does not free any activation seats on the licensing service.
+
+### Parameters
+
+| Parameter | Type    | Required | Description                                |
+| --------- | ------- | -------- | ------------------------------------------ |
+| `network` | boolean | no       | Delete from network level (multisite only) |
+
+### Response
+
+Returns `204 No Content` with no body.

--- a/src/Uplink/API/REST/V1/License_Controller.php
+++ b/src/Uplink/API/REST/V1/License_Controller.php
@@ -2,9 +2,9 @@
 
 namespace StellarWP\Uplink\API\REST\V1;
 
-use StellarWP\Uplink\Licensing\Product_Collection;
 use StellarWP\Uplink\Utils\License_Key;
 use StellarWP\Uplink\Licensing\License_Manager;
+use StellarWP\Uplink\Licensing\Product_Collection;
 use StellarWP\Uplink\Site\Data;
 use WP_Error;
 use WP_REST_Controller;
@@ -110,6 +110,29 @@ final class License_Controller extends WP_REST_Controller {
 
 		register_rest_route(
 			$this->namespace,
+			'/' . $this->rest_base . '/(?P<key>[A-Za-z0-9-]+)',
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'lookup_item' ],
+					'permission_callback' => [ $this, 'check_permissions' ],
+					'args'                => [
+						'key' => [
+							'description'       => __( 'The license key to look up.', '%TEXTDOMAIN%' ),
+							'type'              => 'string',
+							'required'          => true,
+							'validate_callback' => static function ( $value ): bool {
+								return is_string( $value ) && License_Key::is_valid_format( $value );
+							},
+						],
+					],
+				],
+				'schema' => [ $this, 'get_public_item_schema' ],
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
 			'/' . $this->rest_base . '/validate',
 			[
 				[
@@ -118,6 +141,7 @@ final class License_Controller extends WP_REST_Controller {
 					'permission_callback' => [ $this, 'check_permissions' ],
 					'args'                => $this->get_validate_args(),
 				],
+				'schema' => [ $this, 'get_public_item_schema' ],
 			]
 		);
 	}
@@ -147,14 +171,40 @@ final class License_Controller extends WP_REST_Controller {
 	 */
 	public function get_item( $request ): WP_REST_Response {
 		$domain   = $this->site_data->get_domain();
+		$key      = $this->manager->get_key();
 		$products = $this->manager->get_products( $domain );
 
-		$data = [
-			'key'      => $this->manager->get_key(),
-			'products' => $products instanceof Product_Collection ? $products->to_array() : [],
-		];
+		if ( is_wp_error( $products ) ) {
+			$products = new Product_Collection();
+		}
 
-		return new WP_REST_Response( $data );
+		return new WP_REST_Response(
+			License_Response::make( $key, $products )
+		);
+	}
+
+	/**
+	 * Looks up the products for a license key, skipping storage.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function lookup_item( $request ) {
+		/** @var string $key */
+		$key    = $request->get_param( 'key' );
+		$domain = $this->site_data->get_domain();
+		$result = $this->manager->lookup_products( $key, $domain );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return new WP_REST_Response(
+			License_Response::make( $key, $result )
+		);
 	}
 
 	/**
@@ -187,12 +237,15 @@ final class License_Controller extends WP_REST_Controller {
 			return $result;
 		}
 
-		$data = [
-			'key'      => $key,
-			'products' => Product_Collection::from_array( $result )->to_array(),
-		];
+		$products = $this->manager->get_products( $domain );
 
-		return new WP_REST_Response( $data );
+		if ( is_wp_error( $products ) ) {
+			$products = new Product_Collection();
+		}
+
+		return new WP_REST_Response(
+			License_Response::make( $this->manager->get_key(), $products )
+		);
 	}
 
 	/**
@@ -224,7 +277,16 @@ final class License_Controller extends WP_REST_Controller {
 			return $result;
 		}
 
-		return new WP_REST_Response( null, 201 );
+		// Product validation fetched the updated products list.
+		$products = $this->manager->get_products( $domain );
+
+		if ( is_wp_error( $products ) ) {
+			$products = new Product_Collection();
+		}
+
+		return new WP_REST_Response(
+			License_Response::make( $this->manager->get_key(), $products )
+		);
 	}
 
 	/**
@@ -265,10 +327,71 @@ final class License_Controller extends WP_REST_Controller {
 			'title'      => 'license',
 			'type'       => 'object',
 			'properties' => [
-				'key' => [
+				'key'      => [
 					'description' => __( 'The unified license key.', '%TEXTDOMAIN%' ),
 					'type'        => [ 'string', 'null' ],
 					'context'     => [ 'view' ],
+				],
+				'products' => [
+					'description' => __( 'The products associated with the license key.', '%TEXTDOMAIN%' ),
+					'type'        => 'array',
+					'context'     => [ 'view' ],
+					'items'       => [
+						'type'       => 'object',
+						'properties' => [
+							'product_slug'      => [
+								'description' => __( 'The product identifier.', '%TEXTDOMAIN%' ),
+								'type'        => 'string',
+							],
+							'tier'              => [
+								'description' => __( 'The subscription tier.', '%TEXTDOMAIN%' ),
+								'type'        => 'string',
+							],
+							'pending_tier'      => [
+								'description' => __( 'The pending tier on next renewal.', '%TEXTDOMAIN%' ),
+								'type'        => [ 'string', 'null' ],
+							],
+							'status'            => [
+								'description' => __( 'The subscription status.', '%TEXTDOMAIN%' ),
+								'type'        => 'string',
+							],
+							'expires'           => [
+								'description' => __( 'The expiration date.', '%TEXTDOMAIN%' ),
+								'type'        => 'string',
+								'format'      => 'date-time',
+							],
+							'activations'       => [
+								'description' => __( 'Activation seat data.', '%TEXTDOMAIN%' ),
+								'type'        => 'object',
+								'properties'  => [
+									'site_limit'   => [
+										'description' => __( 'Maximum activation seats (0 = unlimited).', '%TEXTDOMAIN%' ),
+										'type'        => 'integer',
+									],
+									'active_count' => [
+										'description' => __( 'Current active activations.', '%TEXTDOMAIN%' ),
+										'type'        => 'integer',
+									],
+									'over_limit'   => [
+										'description' => __( 'Whether the seat limit is exceeded.', '%TEXTDOMAIN%' ),
+										'type'        => 'boolean',
+									],
+								],
+							],
+							'installed_here'    => [
+								'description' => __( 'Whether the product is activated on this domain.', '%TEXTDOMAIN%' ),
+								'type'        => [ 'boolean', 'null' ],
+							],
+							'validation_status' => [
+								'description' => __( 'The validation status for this product.', '%TEXTDOMAIN%' ),
+								'type'        => [ 'string', 'null' ],
+							],
+							'is_valid'          => [
+								'description' => __( 'Whether the product has a valid license.', '%TEXTDOMAIN%' ),
+								'type'        => 'boolean',
+							],
+						],
+					],
 				],
 			],
 		];

--- a/src/Uplink/API/REST/V1/License_Controller.php
+++ b/src/Uplink/API/REST/V1/License_Controller.php
@@ -2,9 +2,10 @@
 
 namespace StellarWP\Uplink\API\REST\V1;
 
-use StellarWP\Uplink\Licensing\Error_Code;
+use StellarWP\Uplink\Licensing\Product_Collection;
 use StellarWP\Uplink\Utils\License_Key;
 use StellarWP\Uplink\Licensing\License_Manager;
+use StellarWP\Uplink\Site\Data;
 use WP_Error;
 use WP_REST_Controller;
 use WP_REST_Request;
@@ -51,16 +52,27 @@ final class License_Controller extends WP_REST_Controller {
 	private License_Manager $manager;
 
 	/**
+	 * The site data provider.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var Data
+	 */
+	private Data $site_data;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param License_Manager $manager The license manager.
+	 * @param License_Manager $manager   The license manager.
+	 * @param Data            $site_data The site data provider.
 	 *
 	 * @return void
 	 */
-	public function __construct( License_Manager $manager ) {
-		$this->manager = $manager;
+	public function __construct( License_Manager $manager, Data $site_data ) {
+		$this->manager   = $manager;
+		$this->site_data = $site_data;
 	}
 
 	/**
@@ -95,6 +107,19 @@ final class License_Controller extends WP_REST_Controller {
 				'schema' => [ $this, 'get_public_item_schema' ],
 			]
 		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/validate',
+			[
+				[
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => [ $this, 'validate_item' ],
+					'permission_callback' => [ $this, 'check_permissions' ],
+					'args'                => $this->get_validate_args(),
+				],
+			]
+		);
 	}
 
 	/**
@@ -109,7 +134,7 @@ final class License_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Returns the current unified license key.
+	 * Returns the current unified license key and its associated products.
 	 *
 	 * Always returns 200. The key field will be null if no key is stored
 	 * and none is discoverable from the product registry.
@@ -121,11 +146,22 @@ final class License_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function get_item( $request ): WP_REST_Response {
-		return new WP_REST_Response( [ 'key' => $this->manager->get_key() ] );
+		$domain   = $this->site_data->get_domain();
+		$products = $this->manager->get_products( $domain );
+
+		$data = [
+			'key'      => $this->manager->get_key(),
+			'products' => $products instanceof Product_Collection ? $products->to_array() : [],
+		];
+
+		return new WP_REST_Response( $data );
 	}
 
 	/**
-	 * Stores the unified license key.
+	 * Validates a license key against the remote API and stores it.
+	 *
+	 * Verifies the key is recognized (has products) but does not activate
+	 * any product or consume a seat. Returns the stored key on success.
 	 *
 	 * @since 3.0.0
 	 *
@@ -137,22 +173,65 @@ final class License_Controller extends WP_REST_Controller {
 		/** @var string $key */
 		$key     = $request->get_param( 'key' );
 		$network = (bool) $request->get_param( 'network' );
-		$domain  = (string) wp_parse_url( get_site_url(), PHP_URL_HOST );
+		$domain  = $this->site_data->get_domain();
 
 		$result = $this->manager->validate_and_store( $key, $domain, $network );
 
 		if ( is_wp_error( $result ) ) {
-			$status = $result->get_error_code() === Error_Code::INVALID_KEY ? 422 : 500;
-			$result->add_data( [ 'status' => $status ] );
+			$data = $result->get_error_data();
+
+			if ( ! is_array( $data ) || empty( $data['status'] ) ) {
+				$result->add_data( [ 'status' => 500 ] );
+			}
 
 			return $result;
 		}
 
-		return new WP_REST_Response( [ 'key' => $this->manager->get_key() ] );
+		$data = [
+			'key'      => $key,
+			'products' => Product_Collection::from_array( $result )->to_array(),
+		];
+
+		return new WP_REST_Response( $data );
+	}
+
+	/**
+	 * Validates a product on this domain using the stored license key.
+	 *
+	 * Calls the licensing API validate endpoint, which may consume an
+	 * activation seat. Returns the validation result.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function validate_item( $request ) {
+		/** @var string $product_slug */
+		$product_slug = $request->get_param( 'product_slug' );
+		$domain       = $this->site_data->get_domain();
+
+		$result = $this->manager->validate_product( $domain, $product_slug );
+
+		if ( is_wp_error( $result ) ) {
+			$data = $result->get_error_data();
+
+			if ( ! is_array( $data ) || empty( $data['status'] ) ) {
+				$result->add_data( [ 'status' => 500 ] );
+			}
+
+			return $result;
+		}
+
+		return new WP_REST_Response( null, 201 );
 	}
 
 	/**
 	 * Deletes the stored unified license key.
+	 *
+	 * This only removes the locally stored key. It does not free any
+	 * activation seats on the licensing service.
 	 *
 	 * @since 3.0.0
 	 *
@@ -165,7 +244,7 @@ final class License_Controller extends WP_REST_Controller {
 
 		$this->manager->delete_key( $network );
 
-		return new WP_REST_Response( [ 'deleted' => true ] );
+		return new WP_REST_Response( null, 204 );
 	}
 
 	/**
@@ -220,6 +299,24 @@ final class License_Controller extends WP_REST_Controller {
 			],
 			$this->get_network_args()
 		);
+	}
+
+	/**
+	 * Gets the argument definitions for the validate (POST) endpoint.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	private function get_validate_args(): array {
+		return [
+			'product_slug' => [
+				'description'       => __( 'The product to validate.', '%TEXTDOMAIN%' ),
+				'type'              => 'string',
+				'required'          => true,
+				'sanitize_callback' => 'sanitize_text_field',
+			],
+		];
 	}
 
 	/**

--- a/src/Uplink/API/REST/V1/License_Response.php
+++ b/src/Uplink/API/REST/V1/License_Response.php
@@ -1,0 +1,30 @@
+<?php declare( strict_types=1 );
+
+namespace StellarWP\Uplink\API\REST\V1;
+
+use StellarWP\Uplink\Licensing\Product_Collection;
+
+/**
+ * Builds the standard {key, products} response shape.
+ *
+ * @since 3.0.0
+ */
+final class License_Response {
+
+	/**
+	 * Builds the standard license response array.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string|null        $key      The license key.
+	 * @param Product_Collection $products The product collection.
+	 *
+	 * @return array{key: string|null, products: array<int, array<string, mixed>>}
+	 */
+	public static function make( ?string $key, Product_Collection $products ): array {
+		return [
+			'key'      => $key,
+			'products' => $products->to_array(),
+		];
+	}
+}

--- a/src/Uplink/API/REST/V1/Provider.php
+++ b/src/Uplink/API/REST/V1/Provider.php
@@ -2,11 +2,7 @@
 
 namespace StellarWP\Uplink\API\REST\V1;
 
-use StellarWP\ContainerContract\ContainerInterface;
-use StellarWP\Uplink\Catalog\Catalog_Repository;
 use StellarWP\Uplink\Contracts\Abstract_Provider;
-use StellarWP\Uplink\Features\Manager;
-use StellarWP\Uplink\Licensing\License_Manager;
 use StellarWP\Uplink\Utils\Version;
 
 /**
@@ -20,26 +16,9 @@ final class Provider extends Abstract_Provider {
 	 * @inheritDoc
 	 */
 	public function register(): void {
-		$this->container->singleton(
-			Feature_Controller::class,
-			static function ( ContainerInterface $c ) {
-				return new Feature_Controller( $c->get( Manager::class ) );
-			}
-		);
-
-		$this->container->singleton(
-			License_Controller::class,
-			static function ( ContainerInterface $c ) {
-				return new License_Controller( $c->get( License_Manager::class ) );
-			}
-		);
-
-		$this->container->singleton(
-			Catalog_Controller::class,
-			static function ( ContainerInterface $c ) {
-				return new Catalog_Controller( $c->get( Catalog_Repository::class ) );
-			}
-		);
+		$this->container->singleton( Feature_Controller::class );
+		$this->container->singleton( License_Controller::class );
+		$this->container->singleton( Catalog_Controller::class );
 
 		add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
 	}

--- a/src/Uplink/Licensing/Enums/Validation_Status.php
+++ b/src/Uplink/Licensing/Enums/Validation_Status.php
@@ -184,6 +184,6 @@ final class Validation_Status {
 			self::INVALID_KEY        => Error_Code::INVALID_KEY,
 		];
 
-		return $map[ $value ] ?? Error_Code::INVALID_RESPONSE;
+		return $map[ $value ] ?? Error_Code::UNKNOWN_ERROR;
 	}
 }

--- a/src/Uplink/Licensing/Enums/Validation_Status.php
+++ b/src/Uplink/Licensing/Enums/Validation_Status.php
@@ -2,6 +2,8 @@
 
 namespace StellarWP\Uplink\Licensing\Enums;
 
+use StellarWP\Uplink\Licensing\Error_Code;
+
 /**
  * Validation status constants mirroring the v4 licensing API.
  *
@@ -134,5 +136,54 @@ final class Validation_Status {
 	 */
 	public static function is_valid( string $value ): bool {
 		return in_array( $value, self::all(), true );
+	}
+
+	/**
+	 * Returns a human-readable error message for a non-valid status.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $value The status value.
+	 *
+	 * @return string
+	 */
+	public static function message( string $value ): string {
+		$messages = [
+			self::EXPIRED            => __( 'The subscription has expired.', '%TEXTDOMAIN%' ),
+			self::SUSPENDED          => __( 'The subscription is suspended.', '%TEXTDOMAIN%' ),
+			self::CANCELLED          => __( 'The subscription is cancelled.', '%TEXTDOMAIN%' ),
+			self::LICENSE_SUSPENDED  => __( 'The license is suspended.', '%TEXTDOMAIN%' ),
+			self::LICENSE_BANNED     => __( 'The license is banned.', '%TEXTDOMAIN%' ),
+			self::NO_SUBSCRIPTION    => __( 'No subscription exists for this product.', '%TEXTDOMAIN%' ),
+			self::NOT_ACTIVATED      => __( 'The product is not activated on this domain.', '%TEXTDOMAIN%' ),
+			self::OUT_OF_ACTIVATIONS => __( 'All activation seats are in use.', '%TEXTDOMAIN%' ),
+			self::INVALID_KEY        => __( 'The license key is not recognized.', '%TEXTDOMAIN%' ),
+		];
+
+		return $messages[ $value ] ?? __( 'The license validation failed.', '%TEXTDOMAIN%' );
+	}
+
+	/**
+	 * Maps a validation status to its corresponding Error_Code constant.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $value The validation status value.
+	 *
+	 * @return string An Error_Code constant value.
+	 */
+	public static function error_code( string $value ): string {
+		$map = [
+			self::EXPIRED            => Error_Code::EXPIRED,
+			self::SUSPENDED          => Error_Code::SUSPENDED,
+			self::CANCELLED          => Error_Code::CANCELLED,
+			self::LICENSE_SUSPENDED  => Error_Code::LICENSE_SUSPENDED,
+			self::LICENSE_BANNED     => Error_Code::LICENSE_BANNED,
+			self::NO_SUBSCRIPTION    => Error_Code::NO_SUBSCRIPTION,
+			self::OUT_OF_ACTIVATIONS => Error_Code::OUT_OF_ACTIVATIONS,
+			self::INVALID_KEY        => Error_Code::INVALID_KEY,
+		];
+
+		return $map[ $value ] ?? Error_Code::INVALID_RESPONSE;
 	}
 }

--- a/src/Uplink/Licensing/Error_Code.php
+++ b/src/Uplink/Licensing/Error_Code.php
@@ -44,4 +44,103 @@ final class Error_Code {
 	 * @var string
 	 */
 	public const STORE_FAILED = 'stellarwp-uplink-store-failed';
+
+	/**
+	 * The subscription has expired.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string
+	 */
+	public const EXPIRED = 'stellarwp-uplink-expired';
+
+	/**
+	 * The subscription is suspended.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string
+	 */
+	public const SUSPENDED = 'stellarwp-uplink-suspended';
+
+	/**
+	 * The subscription is cancelled.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string
+	 */
+	public const CANCELLED = 'stellarwp-uplink-cancelled';
+
+	/**
+	 * The license is suspended (all products affected).
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string
+	 */
+	public const LICENSE_SUSPENDED = 'stellarwp-uplink-license-suspended';
+
+	/**
+	 * The license is banned (all products affected).
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string
+	 */
+	public const LICENSE_BANNED = 'stellarwp-uplink-license-banned';
+
+	/**
+	 * No subscription exists for this product under the license.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string
+	 */
+	public const NO_SUBSCRIPTION = 'stellarwp-uplink-no-subscription';
+
+	/**
+	 * All activation seats are in use.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string
+	 */
+	public const OUT_OF_ACTIVATIONS = 'stellarwp-uplink-out-of-activations';
+
+	/**
+	 * Maps an error code to its recommended HTTP status code.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $code An Error_Code constant value.
+	 *
+	 * @return int The HTTP status code (defaults to 422 for unknown codes).
+	 */
+	public static function http_status( string $code ): int {
+		/** @var array<string, int> */
+		static $map = [
+			// 400 Bad Request — the key format is invalid.
+			self::INVALID_KEY          => 400,
+
+			// 422 Unprocessable Entity — the request was understood but the
+			// license state prevents the operation from completing.
+			self::PRODUCT_NOT_FOUND    => 422,
+			self::EXPIRED              => 422,
+			self::SUSPENDED            => 422,
+			self::CANCELLED            => 422,
+			self::LICENSE_SUSPENDED    => 422,
+			self::LICENSE_BANNED       => 422,
+			self::NO_SUBSCRIPTION      => 422,
+			self::OUT_OF_ACTIVATIONS   => 422,
+
+			// 500 Internal Server Error — storage failure.
+			self::STORE_FAILED         => 500,
+
+			// 502 Bad Gateway — upstream service returned an invalid response.
+			self::INVALID_RESPONSE     => 502,
+		];
+
+		return $map[ $code ] ?? 422;
+	}
 }

--- a/src/Uplink/Licensing/Error_Code.php
+++ b/src/Uplink/Licensing/Error_Code.php
@@ -109,6 +109,15 @@ final class Error_Code {
 	public const OUT_OF_ACTIVATIONS = 'stellarwp-uplink-out-of-activations';
 
 	/**
+	 * An unexpected or unrecognized error occurred.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string
+	 */
+	public const UNKNOWN_ERROR = 'stellarwp-uplink-unknown-error';
+
+	/**
 	 * Maps an error code to its recommended HTTP status code.
 	 *
 	 * @since 3.0.0
@@ -136,6 +145,9 @@ final class Error_Code {
 
 			// 500 Internal Server Error — storage failure.
 			self::STORE_FAILED         => 500,
+
+			// 500 Internal Server Error — unexpected or unrecognized error.
+			self::UNKNOWN_ERROR        => 500,
 
 			// 502 Bad Gateway — upstream service returned an invalid response.
 			self::INVALID_RESPONSE     => 502,

--- a/src/Uplink/Licensing/Fixture_Client.php
+++ b/src/Uplink/Licensing/Fixture_Client.php
@@ -74,7 +74,8 @@ final class Fixture_Client implements Licensing_Client {
 		if ( ! file_exists( $file ) ) {
 			$this->cache[ $cache_key ] = new WP_Error(
 				Error_Code::INVALID_KEY,
-				sprintf( 'License key not recognized: %s', $key )
+				sprintf( 'License key not recognized: %s', $key ),
+				[ 'status' => Error_Code::http_status( Error_Code::INVALID_KEY ) ]
 			);
 
 			return $this->cache[ $cache_key ];
@@ -85,7 +86,8 @@ final class Fixture_Client implements Licensing_Client {
 		if ( $json === false ) {
 			$this->cache[ $cache_key ] = new WP_Error(
 				Error_Code::INVALID_RESPONSE,
-				sprintf( 'License response could not be read: %s', $file )
+				sprintf( 'License response could not be read: %s', $file ),
+				[ 'status' => Error_Code::http_status( Error_Code::INVALID_RESPONSE ) ]
 			);
 
 			return $this->cache[ $cache_key ];
@@ -96,7 +98,8 @@ final class Fixture_Client implements Licensing_Client {
 		if ( ! is_array( $data ) || ! isset( $data['products'] ) || ! is_array( $data['products'] ) ) {
 			$this->cache[ $cache_key ] = new WP_Error(
 				Error_Code::INVALID_RESPONSE,
-				sprintf( 'License response could not be decoded: %s', $file )
+				sprintf( 'License response could not be decoded: %s', $file ),
+				[ 'status' => Error_Code::http_status( Error_Code::INVALID_RESPONSE ) ]
 			);
 
 			return $this->cache[ $cache_key ];
@@ -138,7 +141,8 @@ final class Fixture_Client implements Licensing_Client {
 		if ( $entry === null ) {
 			return new WP_Error(
 				Error_Code::PRODUCT_NOT_FOUND,
-				sprintf( 'Product not found: %s', $product_slug )
+				sprintf( 'Product not found: %s', $product_slug ),
+				[ 'status' => Error_Code::http_status( Error_Code::PRODUCT_NOT_FOUND ) ]
 			);
 		}
 

--- a/src/Uplink/Licensing/License_Manager.php
+++ b/src/Uplink/Licensing/License_Manager.php
@@ -200,11 +200,7 @@ final class License_Manager {
 		}
 
 		if ( ! $result->is_valid() ) {
-			return new WP_Error(
-				$result->error_code(),
-				$result->error_message(),
-				[ 'status' => 422 ]
-			);
+			return $result->to_wp_error();
 		}
 
 		$this->fetch_and_cache( $key, $domain );
@@ -291,6 +287,43 @@ final class License_Manager {
 		$this->repository->delete_products();
 
 		return $this->fetch_and_cache( $key, $domain );
+	}
+
+	/**
+	 * Look up the products for a license key without storing anything.
+	 *
+	 * Validates the key format, calls the remote API, and returns the
+	 * product collection. Never persists the key or caches results.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $key    The license key to look up.
+	 * @param string $domain The site domain.
+	 *
+	 * @return Product_Collection|WP_Error
+	 */
+	public function lookup_products( string $key, string $domain ) {
+		if ( ! License_Key::is_valid_format( $key ) ) {
+			return new WP_Error(
+				Error_Code::INVALID_KEY,
+				__( 'The license key format is invalid.', '%TEXTDOMAIN%' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$result = $this->client->get_products( $key, $domain );
+
+		if ( is_wp_error( $result ) ) {
+			$data = $result->get_error_data();
+
+			if ( ! is_array( $data ) || empty( $data['status'] ) ) {
+				$result->add_data( [ 'status' => 500 ] );
+			}
+
+			return $result;
+		}
+
+		return Product_Collection::from_array( $result );
 	}
 
 	/**

--- a/src/Uplink/Licensing/License_Manager.php
+++ b/src/Uplink/Licensing/License_Manager.php
@@ -7,6 +7,7 @@ use StellarWP\Uplink\Licensing\Contracts\Licensing_Client;
 use StellarWP\Uplink\Licensing\Registry\Product_Registry;
 use StellarWP\Uplink\Licensing\Repositories\License_Repository;
 use StellarWP\Uplink\Licensing\Results\Product_Entry;
+use StellarWP\Uplink\Licensing\Results\Validation_Result;
 use WP_Error;
 
 /**
@@ -113,10 +114,10 @@ final class License_Manager {
 	}
 
 	/**
-	 * Validate a license key against the remote licensing API and store it on success.
+	 * Verify a license key is recognized by the remote API and store it.
 	 *
-	 * Fetches the product catalog for the given key to verify it is recognized,
-	 * primes the cache, then persists the key.
+	 * Fetches the product catalog to confirm the key exists, then persists it.
+	 * Does not activate any products or consume seats.
 	 *
 	 * @since 3.0.0
 	 *
@@ -124,13 +125,14 @@ final class License_Manager {
 	 * @param string $domain  The site domain sent to the licensing API.
 	 * @param bool   $network Whether to store at the network level (multisite only).
 	 *
-	 * @return true|WP_Error True on success, WP_Error on validation or storage failure.
+	 * @return Product_Entry[]|WP_Error The product list on success, WP_Error on failure.
 	 */
 	public function validate_and_store( string $key, string $domain, bool $network = false ) {
 		if ( ! License_Key::is_valid_format( $key ) ) {
 			return new WP_Error(
 				Error_Code::INVALID_KEY,
-				__( 'The license key format is invalid.', '%TEXTDOMAIN%' )
+				__( 'The license key format is invalid.', '%TEXTDOMAIN%' ),
+				[ 'status' => 400 ]
 			);
 		}
 
@@ -138,6 +140,12 @@ final class License_Manager {
 		$result = $this->client->get_products( $key, $domain );
 
 		if ( is_wp_error( $result ) ) {
+			$data = $result->get_error_data();
+
+			if ( ! is_array( $data ) || empty( $data['status'] ) ) {
+				$result->add_data( [ 'status' => 500 ] );
+			}
+
 			return $result;
 		}
 
@@ -146,11 +154,62 @@ final class License_Manager {
 		if ( ! $this->repository->store_key( $key, $network ) ) {
 			return new WP_Error(
 				Error_Code::STORE_FAILED,
-				__( 'The license key could not be stored.', '%TEXTDOMAIN%' )
+				__( 'The license key could not be stored.', '%TEXTDOMAIN%' ),
+				[ 'status' => 500 ]
 			);
 		}
 
-		return true;
+		return $result;
+	}
+
+	/**
+	 * Validate a product on this domain using the stored license key.
+	 *
+	 * Calls the licensing API validate endpoint to check (and potentially
+	 * consume) an activation seat for the given product. On success the
+	 * product cache is cleared so the next read reflects the new state.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $domain       The site domain.
+	 * @param string $product_slug The product to validate.
+	 *
+	 * @return Validation_Result|WP_Error
+	 */
+	public function validate_product( string $domain, string $product_slug ) {
+		$key = $this->get_key();
+
+		if ( $key === null ) {
+			return new WP_Error(
+				Error_Code::INVALID_KEY,
+				__( 'No license key is stored.', '%TEXTDOMAIN%' ),
+				[ 'status' => 422 ]
+			);
+		}
+
+		$result = $this->client->validate( $key, $domain, $product_slug );
+
+		if ( is_wp_error( $result ) ) {
+			$data = $result->get_error_data();
+
+			if ( ! is_array( $data ) || empty( $data['status'] ) ) {
+				$result->add_data( [ 'status' => 500 ] );
+			}
+
+			return $result;
+		}
+
+		if ( ! $result->is_valid() ) {
+			return new WP_Error(
+				$result->error_code(),
+				$result->error_message(),
+				[ 'status' => 422 ]
+			);
+		}
+
+		$this->fetch_and_cache( $key, $domain );
+
+		return $result;
 	}
 
 	/**
@@ -195,7 +254,8 @@ final class License_Manager {
 		if ( $key === null ) {
 			return new WP_Error(
 				Error_Code::INVALID_KEY,
-				__( 'No license key is stored.', '%TEXTDOMAIN%' )
+				__( 'No license key is stored.', '%TEXTDOMAIN%' ),
+				[ 'status' => 422 ]
 			);
 		}
 
@@ -223,7 +283,8 @@ final class License_Manager {
 		if ( $key === null ) {
 			return new WP_Error(
 				Error_Code::INVALID_KEY,
-				__( 'No license key is stored.', '%TEXTDOMAIN%' )
+				__( 'No license key is stored.', '%TEXTDOMAIN%' ),
+				[ 'status' => 422 ]
 			);
 		}
 

--- a/src/Uplink/Licensing/Results/Validation_Result.php
+++ b/src/Uplink/Licensing/Results/Validation_Result.php
@@ -3,7 +3,9 @@
 namespace StellarWP\Uplink\Licensing\Results;
 
 use StellarWP\Uplink\Licensing\Enums\Validation_Status;
+use StellarWP\Uplink\Licensing\Error_Code;
 use StellarWP\Uplink\Utils\Cast;
+use WP_Error;
 
 /**
  * The outcome of validating a license for a product on a domain.
@@ -165,38 +167,35 @@ final class Validation_Result {
 	}
 
 	/**
-	 * Returns the WP_Error code for a non-valid result.
-	 *
-	 * @since 3.0.0
-	 *
-	 * @return string An Error_Code constant value.
-	 */
-	public function error_code(): string {
-		return Validation_Status::error_code( $this->get_status() );
-	}
-
-	/**
-	 * Returns a human-readable error message for a non-valid result.
+	 * Converts a non-valid result to a WP_Error.
 	 *
 	 * Uses subscription data to provide contextual detail when available,
-	 * such as the site limit for out_of_activations.
+	 * such as the site limit for out_of_activations. Falls back to a
+	 * generic unknown error when the status has no mapping.
 	 *
 	 * @since 3.0.0
 	 *
-	 * @return string
+	 * @return WP_Error
 	 */
-	public function error_message(): string {
+	public function to_wp_error(): WP_Error {
 		$status       = $this->get_status();
+		$code         = Validation_Status::error_code( $status );
 		$subscription = $this->get_subscription();
 
 		if ( $status === Validation_Status::OUT_OF_ACTIVATIONS && $subscription !== null ) {
-			return sprintf(
+			$message = sprintf(
 				/* translators: %d: number of activation seats */
 				__( 'All %d activation seats are in use.', '%TEXTDOMAIN%' ),
 				$subscription['site_limit']
 			);
+		} else {
+			$message = Validation_Status::message( $status );
 		}
 
-		return Validation_Status::message( $status );
+		return new WP_Error(
+			$code,
+			$message,
+			[ 'status' => Error_Code::http_status( $code ) ]
+		);
 	}
 }

--- a/src/Uplink/Licensing/Results/Validation_Result.php
+++ b/src/Uplink/Licensing/Results/Validation_Result.php
@@ -163,4 +163,40 @@ final class Validation_Result {
 	public function is_valid(): bool {
 		return $this->get_status() === Validation_Status::VALID;
 	}
+
+	/**
+	 * Returns the WP_Error code for a non-valid result.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return string An Error_Code constant value.
+	 */
+	public function error_code(): string {
+		return Validation_Status::error_code( $this->get_status() );
+	}
+
+	/**
+	 * Returns a human-readable error message for a non-valid result.
+	 *
+	 * Uses subscription data to provide contextual detail when available,
+	 * such as the site limit for out_of_activations.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return string
+	 */
+	public function error_message(): string {
+		$status       = $this->get_status();
+		$subscription = $this->get_subscription();
+
+		if ( $status === Validation_Status::OUT_OF_ACTIVATIONS && $subscription !== null ) {
+			return sprintf(
+				/* translators: %d: number of activation seats */
+				__( 'All %d activation seats are in use.', '%TEXTDOMAIN%' ),
+				$subscription['site_limit']
+			);
+		}
+
+		return Validation_Status::message( $status );
+	}
 }

--- a/tests/wpunit/API/REST/V1/License_ControllerTest.php
+++ b/tests/wpunit/API/REST/V1/License_ControllerTest.php
@@ -185,7 +185,7 @@ final class License_ControllerTest extends UplinkTestCase {
 	// POST /license/validate
 	// -------------------------------------------------------------------------
 
-	public function test_validate_returns_201_on_success(): void {
+	public function test_validate_returns_key_and_products_on_success(): void {
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 
 		$this->manager->store_key( 'LWSW-UNIFIED-PRO-2026' );
@@ -194,9 +194,12 @@ final class License_ControllerTest extends UplinkTestCase {
 		$request->set_param( 'product_slug', 'give' );
 
 		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
 
-		$this->assertSame( 201, $response->get_status() );
-		$this->assertNull( $response->get_data() );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'LWSW-UNIFIED-PRO-2026', $data['key'] );
+		$this->assertIsArray( $data['products'] );
+		$this->assertNotEmpty( $data['products'] );
 	}
 
 	public function test_validate_requires_product_slug(): void {
@@ -275,12 +278,16 @@ final class License_ControllerTest extends UplinkTestCase {
 	// Schema
 	// -------------------------------------------------------------------------
 
-	public function test_schema_has_key_property(): void {
+	public function test_schema_has_key_and_products_properties(): void {
 		$controller = new License_Controller( $this->manager, new Data() );
 		$schema     = $controller->get_item_schema();
 
 		$this->assertArrayHasKey( 'properties', $schema );
 		$this->assertArrayHasKey( 'key', $schema['properties'] );
+		$this->assertArrayHasKey( 'products', $schema['properties'] );
+		$this->assertSame( 'array', $schema['properties']['products']['type'] );
+		$this->assertArrayHasKey( 'product_slug', $schema['properties']['products']['items']['properties'] );
+		$this->assertArrayHasKey( 'activations', $schema['properties']['products']['items']['properties'] );
 	}
 
 	public function test_store_rejects_key_not_recognized_by_api(): void {
@@ -303,6 +310,60 @@ final class License_ControllerTest extends UplinkTestCase {
 		$this->server->dispatch( $request );
 
 		$this->assertEmpty( get_option( License_Repository::KEY_OPTION_NAME ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// GET /license/{key}
+	// -------------------------------------------------------------------------
+
+	public function test_lookup_returns_key_and_products(): void {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$request  = new WP_REST_Request( 'GET', '/stellarwp/uplink/v1/license/LWSW-UNIFIED-PRO-2026' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'LWSW-UNIFIED-PRO-2026', $data['key'] );
+		$this->assertIsArray( $data['products'] );
+		$this->assertNotEmpty( $data['products'] );
+		$this->assertArrayHasKey( 'product_slug', $data['products'][0] );
+	}
+
+	public function test_lookup_rejects_invalid_key_format(): void {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$request  = new WP_REST_Request( 'GET', '/stellarwp/uplink/v1/license/INVALID-KEY-NO-PREFIX' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	public function test_lookup_returns_error_for_unrecognized_key(): void {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$request  = new WP_REST_Request( 'GET', '/stellarwp/uplink/v1/license/LWSW-NOT-A-REAL-KEY' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	public function test_lookup_does_not_store_key(): void {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$request = new WP_REST_Request( 'GET', '/stellarwp/uplink/v1/license/LWSW-UNIFIED-PRO-2026' );
+		$this->server->dispatch( $request );
+
+		$this->assertEmpty( get_option( License_Repository::KEY_OPTION_NAME ) );
+	}
+
+	public function test_lookup_requires_manage_options(): void {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );
+
+		$request  = new WP_REST_Request( 'GET', '/stellarwp/uplink/v1/license/LWSW-UNIFIED-PRO-2026' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
 	}
 
 	// -------------------------------------------------------------------------

--- a/tests/wpunit/API/REST/V1/License_ControllerTest.php
+++ b/tests/wpunit/API/REST/V1/License_ControllerTest.php
@@ -8,6 +8,7 @@ use StellarWP\Uplink\Licensing\License_Manager;
 use StellarWP\Uplink\Licensing\Registry\Product_Registry;
 use StellarWP\Uplink\Licensing\Repositories\License_Repository;
 use StellarWP\Uplink\API\REST\V1\License_Controller;
+use StellarWP\Uplink\Site\Data;
 use StellarWP\Uplink\Tests\Traits\With_Uopz;
 use StellarWP\Uplink\Tests\UplinkTestCase;
 use WP_REST_Request;
@@ -47,7 +48,7 @@ final class License_ControllerTest extends UplinkTestCase {
 			true
 		);
 
-		$controller = new License_Controller( $this->manager );
+		$controller = new License_Controller( $this->manager, new Data() );
 		$controller->register_routes();
 	}
 
@@ -73,6 +74,7 @@ final class License_ControllerTest extends UplinkTestCase {
 
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertNull( $response->get_data()['key'] );
+		$this->assertSame( [], $response->get_data()['products'] );
 	}
 
 	public function test_get_returns_stored_key(): void {
@@ -85,6 +87,21 @@ final class License_ControllerTest extends UplinkTestCase {
 
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( 'LWSW-UNIFIED-PRO-2026', $response->get_data()['key'] );
+	}
+
+	public function test_get_returns_products_array(): void {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$this->manager->store_key( 'LWSW-UNIFIED-PRO-2026' );
+
+		$request  = new WP_REST_Request( 'GET', '/stellarwp/uplink/v1/license' );
+		$response = $this->server->dispatch( $request );
+
+		$products = $response->get_data()['products'];
+
+		$this->assertIsArray( $products );
+		$this->assertNotEmpty( $products );
+		$this->assertArrayHasKey( 'product_slug', $products[0] );
 	}
 
 	public function test_get_requires_manage_options(): void {
@@ -106,7 +123,7 @@ final class License_ControllerTest extends UplinkTestCase {
 	}
 
 	// -------------------------------------------------------------------------
-	// POST
+	// POST /license
 	// -------------------------------------------------------------------------
 
 	public function test_store_saves_key_and_returns_it(): void {
@@ -116,9 +133,10 @@ final class License_ControllerTest extends UplinkTestCase {
 		$request->set_param( 'key', 'LWSW-UNIFIED-PRO-2026' );
 
 		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
 
 		$this->assertSame( 200, $response->get_status() );
-		$this->assertSame( 'LWSW-UNIFIED-PRO-2026', $response->get_data()['key'] );
+		$this->assertSame( 'LWSW-UNIFIED-PRO-2026', $data['key'] );
 	}
 
 	public function test_store_persists_to_options(): void {
@@ -164,6 +182,70 @@ final class License_ControllerTest extends UplinkTestCase {
 	}
 
 	// -------------------------------------------------------------------------
+	// POST /license/validate
+	// -------------------------------------------------------------------------
+
+	public function test_validate_returns_201_on_success(): void {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$this->manager->store_key( 'LWSW-UNIFIED-PRO-2026' );
+
+		$request = new WP_REST_Request( 'POST', '/stellarwp/uplink/v1/license/validate' );
+		$request->set_param( 'product_slug', 'give' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertNull( $response->get_data() );
+	}
+
+	public function test_validate_requires_product_slug(): void {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$this->manager->store_key( 'LWSW-UNIFIED-PRO-2026' );
+
+		$request  = new WP_REST_Request( 'POST', '/stellarwp/uplink/v1/license/validate' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	public function test_validate_returns_error_when_no_key_stored(): void {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$request = new WP_REST_Request( 'POST', '/stellarwp/uplink/v1/license/validate' );
+		$request->set_param( 'product_slug', 'give' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 422, $response->get_status() );
+	}
+
+	public function test_validate_returns_error_for_unknown_product(): void {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$this->manager->store_key( 'LWSW-UNIFIED-PRO-2026' );
+
+		$request = new WP_REST_Request( 'POST', '/stellarwp/uplink/v1/license/validate' );
+		$request->set_param( 'product_slug', 'unknown-product' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 422, $response->get_status() );
+	}
+
+	public function test_validate_requires_manage_options(): void {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );
+
+		$request = new WP_REST_Request( 'POST', '/stellarwp/uplink/v1/license/validate' );
+		$request->set_param( 'product_slug', 'give' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	// -------------------------------------------------------------------------
 	// DELETE
 	// -------------------------------------------------------------------------
 
@@ -175,8 +257,8 @@ final class License_ControllerTest extends UplinkTestCase {
 		$request  = new WP_REST_Request( 'DELETE', '/stellarwp/uplink/v1/license' );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertSame( 200, $response->get_status() );
-		$this->assertTrue( $response->get_data()['deleted'] );
+		$this->assertSame( 204, $response->get_status() );
+		$this->assertNull( $response->get_data() );
 		$this->assertNull( $this->manager->get_key() );
 	}
 
@@ -194,7 +276,7 @@ final class License_ControllerTest extends UplinkTestCase {
 	// -------------------------------------------------------------------------
 
 	public function test_schema_has_key_property(): void {
-		$controller = new License_Controller( $this->manager );
+		$controller = new License_Controller( $this->manager, new Data() );
 		$schema     = $controller->get_item_schema();
 
 		$this->assertArrayHasKey( 'properties', $schema );
@@ -209,7 +291,7 @@ final class License_ControllerTest extends UplinkTestCase {
 
 		$response = $this->server->dispatch( $request );
 
-		$this->assertSame( 422, $response->get_status() );
+		$this->assertSame( 400, $response->get_status() );
 	}
 
 	public function test_store_does_not_persist_key_not_recognized_by_api(): void {

--- a/tests/wpunit/Licensing/License_ManagerTest.php
+++ b/tests/wpunit/Licensing/License_ManagerTest.php
@@ -272,11 +272,11 @@ final class License_ManagerTest extends UplinkTestCase {
 	public function test_validate_product_refreshes_product_cache(): void {
 		$this->manager->store_key( 'LWSW-UNIFIED-PRO-2026' );
 		$this->manager->get_products( 'example.com' );
-		$this->assertNotFalse( get_transient( License_Repository::PRODUCTS_TRANSIENT_KEY ) );
+		$this->assertNotEmpty( get_option( License_Repository::PRODUCTS_STATE_OPTION_NAME ) );
 
 		$this->manager->validate_product( 'example.com', 'give' );
 
-		$this->assertNotFalse( get_transient( License_Repository::PRODUCTS_TRANSIENT_KEY ) );
+		$this->assertNotEmpty( get_option( License_Repository::PRODUCTS_STATE_OPTION_NAME ) );
 	}
 
 	public function test_validate_product_returns_error_when_no_key_stored(): void {

--- a/tests/wpunit/Licensing/License_ManagerTest.php
+++ b/tests/wpunit/Licensing/License_ManagerTest.php
@@ -2,12 +2,14 @@
 
 namespace StellarWP\Uplink\Tests\Licensing;
 
+use StellarWP\Uplink\Licensing\Enums\Validation_Status;
 use StellarWP\Uplink\Licensing\Error_Code;
 use StellarWP\Uplink\Licensing\Fixture_Client;
 use StellarWP\Uplink\Licensing\License_Manager;
 use StellarWP\Uplink\Licensing\Product_Collection;
 use StellarWP\Uplink\Licensing\Registry\Product_Registry;
 use StellarWP\Uplink\Licensing\Repositories\License_Repository;
+use StellarWP\Uplink\Licensing\Results\Validation_Result;
 use StellarWP\Uplink\Tests\UplinkTestCase;
 use WP_Error;
 
@@ -199,10 +201,11 @@ final class License_ManagerTest extends UplinkTestCase {
 	// validate_and_store()
 	// -------------------------------------------------------------------------
 
-	public function test_validate_and_store_returns_true_for_recognized_key(): void {
+	public function test_validate_and_store_returns_products_for_recognized_key(): void {
 		$result = $this->manager->validate_and_store( 'LWSW-UNIFIED-PRO-2026', 'example.com' );
 
-		$this->assertTrue( $result );
+		$this->assertIsArray( $result );
+		$this->assertNotEmpty( $result );
 	}
 
 	public function test_validate_and_store_persists_key_on_success(): void {
@@ -229,6 +232,67 @@ final class License_ManagerTest extends UplinkTestCase {
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( Error_Code::INVALID_KEY, $result->get_error_code() );
+	}
+
+	// -------------------------------------------------------------------------
+	// validate_product()
+	// -------------------------------------------------------------------------
+
+	public function test_validate_product_returns_validation_result(): void {
+		$this->manager->store_key( 'LWSW-UNIFIED-PRO-2026' );
+
+		$result = $this->manager->validate_product( 'example.com', 'give' );
+
+		$this->assertInstanceOf( Validation_Result::class, $result );
+	}
+
+	public function test_validate_product_result_has_expected_status(): void {
+		$this->manager->store_key( 'LWSW-UNIFIED-PRO-2026' );
+
+		/** @var Validation_Result $result */
+		$result = $this->manager->validate_product( 'example.com', 'give' );
+
+		$this->assertSame( Validation_Status::VALID, $result->get_status() );
+		$this->assertTrue( $result->is_valid() );
+	}
+
+	public function test_validate_product_result_contains_subscription_data(): void {
+		$this->manager->store_key( 'LWSW-UNIFIED-PRO-2026' );
+
+		/** @var Validation_Result $result */
+		$result = $this->manager->validate_product( 'example.com', 'give' );
+
+		$subscription = $result->get_subscription();
+
+		$this->assertNotNull( $subscription );
+		$this->assertSame( 'give', $subscription['product_slug'] );
+		$this->assertSame( 'give-pro', $subscription['tier'] );
+	}
+
+	public function test_validate_product_refreshes_product_cache(): void {
+		$this->manager->store_key( 'LWSW-UNIFIED-PRO-2026' );
+		$this->manager->get_products( 'example.com' );
+		$this->assertNotFalse( get_transient( License_Repository::PRODUCTS_TRANSIENT_KEY ) );
+
+		$this->manager->validate_product( 'example.com', 'give' );
+
+		$this->assertNotFalse( get_transient( License_Repository::PRODUCTS_TRANSIENT_KEY ) );
+	}
+
+	public function test_validate_product_returns_error_when_no_key_stored(): void {
+		$result = $this->manager->validate_product( 'example.com', 'give' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( Error_Code::INVALID_KEY, $result->get_error_code() );
+	}
+
+	public function test_validate_product_returns_error_for_unknown_product(): void {
+		$this->manager->store_key( 'LWSW-UNIFIED-PRO-2026' );
+
+		$result = $this->manager->validate_product( 'example.com', 'unknown-product' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( Error_Code::PRODUCT_NOT_FOUND, $result->get_error_code() );
 	}
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The licensing REST endpoint now fully supports product validation, proper error semantics, and multisite-aware domain resolution.

Previously the `POST /license` endpoint only stored a key and returned it. Now it validates the key against the remote API before storing, returns the licensed product catalog on success, and rejects unrecognized keys with structured errors.

A new `POST /license/validate` endpoint activates a product on the current domain, consuming a seat only when the validation status is valid. Non-valid statuses (expired, suspended, out of activations, etc.) are returned as `WP_Error` responses with appropriate HTTP status codes rather than successful `200` responses with embedded failure data.

The controller now uses `Site\Data` for multisite-aware domain resolution instead of raw `wp_parse_url(get_site_url())`, and the REST provider uses container auto-wiring instead of explicit factory closures.

## Major changes

  - `POST /license/validate` endpoint - New endpoint that calls the licensing API validate endpoint for a specific product.
  - `POST /license `returns product catalog - `validate_and_store()` now returns the product list from the API on success, giving the frontend the full catalog in a single round-trip.
  - `GET /license` returns products - Response now includes both the key and the associated product catalog.
  - `DELETE /license` returns 204 - Returns null body with `204` status instead of `{ deleted: true }`.
  - `Validation_Status` error mapping - Added `message()` and `error_code()` methods to `Validation_Status` enum. Each status maps to a namespaced `Error_Code` constant (e.g. `stellarwp-uplink-expired`) and a human-readable message.
  - `Validation_Result` error helpers - Added `error_code()` and `error_message()` to `Validation_Result`. The `out_of_activations` message uses the subscription's `site_limit` for contextual detail.
  - `Error_Code` HTTP status mapping - Added `http_status()` to Licensing `Error_Code`, mapping each code to its recommended HTTP status.
  - Manager owns error statuses - All `WP_Error` instances created by `License_Manager` include `['status' => N]` in their data. Client errors that bubble up without a status default to `500`. The controller forwards whatever status the manager set.
  - Provider auto-wiring - REST provider singletons use container auto-wiring instead of explicit factory closures.
  
Fixes [SCON-304].

[SCON-304]: https://stellarwp.atlassian.net/browse/SCON-304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ