### PR TITLE
Refactor: store licensing product state option

### DIFF
--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -111,17 +111,18 @@ The unified key is stored in a WordPress option (`stellarwp_uplink_unified_licen
 
 ### License State Storage
 
-The full product catalog and related metadata are stored in a WordPress option (`stellarwp_uplink_licensing_products_state`) as a state envelope with three keys:
+The full product catalog and related metadata are stored in a WordPress option (`stellarwp_uplink_licensing_products_state`) as a state envelope with four keys:
 
-| Key               | Type                | Description                                                                                 |
-| ----------------- | ------------------- | ------------------------------------------------------------------------------------------- |
-| `collection`      | `array&#124;null`   | `Product_Collection::to_array()` from the last successful fetch, or `null` if never fetched |
-| `last_success_at` | `int&#124;null`     | Unix timestamp of the last successful fetch                                                 |
-| `last_error`      | `WP_Error&#124;null`| Error from the most recent failed attempt, or `null` if the last fetch succeeded            |
+| Key                | Type                 | Description                                                                                 |
+| ------------------ | -------------------- | ------------------------------------------------------------------------------------------- |
+| `collection`       | `array&#124;null`    | `Product_Collection::to_array()` from the last successful fetch, or `null` if never fetched |
+| `last_success_at`  | `int&#124;null`      | Unix timestamp of the last successful fetch                                                 |
+| `last_failure_at`  | `int&#124;null`      | Unix timestamp of the most recent failed fetch, or `null` if no failure has occurred        |
+| `last_error`       | `WP_Error&#124;null` | Error from the most recent failed attempt, or `null` if the last fetch succeeded            |
 
 Unlike a transient, this option has no TTL — product data persists indefinitely. Re-validation frequency (how often the API is called to refresh) is a separate concern from data persistence.
 
-On a successful fetch, `collection` and `last_success_at` are updated and `last_error` is cleared. On a failed fetch, only `last_error` is updated; the existing `collection` and `last_success_at` are preserved so the last known-good catalog remains available even when the licensing server is unreachable.
+On a successful fetch, `collection` and `last_success_at` are updated and `last_error` is cleared. `last_failure_at` is not touched so callers can always see when the last failure occurred. On a failed fetch, `last_error` and `last_failure_at` are updated; the existing `collection` and `last_success_at` are preserved so the last known-good catalog remains available even when the licensing server is unreachable.
 
 Since there is only one unified key per site, there is only one state entry. Invalidation is simple: `delete_products()` removes the option entirely, causing the next read to return `null` and trigger a fresh API call.
 
@@ -212,7 +213,7 @@ License_Manager::get_products($key, $domain)
 ├─ if only last_error present → return WP_Error
 ├─ if null → Licensing_Client::get_products()
 │  ├─ on success → update collection + last_success_at, clear last_error
-│  └─ on failure → update last_error only, preserve existing collection
+│  └─ on failure → update last_error + last_failure_at, preserve existing collection
 └─ return Product_Collection|WP_Error
 ```
 

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -113,11 +113,11 @@ The unified key is stored in a WordPress option (`stellarwp_uplink_unified_licen
 
 The full product catalog and related metadata are stored in a WordPress option (`stellarwp_uplink_licensing_products_state`) as a state envelope with three keys:
 
-| Key              | Type             | Description                                                  |
-| ---------------- | ---------------- | ------------------------------------------------------------ |
-| `collection`     | `array\|null`    | `Product_Collection::to_array()` from the last successful fetch, or `null` if never fetched |
-| `last_success_at`| `int\|null`      | Unix timestamp of the last successful fetch                  |
-| `last_error`     | `WP_Error\|null` | Error from the most recent failed attempt, or `null` if the last fetch succeeded |
+| Key               | Type                | Description                                                                                 |
+| ----------------- | ------------------- | ------------------------------------------------------------------------------------------- |
+| `collection`      | `array&#124;null`   | `Product_Collection::to_array()` from the last successful fetch, or `null` if never fetched |
+| `last_success_at` | `int&#124;null`     | Unix timestamp of the last successful fetch                                                 |
+| `last_error`      | `WP_Error&#124;null`| Error from the most recent failed attempt, or `null` if the last fetch succeeded            |
 
 Unlike a transient, this option has no TTL — product data persists indefinitely. Re-validation frequency (how often the API is called to refresh) is a separate concern from data persistence.
 
@@ -129,13 +129,13 @@ Since there is only one unified key per site, there is only one state entry. Inv
 
 Products opt into unified licensing by declaring themselves through a WordPress filter (`stellarwp/uplink/product_registry`). Each product contributes:
 
-| Field          | Required | Description                                         |
-| -------------- | -------- | --------------------------------------------------- |
-| `slug`         | Yes      | Product identifier, must match what Licensing knows |
-| `embedded_key` | No       | `LWSW-`-prefixed key if the product ships with one  |
-| `name`         | No       | Human-readable display name                         |
-| `version`      | No       | Currently installed version                         |
-| `group`        | No       | Product brand/family (e.g., `givewp`, `kadence`)    |
+| Field           | Required | Description                                         |
+| --------------- | -------- | --------------------------------------------------- |
+| `slug`          | Yes      | Product identifier, must match what Licensing knows |
+| `embedded_key`  | No       | `LWSW-`-prefixed key if the product ships with one  |
+| `name`          | No       | Human-readable display name                         |
+| `version`       | No       | Currently installed version                         |
+| `group`         | No       | Product brand/family (e.g., `givewp`, `kadence`)    |
 
 Only `slug` is required. Products do not declare their tier. Tiers are a property of the license, not the product.
 

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -4,7 +4,7 @@
 
 The Licensing subsystem is how a WordPress site learns what a unified license key covers. The site presents its `LWSW-`-prefixed key to the Licensing API, and the API returns which products are entitled, what tier each is on, and whether seats are available. The site stores this response and uses it as the source of truth for all entitlement decisions.
 
-This document describes the data the site gets from Licensing, how it stores and caches that data, and the workflows that drive key discovery and validation.
+This document describes the data the site gets from Licensing, how it stores that data, and the workflows that drive key discovery and validation.
 
 > **Development status.** The architectural patterns here (key discovery, caching, repository structure) are stable. The upstream API is not. The current implementation targets a v4 Licensing API that is still in development. If v4 does not ship in time or does not meet our needs, we may fall back to the existing v3 Licensing API. The v3 API is already plugin/theme-aware and gives us most of the entitlement data we need, though it lacks some catalog-style information like upsell data. Specific data shapes, tier slugs, and response formats are all subject to change. Fixture data in `tests/_data/licensing/` reflects our current working assumptions, not a finalized spec.
 
@@ -103,19 +103,27 @@ The `Validation_Status` enum covers every state a product can be in:
 | `out_of_activations` | All seats are consumed                                |
 | `invalid_key`        | Key is not recognized                                 |
 
-## Caching and Storage
+## Storage
 
 ### Key Storage
 
 The unified key is stored in a WordPress option (`stellarwp_uplink_unified_license_key`). The `License_Repository` handles reads and writes, including multisite-aware lookups.
 
-### Product Catalog Cache
+### License State Storage
 
-The full product catalog response is cached in a WordPress transient (`stellarwp_uplink_licensing_products`) with a 12-hour TTL. The `Product_Repository` manages this cache transparently. Callers use `get()` and never touch the client directly.
+The full product catalog and related metadata are stored in a WordPress option (`stellarwp_uplink_licensing_products_state`) as a state envelope with three keys:
 
-Since there's only one unified key per site, there's only one cache entry. Cache invalidation is simple: `refresh()` deletes the transient and re-fetches.
+| Key              | Type             | Description                                                  |
+| ---------------- | ---------------- | ------------------------------------------------------------ |
+| `collection`     | `array\|null`    | `Product_Collection::to_array()` from the last successful fetch, or `null` if never fetched |
+| `last_success_at`| `int\|null`      | Unix timestamp of the last successful fetch                  |
+| `last_error`     | `WP_Error\|null` | Error from the most recent failed attempt, or `null` if the last fetch succeeded |
 
-Both successful responses and errors are cached. If the API returns an error, the error is stored for the full TTL so the site doesn't hammer the API on repeated failures.
+Unlike a transient, this option has no TTL — product data persists indefinitely. Re-validation frequency (how often the API is called to refresh) is a separate concern from data persistence.
+
+On a successful fetch, `collection` and `last_success_at` are updated and `last_error` is cleared. On a failed fetch, only `last_error` is updated; the existing `collection` and `last_success_at` are preserved so the last known-good catalog remains available even when the licensing server is unreachable.
+
+Since there is only one unified key per site, there is only one state entry. Invalidation is simple: `delete_products()` removes the option entirely, causing the next read to return `null` and trigger a fresh API call.
 
 ## Product Registry
 
@@ -185,10 +193,10 @@ License_Manager::get()
 ```
 License_Manager::validate_and_store($key, $domain)
 ├─ validate LWSW- prefix format
-├─ Product_Repository::get($key, $domain)
-│  ├─ check transient cache
+├─ License_Manager::get_products($key, $domain)
+│  ├─ check license state option (collection key)
 │  ├─ if miss → Licensing_Client::get_products()
-│  └─ cache response (12hr TTL)
+│  └─ persist result to license state option
 ├─ if API error → return WP_Error
 ├─ License_Repository::store($key)
 └─ return true
@@ -197,11 +205,14 @@ License_Manager::validate_and_store($key, $domain)
 ### Periodic Status Check
 
 ```
-Product_Repository::get($key, $domain)
-├─ check transient cache
-├─ if hit → return cached Product_Collection
-├─ if miss → Licensing_Client::get_products()
-├─ cache result (success or error, 12hr TTL)
+License_Manager::get_products($key, $domain)
+├─ License_Repository::get_products()
+│  └─ read license state option
+├─ if collection present → return Product_Collection
+├─ if only last_error present → return WP_Error
+├─ if null → Licensing_Client::get_products()
+│  ├─ on success → update collection + last_success_at, clear last_error
+│  └─ on failure → update last_error only, preserve existing collection
 └─ return Product_Collection|WP_Error
 ```
 

--- a/src/Uplink/Licensing/Repositories/License_Repository.php
+++ b/src/Uplink/Licensing/Repositories/License_Repository.php
@@ -58,6 +58,8 @@ final class License_Repository {
 	 *
 	 * Stored as an associative array keyed by product slug.
 	 *
+	 *  TODO: Decide where to store this data. See discussion in https://github.com/stellarwp/uplink/pull/162/changes#r2906722318
+	 *
 	 * @since 3.0.0
 	 *
 	 * @var string

--- a/src/Uplink/Licensing/Repositories/License_Repository.php
+++ b/src/Uplink/Licensing/Repositories/License_Repository.php
@@ -40,12 +40,14 @@ final class License_Repository {
 	/**
 	 * Option name for the license state envelope.
 	 *
-	 * Stores an associative array with three keys:
-	 *   - collection     (array|null)    Product_Collection::to_array() from the last
-	 *                                    successful API fetch, or null if never fetched.
-	 *   - last_success_at (int|null)     Unix timestamp of the last successful fetch.
+	 * Stores an associative array with four keys:
+	 *   - collection      (array|null)     Product_Collection::to_array() from the last
+	 *                                     successful API fetch, or null if never fetched.
+	 *   - last_success_at (int|null)      Unix timestamp of the last successful fetch.
+	 *   - last_failure_at (int|null)      Unix timestamp of the most recent failed fetch,
+	 *                                     or null if no failure has occurred.
 	 *   - last_error      (WP_Error|null) Error from the most recent failed attempt, or
-	 *                                    null when the last fetch succeeded.
+	 *                                     null when the last fetch succeeded.
 	 *
 	 * @since 3.0.0
 	 *
@@ -260,8 +262,9 @@ final class License_Repository {
 		}
 
 		if ( is_wp_error( $data ) ) {
-			$state               = $this->read_products_state();
-			$state['last_error'] = $data;
+			$state                    = $this->read_products_state();
+			$state['last_error']      = $data;
+			$state['last_failure_at'] = time();
 			update_option( self::PRODUCTS_STATE_OPTION_NAME, $state, false );
 		}
 	}
@@ -291,6 +294,20 @@ final class License_Repository {
 	}
 
 	/**
+	 * Unix timestamp of the most recent failed products fetch, or null if no
+	 * failure has occurred.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return int|null
+	 */
+	public function get_products_last_failure_at(): ?int {
+		$value = $this->read_products_state()['last_failure_at'];
+
+		return is_int( $value ) ? $value : null;
+	}
+
+	/**
 	 * WP_Error from the most recent failed fetch attempt, or null if the last
 	 * fetch was successful (or no fetch has occurred).
 	 *
@@ -310,7 +327,7 @@ final class License_Repository {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @return array{collection: array<array<string,mixed>>|null, last_success_at: int|null, last_error: WP_Error|null}
+	 * @return array{collection: array<array<string,mixed>>|null, last_success_at: int|null, last_failure_at: int|null, last_error: WP_Error|null}
 	 */
 	private function read_products_state(): array {
 		$raw = get_option( self::PRODUCTS_STATE_OPTION_NAME, null );
@@ -319,6 +336,7 @@ final class License_Repository {
 			return [
 				'collection'      => null,
 				'last_success_at' => null,
+				'last_failure_at' => null,
 				'last_error'      => null,
 			];
 		}
@@ -330,11 +348,13 @@ final class License_Repository {
 		}
 
 		$last_success_at = isset( $raw['last_success_at'] ) && is_int( $raw['last_success_at'] ) ? $raw['last_success_at'] : null;
+		$last_failure_at = isset( $raw['last_failure_at'] ) && is_int( $raw['last_failure_at'] ) ? $raw['last_failure_at'] : null;
 		$last_error      = isset( $raw['last_error'] ) && $raw['last_error'] instanceof WP_Error ? $raw['last_error'] : null;
 
 		return [
 			'collection'      => $collection,
 			'last_success_at' => $last_success_at,
+			'last_failure_at' => $last_failure_at,
 			'last_error'      => $last_error,
 		];
 	}

--- a/src/Uplink/Licensing/Repositories/License_Repository.php
+++ b/src/Uplink/Licensing/Repositories/License_Repository.php
@@ -12,7 +12,9 @@ use WP_Error;
  *
  * Covers two storage layers:
  *   - WordPress options: the unified license key (single key per site).
- *   - WordPress transients: the product catalog cache (keyed by a fixed name).
+ *   - WordPress options: the license state (last successful products, fetch
+ *     timestamp, last error). Stored without a TTL so product data survives
+ *     indefinitely even when the licensing server is unreachable.
  *
  * This class is a pure data-access layer — it only reads from and writes to
  * WordPress storage. It never calls external APIs or applies business logic.
@@ -36,35 +38,31 @@ final class License_Repository {
 	public const KEY_OPTION_NAME = 'stellarwp_uplink_unified_license_key';
 
 	/**
-	 * Transient key for the cached product catalog.
+	 * Option name for the license state envelope.
+	 *
+	 * Stores an associative array with three keys:
+	 *   - collection     (array|null)    Product_Collection::to_array() from the last
+	 *                                    successful API fetch, or null if never fetched.
+	 *   - last_success_at (int|null)     Unix timestamp of the last successful fetch.
+	 *   - last_error      (WP_Error|null) Error from the most recent failed attempt, or
+	 *                                    null when the last fetch succeeded.
 	 *
 	 * @since 3.0.0
 	 *
 	 * @var string
 	 */
-	public const PRODUCTS_TRANSIENT_KEY = 'stellarwp_uplink_licensing_products';
+	public const PRODUCTS_STATE_OPTION_NAME = 'stellarwp_uplink_licensing_products_state';
 
 	/**
 	 * Option name for the map of per-product last-active timestamps.
 	 *
 	 * Stored as an associative array keyed by product slug.
 	 *
-	 * TODO: Decide where to store this data. See discussion in https://github.com/stellarwp/uplink/pull/162/changes#r2906722318
-	 *
 	 * @since 3.0.0
 	 *
 	 * @var string
 	 */
 	public const PRODUCTS_LAST_ACTIVE_DATES_OPTION_NAME = 'stellarwp_uplink_licensing_products_last_active_dates';
-
-	/**
-	 * Default cache duration in seconds (12 hours).
-	 *
-	 * @since 3.0.0
-	 *
-	 * @var int
-	 */
-	public const CACHE_DURATION = HOUR_IN_SECONDS * 12;
 
 	/**
 	 * Get the stored unified license key.
@@ -204,61 +202,139 @@ final class License_Repository {
 	}
 
 	/**
-	 * Read the cached product catalog from the transient.
+	 * Read the stored license state and return the products portion.
 	 *
-	 * Returns null when no catalog has been cached yet. Use
-	 * License_Manager::get_products() for a call that will fetch from the
-	 * API on a cache miss.
+	 * When a successful product catalog has been stored, it is returned even if
+	 * a subsequent fetch failed. When no catalog exists but a previous error was
+	 * recorded, that WP_Error is returned so callers can surface it. Returns
+	 * null when nothing has been stored yet.
+	 *
+	 * Use License_Manager::get_products() for a call that will fetch from the
+	 * API on a miss.
 	 *
 	 * @since 3.0.0
 	 *
-	 * @return Product_Collection|WP_Error|null Cached value, WP_Error on error, or null on miss.
+	 * @return Product_Collection|WP_Error|null
 	 */
 	public function get_products() {
-		$products = get_transient( self::PRODUCTS_TRANSIENT_KEY );
+		$state = $this->read_products_state();
 
-		if ( is_wp_error( $products ) ) {
-			return $products;
+		if ( is_array( $state['collection'] ) ) {
+			return Product_Collection::from_array( $state['collection'] );
 		}
 
-		if ( is_array( $products ) ) {
-			/** @var array<array<string, mixed>> $products */
-			return Product_Collection::from_array( $products );
+		if ( $state['last_error'] instanceof WP_Error ) {
+			return $state['last_error'];
 		}
 
 		return null;
 	}
 
 	/**
-	 * Write the product catalog to the transient cache.
+	 * Persist the product catalog or a fetch error to the license state option.
+	 *
+	 * On success (Product_Collection): updates collection and last_success_at,
+	 * clears last_error.
+	 *
+	 * On failure (WP_Error): stores last_error only. The existing collection and
+	 * last_success_at are preserved so callers can still use the last known-good
+	 * catalog.
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param Product_Collection|WP_Error $data The catalog data to cache.
+	 * @param Product_Collection|WP_Error $data
 	 *
 	 * @return void
 	 */
 	public function set_products( $data ): void {
 		if ( $data instanceof Product_Collection ) {
-			set_transient( self::PRODUCTS_TRANSIENT_KEY, $data->to_array(), self::CACHE_DURATION );
+			$state                    = $this->read_products_state();
+			$state['collection']      = $data->to_array();
+			$state['last_success_at'] = time();
+			$state['last_error']      = null;
+			update_option( self::PRODUCTS_STATE_OPTION_NAME, $state, false );
 
 			return;
 		}
 
 		if ( is_wp_error( $data ) ) {
-			set_transient( self::PRODUCTS_TRANSIENT_KEY, $data, self::CACHE_DURATION );
+			$state               = $this->read_products_state();
+			$state['last_error'] = $data;
+			update_option( self::PRODUCTS_STATE_OPTION_NAME, $state, false );
 		}
 	}
 
 	/**
-	 * Delete the cached product catalog.
+	 * Delete the entire license state option.
 	 *
 	 * @since 3.0.0
 	 *
 	 * @return void
 	 */
 	public function delete_products(): void {
-		delete_transient( self::PRODUCTS_TRANSIENT_KEY );
+		delete_option( self::PRODUCTS_STATE_OPTION_NAME );
+	}
+
+	/**
+	 * Unix timestamp of the last successful products fetch, or null if never fetched.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return int|null
+	 */
+	public function get_products_last_success_at(): ?int {
+		$value = $this->read_products_state()['last_success_at'];
+
+		return is_int( $value ) ? $value : null;
+	}
+
+	/**
+	 * WP_Error from the most recent failed fetch attempt, or null if the last
+	 * fetch was successful (or no fetch has occurred).
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return WP_Error|null
+	 */
+	public function get_products_last_error(): ?WP_Error {
+		$error = $this->read_products_state()['last_error'];
+
+		return $error instanceof WP_Error ? $error : null;
+	}
+
+	/**
+	 * Read the raw license state array from the option, returning a zeroed
+	 * default when nothing has been stored.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return array{collection: array<array<string,mixed>>|null, last_success_at: int|null, last_error: WP_Error|null}
+	 */
+	private function read_products_state(): array {
+		$raw = get_option( self::PRODUCTS_STATE_OPTION_NAME, null );
+
+		if ( ! is_array( $raw ) ) {
+			return [
+				'collection'      => null,
+				'last_success_at' => null,
+				'last_error'      => null,
+			];
+		}
+
+		$collection = null;
+		if ( isset( $raw['collection'] ) && is_array( $raw['collection'] ) ) {
+			/** @var array<array<string, mixed>> $collection */
+			$collection = $raw['collection'];
+		}
+
+		$last_success_at = isset( $raw['last_success_at'] ) && is_int( $raw['last_success_at'] ) ? $raw['last_success_at'] : null;
+		$last_error      = isset( $raw['last_error'] ) && $raw['last_error'] instanceof WP_Error ? $raw['last_error'] : null;
+
+		return [
+			'collection'      => $collection,
+			'last_success_at' => $last_success_at,
+			'last_error'      => $last_error,
+		];
 	}
 
 	/**

--- a/src/Uplink/Licensing/Repositories/License_Repository.php
+++ b/src/Uplink/Licensing/Repositories/License_Repository.php
@@ -244,7 +244,7 @@ final class License_Repository {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param Product_Collection|WP_Error $data
+	 * @param Product_Collection|WP_Error $data The product catalog or fetch error to store.
 	 *
 	 * @return void
 	 */
@@ -346,7 +346,7 @@ final class License_Repository {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string $slug Product slug.
+	 * @param string $slug The product slug to retrieve.
 	 *
 	 * @return Product_Entry|null
 	 */
@@ -365,7 +365,7 @@ final class License_Repository {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string $slug Product slug.
+	 * @param string $slug The product slug to check.
 	 *
 	 * @return bool
 	 */
@@ -378,7 +378,7 @@ final class License_Repository {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string $slug Product slug.
+	 * @param string $slug The product slug to check.
 	 *
 	 * @return bool
 	 */
@@ -398,7 +398,7 @@ final class License_Repository {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string $slug Product slug.
+	 * @param string $slug The product slug to retrieve.
 	 *
 	 * @return bool
 	 */
@@ -417,7 +417,7 @@ final class License_Repository {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string $slug Product slug.
+	 * @param string $slug The product slug to retrieve.
 	 *
 	 * @return int|null Unix timestamp (UTC), or null if never recorded.
 	 */
@@ -438,7 +438,7 @@ final class License_Repository {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string $slug      Product slug.
+	 * @param string $slug      The product slug to record.
 	 * @param int    $timestamp Unix timestamp (UTC) to record.
 	 *
 	 * @return void
@@ -473,7 +473,7 @@ final class License_Repository {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string $slug Product slug.
+	 * @param string $slug The product slug to check.
 	 *
 	 * @return bool
 	 */

--- a/src/Uplink/Licensing/Repositories/License_Repository.php
+++ b/src/Uplink/Licensing/Repositories/License_Repository.php
@@ -56,6 +56,42 @@ final class License_Repository {
 	public const PRODUCTS_STATE_OPTION_NAME = 'stellarwp_uplink_licensing_products_state';
 
 	/**
+	 * State envelope key for the serialized product collection array.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string
+	 */
+	private const STATE_KEY_COLLECTION = 'collection';
+
+	/**
+	 * State envelope key for the last successful fetch timestamp.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string
+	 */
+	private const STATE_KEY_LAST_SUCCESS_AT = 'last_success_at';
+
+	/**
+	 * State envelope key for the last failed fetch timestamp.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string
+	 */
+	private const STATE_KEY_LAST_FAILURE_AT = 'last_failure_at';
+
+	/**
+	 * State envelope key for the last fetch error.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string
+	 */
+	private const STATE_KEY_LAST_ERROR = 'last_error';
+
+	/**
 	 * Option name for the map of per-product last-active timestamps.
 	 *
 	 * Stored as an associative array keyed by product slug.
@@ -223,12 +259,12 @@ final class License_Repository {
 	public function get_products() {
 		$state = $this->read_products_state();
 
-		if ( is_array( $state['collection'] ) ) {
-			return Product_Collection::from_array( $state['collection'] );
+		if ( is_array( $state[ self::STATE_KEY_COLLECTION ] ) ) {
+			return Product_Collection::from_array( $state[ self::STATE_KEY_COLLECTION ] );
 		}
 
-		if ( $state['last_error'] instanceof WP_Error ) {
-			return $state['last_error'];
+		if ( $state[ self::STATE_KEY_LAST_ERROR ] instanceof WP_Error ) {
+			return $state[ self::STATE_KEY_LAST_ERROR ];
 		}
 
 		return null;
@@ -252,19 +288,19 @@ final class License_Repository {
 	 */
 	public function set_products( $data ): void {
 		if ( $data instanceof Product_Collection ) {
-			$state                    = $this->read_products_state();
-			$state['collection']      = $data->to_array();
-			$state['last_success_at'] = time();
-			$state['last_error']      = null;
+			$state                                    = $this->read_products_state();
+			$state[ self::STATE_KEY_COLLECTION ]      = $data->to_array();
+			$state[ self::STATE_KEY_LAST_SUCCESS_AT ] = time();
+			$state[ self::STATE_KEY_LAST_ERROR ]      = null;
 			update_option( self::PRODUCTS_STATE_OPTION_NAME, $state, false );
 
 			return;
 		}
 
 		if ( is_wp_error( $data ) ) {
-			$state                    = $this->read_products_state();
-			$state['last_error']      = $data;
-			$state['last_failure_at'] = time();
+			$state                                    = $this->read_products_state();
+			$state[ self::STATE_KEY_LAST_ERROR ]      = $data;
+			$state[ self::STATE_KEY_LAST_FAILURE_AT ] = time();
 			update_option( self::PRODUCTS_STATE_OPTION_NAME, $state, false );
 		}
 	}
@@ -288,7 +324,7 @@ final class License_Repository {
 	 * @return int|null
 	 */
 	public function get_products_last_success_at(): ?int {
-		$value = $this->read_products_state()['last_success_at'];
+		$value = $this->read_products_state()[ self::STATE_KEY_LAST_SUCCESS_AT ];
 
 		return is_int( $value ) ? $value : null;
 	}
@@ -302,7 +338,7 @@ final class License_Repository {
 	 * @return int|null
 	 */
 	public function get_products_last_failure_at(): ?int {
-		$value = $this->read_products_state()['last_failure_at'];
+		$value = $this->read_products_state()[ self::STATE_KEY_LAST_FAILURE_AT ];
 
 		return is_int( $value ) ? $value : null;
 	}
@@ -316,7 +352,7 @@ final class License_Repository {
 	 * @return WP_Error|null
 	 */
 	public function get_products_last_error(): ?WP_Error {
-		$error = $this->read_products_state()['last_error'];
+		$error = $this->read_products_state()[ self::STATE_KEY_LAST_ERROR ];
 
 		return $error instanceof WP_Error ? $error : null;
 	}
@@ -334,28 +370,28 @@ final class License_Repository {
 
 		if ( ! is_array( $raw ) ) {
 			return [
-				'collection'      => null,
-				'last_success_at' => null,
-				'last_failure_at' => null,
-				'last_error'      => null,
+				self::STATE_KEY_COLLECTION      => null,
+				self::STATE_KEY_LAST_SUCCESS_AT => null,
+				self::STATE_KEY_LAST_FAILURE_AT => null,
+				self::STATE_KEY_LAST_ERROR      => null,
 			];
 		}
 
 		$collection = null;
-		if ( isset( $raw['collection'] ) && is_array( $raw['collection'] ) ) {
+		if ( isset( $raw[ self::STATE_KEY_COLLECTION ] ) && is_array( $raw[ self::STATE_KEY_COLLECTION ] ) ) {
 			/** @var array<array<string, mixed>> $collection */
-			$collection = $raw['collection'];
+			$collection = $raw[ self::STATE_KEY_COLLECTION ];
 		}
 
-		$last_success_at = isset( $raw['last_success_at'] ) && is_int( $raw['last_success_at'] ) ? $raw['last_success_at'] : null;
-		$last_failure_at = isset( $raw['last_failure_at'] ) && is_int( $raw['last_failure_at'] ) ? $raw['last_failure_at'] : null;
-		$last_error      = isset( $raw['last_error'] ) && $raw['last_error'] instanceof WP_Error ? $raw['last_error'] : null;
+		$last_success_at = isset( $raw[ self::STATE_KEY_LAST_SUCCESS_AT ] ) && is_int( $raw[ self::STATE_KEY_LAST_SUCCESS_AT ] ) ? $raw[ self::STATE_KEY_LAST_SUCCESS_AT ] : null;
+		$last_failure_at = isset( $raw[ self::STATE_KEY_LAST_FAILURE_AT ] ) && is_int( $raw[ self::STATE_KEY_LAST_FAILURE_AT ] ) ? $raw[ self::STATE_KEY_LAST_FAILURE_AT ] : null;
+		$last_error      = isset( $raw[ self::STATE_KEY_LAST_ERROR ] ) && $raw[ self::STATE_KEY_LAST_ERROR ] instanceof WP_Error ? $raw[ self::STATE_KEY_LAST_ERROR ] : null;
 
 		return [
-			'collection'      => $collection,
-			'last_success_at' => $last_success_at,
-			'last_failure_at' => $last_failure_at,
-			'last_error'      => $last_error,
+			self::STATE_KEY_COLLECTION      => $collection,
+			self::STATE_KEY_LAST_SUCCESS_AT => $last_success_at,
+			self::STATE_KEY_LAST_FAILURE_AT => $last_failure_at,
+			self::STATE_KEY_LAST_ERROR      => $last_error,
 		];
 	}
 

--- a/tests/wpunit/API/Functions/GlobalFunctionsTest.php
+++ b/tests/wpunit/API/Functions/GlobalFunctionsTest.php
@@ -23,12 +23,12 @@ final class GlobalFunctionsTest extends UplinkTestCase {
 		parent::setUp();
 
 		delete_option( License_Repository::KEY_OPTION_NAME );
-		delete_transient( License_Repository::PRODUCTS_TRANSIENT_KEY );
+		delete_option( License_Repository::PRODUCTS_STATE_OPTION_NAME );
 	}
 
 	protected function tearDown(): void {
 		delete_option( License_Repository::KEY_OPTION_NAME );
-		delete_transient( License_Repository::PRODUCTS_TRANSIENT_KEY );
+		delete_option( License_Repository::PRODUCTS_STATE_OPTION_NAME );
 
 		parent::tearDown();
 	}
@@ -131,7 +131,14 @@ final class GlobalFunctionsTest extends UplinkTestCase {
 			]
 		);
 
-		set_transient( License_Repository::PRODUCTS_TRANSIENT_KEY, $collection->to_array() );
+		update_option(
+			License_Repository::PRODUCTS_STATE_OPTION_NAME,
+			[
+				'collection'      => $collection->to_array(),
+				'last_success_at' => null,
+				'last_error'      => null,
+			] 
+		);
 
 		$this->assertTrue( stellarwp_uplink_is_product_license_active( 'give' ) );
 	}
@@ -151,7 +158,14 @@ final class GlobalFunctionsTest extends UplinkTestCase {
 			]
 		);
 
-		set_transient( License_Repository::PRODUCTS_TRANSIENT_KEY, $collection->to_array() );
+		update_option(
+			License_Repository::PRODUCTS_STATE_OPTION_NAME,
+			[
+				'collection'      => $collection->to_array(),
+				'last_success_at' => null,
+				'last_error'      => null,
+			] 
+		);
 
 		$this->assertFalse( stellarwp_uplink_is_product_license_active( 'give' ) );
 	}
@@ -171,7 +185,14 @@ final class GlobalFunctionsTest extends UplinkTestCase {
 			]
 		);
 
-		set_transient( License_Repository::PRODUCTS_TRANSIENT_KEY, $collection->to_array() );
+		update_option(
+			License_Repository::PRODUCTS_STATE_OPTION_NAME,
+			[
+				'collection'      => $collection->to_array(),
+				'last_success_at' => null,
+				'last_error'      => null,
+			] 
+		);
 
 		$this->assertFalse( stellarwp_uplink_is_product_license_active( 'learndash' ) );
 	}

--- a/tests/wpunit/API/REST/V1/License_ControllerTest.php
+++ b/tests/wpunit/API/REST/V1/License_ControllerTest.php
@@ -24,7 +24,7 @@ final class License_ControllerTest extends UplinkTestCase {
 		parent::setUp();
 
 		delete_option( License_Repository::KEY_OPTION_NAME );
-		delete_transient( License_Repository::PRODUCTS_TRANSIENT_KEY );
+		delete_option( License_Repository::PRODUCTS_STATE_OPTION_NAME );
 
 		$repository    = new License_Repository();
 		$registry      = new Product_Registry();
@@ -56,7 +56,7 @@ final class License_ControllerTest extends UplinkTestCase {
 		$wp_rest_server = null;
 
 		delete_option( License_Repository::KEY_OPTION_NAME );
-		delete_transient( License_Repository::PRODUCTS_TRANSIENT_KEY );
+		delete_option( License_Repository::PRODUCTS_STATE_OPTION_NAME );
 
 		parent::tearDown();
 	}

--- a/tests/wpunit/Features/Feature_RepositoryTest.php
+++ b/tests/wpunit/Features/Feature_RepositoryTest.php
@@ -35,7 +35,7 @@ final class Feature_RepositoryTest extends UplinkTestCase {
 
 		delete_transient( Feature_Repository::TRANSIENT_KEY );
 		delete_transient( Catalog_Repository::TRANSIENT_KEY );
-		delete_transient( License_Repository::PRODUCTS_TRANSIENT_KEY );
+		delete_option( License_Repository::PRODUCTS_STATE_OPTION_NAME );
 	}
 
 	/**
@@ -46,7 +46,7 @@ final class Feature_RepositoryTest extends UplinkTestCase {
 	protected function tearDown(): void {
 		delete_transient( Feature_Repository::TRANSIENT_KEY );
 		delete_transient( Catalog_Repository::TRANSIENT_KEY );
-		delete_transient( License_Repository::PRODUCTS_TRANSIENT_KEY );
+		delete_option( License_Repository::PRODUCTS_STATE_OPTION_NAME );
 
 		parent::tearDown();
 	}

--- a/tests/wpunit/Features/ManagerTest.php
+++ b/tests/wpunit/Features/ManagerTest.php
@@ -92,7 +92,7 @@ final class ManagerTest extends UplinkTestCase {
 		delete_option( License_Repository::KEY_OPTION_NAME );
 		delete_transient( Feature_Repository::TRANSIENT_KEY );
 		delete_transient( Catalog_Repository::TRANSIENT_KEY );
-		delete_transient( License_Repository::PRODUCTS_TRANSIENT_KEY );
+		delete_option( License_Repository::PRODUCTS_STATE_OPTION_NAME );
 
 		parent::tearDown();
 	}

--- a/tests/wpunit/Licensing/License_ManagerTest.php
+++ b/tests/wpunit/Licensing/License_ManagerTest.php
@@ -33,7 +33,7 @@ final class License_ManagerTest extends UplinkTestCase {
 	protected function tearDown(): void {
 		remove_all_filters( Product_Registry::FILTER );
 		delete_option( License_Repository::KEY_OPTION_NAME );
-		delete_transient( License_Repository::PRODUCTS_TRANSIENT_KEY );
+		delete_option( License_Repository::PRODUCTS_STATE_OPTION_NAME );
 		parent::tearDown();
 	}
 

--- a/tests/wpunit/Licensing/Repositories/License_Key_Cache_InvalidationTest.php
+++ b/tests/wpunit/Licensing/Repositories/License_Key_Cache_InvalidationTest.php
@@ -72,7 +72,7 @@ final class License_Key_Cache_InvalidationTest extends UplinkTestCase {
 			}
 		);
 
-		delete_transient( License_Repository::PRODUCTS_TRANSIENT_KEY );
+		delete_option( License_Repository::PRODUCTS_STATE_OPTION_NAME );
 		delete_transient( Catalog_Repository::TRANSIENT_KEY );
 		delete_transient( Feature_Repository::TRANSIENT_KEY );
 		delete_option( License_Repository::KEY_OPTION_NAME );
@@ -81,7 +81,7 @@ final class License_Key_Cache_InvalidationTest extends UplinkTestCase {
 	protected function tearDown(): void {
 		remove_all_filters( 'stellarwp/uplink/unified_license_key_changed' );
 
-		delete_transient( License_Repository::PRODUCTS_TRANSIENT_KEY );
+		delete_option( License_Repository::PRODUCTS_STATE_OPTION_NAME );
 		delete_transient( Catalog_Repository::TRANSIENT_KEY );
 		delete_transient( Feature_Repository::TRANSIENT_KEY );
 		delete_option( License_Repository::KEY_OPTION_NAME );

--- a/tests/wpunit/Licensing/Repositories/License_RepositoryTest.php
+++ b/tests/wpunit/Licensing/Repositories/License_RepositoryTest.php
@@ -307,7 +307,10 @@ final class License_RepositoryTest extends UplinkTestCase {
 							'tier'         => 'give-pro',
 							'status'       => 'active',
 							'expires'      => '2026-12-31 23:59:59',
-							'activations'  => [ 'site_limit' => 0, 'active_count' => 0 ],
+							'activations'  => [
+								'site_limit'   => 0,
+								'active_count' => 0,
+							],
 						]
 					),
 				]

--- a/tests/wpunit/Licensing/Repositories/License_RepositoryTest.php
+++ b/tests/wpunit/Licensing/Repositories/License_RepositoryTest.php
@@ -189,6 +189,7 @@ final class License_RepositoryTest extends UplinkTestCase {
 		$this->assertCount( 1, $state['collection'] );
 		$this->assertSame( 'give', $state['collection'][0]['product_slug'] );
 		$this->assertIsInt( $state['last_success_at'] );
+		$this->assertNull( $state['last_failure_at'] );
 		$this->assertNull( $state['last_error'] );
 	}
 
@@ -275,6 +276,45 @@ final class License_RepositoryTest extends UplinkTestCase {
 		$this->repository->set_products( new WP_Error( Error_Code::INVALID_KEY, 'fail' ) );
 
 		$this->assertSame( $first_last_success_at, $this->repository->get_products_last_success_at() );
+	}
+
+	public function test_get_products_last_failure_at_returns_null_before_first_failure(): void {
+		$this->assertNull( $this->repository->get_products_last_failure_at() );
+	}
+
+	public function test_get_products_last_failure_at_returns_timestamp_after_failed_set(): void {
+		$before = time();
+
+		$this->repository->set_products( new WP_Error( Error_Code::INVALID_KEY, 'fail' ) );
+
+		$last_failure_at = $this->repository->get_products_last_failure_at();
+
+		$this->assertIsInt( $last_failure_at );
+		$this->assertGreaterThanOrEqual( $before, $last_failure_at );
+	}
+
+	public function test_get_products_last_failure_at_not_updated_on_success(): void {
+		$this->repository->set_products( new WP_Error( Error_Code::INVALID_KEY, 'fail' ) );
+
+		$first_last_failure_at = $this->repository->get_products_last_failure_at();
+
+		$this->repository->set_products(
+			Product_Collection::from_array(
+				[
+					Product_Entry::from_array(
+						[
+							'product_slug' => 'give',
+							'tier'         => 'give-pro',
+							'status'       => 'active',
+							'expires'      => '2026-12-31 23:59:59',
+							'activations'  => [ 'site_limit' => 0, 'active_count' => 0 ],
+						]
+					),
+				]
+			)
+		);
+
+		$this->assertSame( $first_last_failure_at, $this->repository->get_products_last_failure_at() );
 	}
 
 	public function test_get_products_last_error_returns_null_when_no_error(): void {

--- a/tests/wpunit/Licensing/Repositories/License_RepositoryTest.php
+++ b/tests/wpunit/Licensing/Repositories/License_RepositoryTest.php
@@ -21,13 +21,13 @@ final class License_RepositoryTest extends UplinkTestCase {
 		$this->repository = new License_Repository();
 		delete_option( License_Repository::KEY_OPTION_NAME );
 		delete_option( License_Repository::PRODUCTS_LAST_ACTIVE_DATES_OPTION_NAME );
-		delete_transient( License_Repository::PRODUCTS_TRANSIENT_KEY );
+		delete_option( License_Repository::PRODUCTS_STATE_OPTION_NAME );
 	}
 
 	protected function tearDown(): void {
 		delete_option( License_Repository::KEY_OPTION_NAME );
 		delete_option( License_Repository::PRODUCTS_LAST_ACTIVE_DATES_OPTION_NAME );
-		delete_transient( License_Repository::PRODUCTS_TRANSIENT_KEY );
+		delete_option( License_Repository::PRODUCTS_STATE_OPTION_NAME );
 		parent::tearDown();
 	}
 
@@ -151,7 +151,14 @@ final class License_RepositoryTest extends UplinkTestCase {
 			],
 		];
 
-		set_transient( License_Repository::PRODUCTS_TRANSIENT_KEY, $raw );
+		update_option(
+			License_Repository::PRODUCTS_STATE_OPTION_NAME,
+			[
+				'collection'      => $raw,
+				'last_success_at' => null,
+				'last_error'      => null,
+			]
+		);
 
 		$result = $this->repository->get_products();
 
@@ -159,7 +166,7 @@ final class License_RepositoryTest extends UplinkTestCase {
 		$this->assertSame( 'give', $result->get( 'give' )->get_product_slug() );
 	}
 
-	public function test_set_products_stores_plain_array_in_transient(): void {
+	public function test_set_products_stores_plain_array_in_option(): void {
 		$collection = Product_Collection::from_array(
 			[
 				Product_Entry::from_array(
@@ -175,15 +182,17 @@ final class License_RepositoryTest extends UplinkTestCase {
 
 		$this->repository->set_products( $collection );
 
-		$raw = get_transient( License_Repository::PRODUCTS_TRANSIENT_KEY );
+		$state = get_option( License_Repository::PRODUCTS_STATE_OPTION_NAME );
 
-		$this->assertIsArray( $raw );
-		$this->assertCount( 1, $raw );
-		$this->assertIsArray( $raw[0] );
-		$this->assertSame( 'give', $raw[0]['product_slug'] );
+		$this->assertIsArray( $state );
+		$this->assertIsArray( $state['collection'] );
+		$this->assertCount( 1, $state['collection'] );
+		$this->assertSame( 'give', $state['collection'][0]['product_slug'] );
+		$this->assertIsInt( $state['last_success_at'] );
+		$this->assertNull( $state['last_error'] );
 	}
 
-	public function test_set_products_caches_wp_error(): void {
+	public function test_set_products_stores_wp_error_in_last_error(): void {
 		$error = new WP_Error( Error_Code::INVALID_KEY, 'Bad key' );
 
 		$this->repository->set_products( $error );
@@ -191,6 +200,116 @@ final class License_RepositoryTest extends UplinkTestCase {
 		$result = $this->repository->get_products();
 
 		$this->assertInstanceOf( WP_Error::class, $result );
+	}
+
+	public function test_set_products_error_preserves_existing_products(): void {
+		$collection = Product_Collection::from_array(
+			[
+				Product_Entry::from_array(
+					[
+						'product_slug' => 'give',
+						'tier'         => 'give-pro',
+						'status'       => 'active',
+						'expires'      => '2026-12-31 23:59:59',
+					]
+				),
+			]
+		);
+
+		$this->repository->set_products( $collection );
+		$this->repository->set_products( new WP_Error( Error_Code::INVALID_KEY, 'Network failure' ) );
+
+		// Products from the successful fetch must survive the error.
+		$result = $this->repository->get_products();
+
+		$this->assertInstanceOf( Product_Collection::class, $result );
+		$this->assertSame( 'give', $result->get( 'give' )->get_product_slug() );
+	}
+
+	public function test_get_products_last_success_at_returns_null_before_first_fetch(): void {
+		$this->assertNull( $this->repository->get_products_last_success_at() );
+	}
+
+	public function test_get_products_last_success_at_returns_timestamp_after_successful_set(): void {
+		$before = time();
+
+		$this->repository->set_products(
+			Product_Collection::from_array(
+				[
+					Product_Entry::from_array(
+						[
+							'product_slug' => 'give',
+							'tier'         => 'give-pro',
+							'status'       => 'active',
+							'expires'      => '2026-12-31 23:59:59',
+						]
+					),
+				]
+			)
+		);
+
+		$last_success_at = $this->repository->get_products_last_success_at();
+
+		$this->assertIsInt( $last_success_at );
+		$this->assertGreaterThanOrEqual( $before, $last_success_at );
+	}
+
+	public function test_get_products_last_success_at_not_updated_on_error(): void {
+		$this->repository->set_products(
+			Product_Collection::from_array(
+				[
+					Product_Entry::from_array(
+						[
+							'product_slug' => 'give',
+							'tier'         => 'give-pro',
+							'status'       => 'active',
+							'expires'      => '2026-12-31 23:59:59',
+						]
+					),
+				]
+			)
+		);
+
+		$first_last_success_at = $this->repository->get_products_last_success_at();
+
+		$this->repository->set_products( new WP_Error( Error_Code::INVALID_KEY, 'fail' ) );
+
+		$this->assertSame( $first_last_success_at, $this->repository->get_products_last_success_at() );
+	}
+
+	public function test_get_products_last_error_returns_null_when_no_error(): void {
+		$this->assertNull( $this->repository->get_products_last_error() );
+	}
+
+	public function test_get_products_last_error_returns_error_after_failed_set(): void {
+		$error = new WP_Error( Error_Code::INVALID_KEY, 'Bad key' );
+
+		$this->repository->set_products( $error );
+
+		$result = $this->repository->get_products_last_error();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( Error_Code::INVALID_KEY, $result->get_error_code() );
+	}
+
+	public function test_get_products_last_error_cleared_after_successful_set(): void {
+		$this->repository->set_products( new WP_Error( Error_Code::INVALID_KEY, 'fail' ) );
+		$this->repository->set_products(
+			Product_Collection::from_array(
+				[
+					Product_Entry::from_array(
+						[
+							'product_slug' => 'give',
+							'tier'         => 'give-pro',
+							'status'       => 'active',
+							'expires'      => '2026-12-31 23:59:59',
+						]
+					),
+				]
+			)
+		);
+
+		$this->assertNull( $this->repository->get_products_last_error() );
 	}
 
 	public function test_delete_products_clears_cache(): void {


### PR DESCRIPTION
Resolves: [SCON-302]

## Description

This PR updates the way we store licensing product information.  Previously there was a flat structure that stored just the product collection or error within a transient.  However, that had some flaws with the way the data expires along with the inflexibility of the stored data.   Now we are storing the data in `wp_option` and including extra information like `last_success_at` and `last_error` that live alongside the collection.

Here's a visual of the data:

```php
stellarwp_uplink_licensing_products_state = [
    'collection' => [
        'give' => [
            'product_slug' => 'give',
            'tier' => 'give-pro',
            'status' => 'active',
            'expires' => '2026-12-31 23:59:59',
            'is_valid' => true,
            ...other product data...
        ],
    ],
    'last_success_at' => 1715328000,
    'last_failure_at' => null,
    'last_error' => null,
]
```

[SCON-302]: https://stellarwp.atlassian.net/browse/SCON-302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ