### PR TITLE
Enhance feature management with new methods | SCON-309

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -70,19 +70,19 @@ Edge cases:
 
 The `Manager` is the public interface for all feature operations.
 
-| Method                       | Returns                        | Purpose                                |
-| ---------------------------- | ------------------------------ | -------------------------------------- |
-| `get_features()`             | `Feature_Collection\|WP_Error` | Get all resolved features              |
-| `get_feature(string $slug)`  | `Feature\|null`                | Look up a single feature               |
-| `is_available(string $slug)` | `bool\|WP_Error`               | Check if the customer's tier qualifies |
-| `is_enabled(string $slug)`   | `bool\|WP_Error`               | Check if the feature is active locally |
-| `enable(string $slug)`       | `true\|WP_Error`               | Enable a feature                       |
-| `disable(string $slug)`      | `true\|WP_Error`               | Disable a feature                      |
+| Method                     | Returns                         | Purpose                                        |
+| -------------------------- | ------------------------------- | ---------------------------------------------- |
+| `get_all()`                | `Feature_Collection\|WP_Error`  | Get all resolved features with live is_enabled |
+| `get(string $slug)`        | `Feature\|null`                 | Look up a single feature with live is_enabled  |
+| `exists(string $slug)`     | `bool\|WP_Error`                | Check if the feature is in the catalog         |
+| `is_enabled(string $slug)` | `bool\|WP_Error`                | Check if the feature is active locally         |
+| `enable(string $slug)`     | `Feature\|WP_Error`             | Enable a feature, return updated Feature       |
+| `disable(string $slug)`    | `Feature\|WP_Error`             | Disable a feature, return updated Feature      |
 
 Global convenience functions in `src/Uplink/global-functions.php` (non-namespaced, always delegate to the version leader):
 
 - **`stellarwp_uplink_is_feature_enabled(string $slug): bool|WP_Error`** — in the catalog AND active locally?
-- **`stellarwp_uplink_is_feature_available(string $slug): bool|WP_Error`** — in the catalog and tier qualifies?
+- **`stellarwp_uplink_is_feature_available(string $slug): bool|WP_Error`** — does the customer's tier include this feature?
 
 ### WordPress Hooks
 
@@ -123,7 +123,7 @@ Four endpoints under `stellarwp/uplink/v1`. All require `manage_options`.
 | `/features/{slug}/enable`  | POST   | Enable a feature                                              |
 | `/features/{slug}/disable` | POST   | Disable a feature                                             |
 
-Each response includes `is_enabled` computed live from the strategy, not cached state.
+Each Feature object includes `is_enabled`, stamped with live state from its strategy by the Manager before any consumer receives it.
 
 ## Error Codes
 
@@ -133,6 +133,8 @@ Each response includes `is_enabled` computed live from the strategy, not cached 
 | `FEATURE_TYPE_MISMATCH`          | 400  | Type doesn't match the strategy                    |
 | `FEATURE_REQUEST_FAILED`         | 502  | Resolution failed (catalog or licensing API error) |
 | `FEATURE_CHECK_FAILED`           | 502  | Unexpected error during availability check         |
+| `FEATURE_ENABLE_FAILED`          | 422  | Strategy threw an exception during enable          |
+| `FEATURE_DISABLE_FAILED`         | 422  | Strategy threw an exception during disable         |
 | `INVALID_RESPONSE`               | 502  | Catalog response couldn't be parsed                |
 | `UNKNOWN_FEATURE_TYPE`           | 422  | No Feature subclass for the catalog type           |
 | `INSTALL_LOCKED`                 | 409  | Another install already in progress                |
@@ -155,12 +157,12 @@ Each response includes `is_enabled` computed live from the strategy, not cached 
 
 ## Data Sources
 
-| Data                                                    | Source                                                              |
-| ------------------------------------------------------- | ------------------------------------------------------------------- |
-| Feature exists, minimum tier, delivery type, tier ranks | Catalog                                                             |
-| Customer's tier, key validity                           | Licensing                                                           |
-| **Whether available**                                   | **Computed: catalog min rank vs. licensing tier rank**              |
-| Whether enabled                                         | Live WordPress state (plugin activation / theme disk / flag option) |
+| Data                                                    | Source                                                                                    |
+| ------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Feature exists, minimum tier, delivery type, tier ranks | Catalog                                                                                   |
+| Customer's tier, key validity                           | Licensing                                                                                 |
+| **Whether available** (`is_available`)                  | **Computed: catalog min rank vs. licensing tier rank**                                    |
+| **Whether enabled** (`is_enabled`)                      | Live WordPress state (plugin activation / theme disk / flag option), stamped by Manager   |
 
 ## What Features Does Not Do
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -75,6 +75,7 @@ The `Manager` is the public interface for all feature operations.
 | `get_all()`                | `Feature_Collection\|WP_Error`  | Get all resolved features with live is_enabled |
 | `get(string $slug)`        | `Feature\|null`                 | Look up a single feature with live is_enabled  |
 | `exists(string $slug)`     | `bool\|WP_Error`                | Check if the feature is in the catalog         |
+| `is_available(string $slug)` | `bool\|WP_Error`              | Check if the customer's tier includes this feature |
 | `is_enabled(string $slug)` | `bool\|WP_Error`                | Check if the feature is active locally         |
 | `enable(string $slug)`     | `Feature\|WP_Error`             | Enable a feature, return updated Feature       |
 | `disable(string $slug)`    | `Feature\|WP_Error`             | Disable a feature, return updated Feature      |

--- a/docs/features.md
+++ b/docs/features.md
@@ -70,15 +70,15 @@ Edge cases:
 
 The `Manager` is the public interface for all feature operations.
 
-| Method                     | Returns                         | Purpose                                        |
-| -------------------------- | ------------------------------- | ---------------------------------------------- |
-| `get_all()`                | `Feature_Collection\|WP_Error`  | Get all resolved features with live is_enabled |
-| `get(string $slug)`        | `Feature\|null`                 | Look up a single feature with live is_enabled  |
-| `exists(string $slug)`     | `bool\|WP_Error`                | Check if the feature is in the catalog         |
-| `is_available(string $slug)` | `bool\|WP_Error`              | Check if the customer's tier includes this feature |
-| `is_enabled(string $slug)` | `bool\|WP_Error`                | Check if the feature is active locally         |
-| `enable(string $slug)`     | `Feature\|WP_Error`             | Enable a feature, return updated Feature       |
-| `disable(string $slug)`    | `Feature\|WP_Error`             | Disable a feature, return updated Feature      |
+| Method                       | Returns                        | Purpose                                            |
+| ---------------------------- | ------------------------------ | -------------------------------------------------- |
+| `get_all()`                  | `Feature_Collection\|WP_Error` | Get all resolved features with live is_enabled     |
+| `get(string $slug)`          | `Feature\|null`                | Look up a single feature with live is_enabled      |
+| `exists(string $slug)`       | `bool\|WP_Error`               | Check if the feature is in the catalog             |
+| `is_available(string $slug)` | `bool\|WP_Error`               | Check if the customer's tier includes this feature |
+| `is_enabled(string $slug)`   | `bool\|WP_Error`               | Check if the feature is active locally             |
+| `enable(string $slug)`       | `Feature\|WP_Error`            | Enable a feature, return updated Feature           |
+| `disable(string $slug)`      | `Feature\|WP_Error`            | Disable a feature, return updated Feature          |
 
 Global convenience functions in `src/Uplink/global-functions.php` (non-namespaced, always delegate to the version leader):
 

--- a/src/Uplink/API/REST/V1/Feature_Controller.php
+++ b/src/Uplink/API/REST/V1/Feature_Controller.php
@@ -154,7 +154,7 @@ class Feature_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function get_items( $request ) {
-		$features = $this->manager->get_features();
+		$features = $this->manager->get_all();
 
 		if ( is_wp_error( $features ) ) {
 			return $this->ensure_error_status( $features );
@@ -177,7 +177,7 @@ class Feature_Controller extends WP_REST_Controller {
 		$data = [];
 
 		foreach ( $features as $feature ) {
-			$data[] = $this->prepare_feature_data( $feature );
+			$data[] = $feature->to_array();
 		}
 
 		return new WP_REST_Response( $data );
@@ -194,7 +194,7 @@ class Feature_Controller extends WP_REST_Controller {
 	 */
 	public function get_item( $request ) {
 		$slug     = Cast::to_string( $request->get_param( 'slug' ) );
-		$features = $this->manager->get_features();
+		$features = $this->manager->get_all();
 
 		if ( is_wp_error( $features ) ) {
 			return $this->ensure_error_status( $features );
@@ -210,7 +210,7 @@ class Feature_Controller extends WP_REST_Controller {
 			);
 		}
 
-		return new WP_REST_Response( $this->prepare_feature_data( $feature ) );
+		return new WP_REST_Response( $feature->to_array() );
 	}
 
 	/**
@@ -223,25 +223,16 @@ class Feature_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function enable( WP_REST_Request $request ) {
-		$slug    = Cast::to_string( $request->get_param( 'slug' ) );
-		$feature = $this->manager->get_feature( $slug );
+		$slug = Cast::to_string( $request->get_param( 'slug' ) );
 
-		if ( ! $feature ) {
-			return new WP_Error(
-				Error_Code::FEATURE_NOT_FOUND,
-				sprintf( 'Feature "%s" not found.', $slug ),
-				[ 'status' => 404 ]
-			);
-		}
+		$feature = $this->manager->enable( $slug );
 
-		$result = $this->manager->enable( $slug );
-
-		if ( is_wp_error( $result ) ) {
-			return $this->ensure_error_status( $result );
+		if ( is_wp_error( $feature ) ) {
+			return $this->ensure_error_status( $feature );
 		}
 
 		return new WP_REST_Response(
-			$this->prepare_feature_data( $feature )
+			$feature->to_array()
 		);
 	}
 
@@ -256,24 +247,14 @@ class Feature_Controller extends WP_REST_Controller {
 	 */
 	public function disable( WP_REST_Request $request ) {
 		$slug    = Cast::to_string( $request->get_param( 'slug' ) );
-		$feature = $this->manager->get_feature( $slug );
+		$feature = $this->manager->disable( $slug );
 
-		if ( ! $feature ) {
-			return new WP_Error(
-				Error_Code::FEATURE_NOT_FOUND,
-				sprintf( 'Feature "%s" not found.', $slug ),
-				[ 'status' => 404 ]
-			);
-		}
-
-		$result = $this->manager->disable( $slug );
-
-		if ( is_wp_error( $result ) ) {
-			return $this->ensure_error_status( $result );
+		if ( is_wp_error( $feature ) ) {
+			return $this->ensure_error_status( $feature );
 		}
 
 		return new WP_REST_Response(
-			$this->prepare_feature_data( $feature )
+			$feature->to_array()
 		);
 	}
 
@@ -454,21 +435,6 @@ class Feature_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Prepares feature data for the response.
-	 *
-	 * @since 3.0.0
-	 *
-	 * @param Feature $feature The feature instance.
-	 *
-	 * @return array<string, mixed>
-	 */
-	private function prepare_feature_data( Feature $feature ): array {
-		return $feature->to_array() + [
-			'is_enabled' => $this->manager->is_enabled( $feature->get_slug() ),
-		];
-	}
-
-	/**
 	 * Ensures a WP_Error has an HTTP status code in its data.
 	 *
 	 * Errors from the Manager and its strategies do not carry HTTP
@@ -514,7 +480,11 @@ class Feature_Controller extends WP_REST_Controller {
 				'type'              => 'string',
 				'sanitize_callback' => 'sanitize_text_field',
 				'validate_callback' => function ( $slug ): bool {
-					return Cast::to_bool( $this->manager->is_available( Cast::to_string( $slug ) ) );
+					return Cast::to_bool(
+						$this->manager->exists(
+							Cast::to_string( $slug )
+						)
+					);
 				},
 			],
 		];

--- a/src/Uplink/CLI/Commands/Feature.php
+++ b/src/Uplink/CLI/Commands/Feature.php
@@ -138,7 +138,7 @@ class Feature extends WP_CLI_Command {
 	 * @return void
 	 */
 	public function list_( array $args, array $assoc_args ): void {
-		$features = $this->manager->get_features();
+		$features = $this->manager->get_all();
 
 		if ( is_wp_error( $features ) ) {
 			WP_CLI::error( $features->get_error_message() );
@@ -202,7 +202,7 @@ class Feature extends WP_CLI_Command {
 	 */
 	public function get( array $args, array $assoc_args ): void {
 		$slug    = $args[0];
-		$feature = $this->manager->get_feature( $slug );
+		$feature = $this->manager->get( $slug );
 
 		if ( ! $feature ) {
 			WP_CLI::error( sprintf( 'Feature "%s" not found.', $slug ) );
@@ -249,20 +249,13 @@ class Feature extends WP_CLI_Command {
 	 * @return void
 	 */
 	public function is_enabled( array $args, array $assoc_args ): void {
-		$slug = $args[0];
-
-		if ( ! $this->manager->get_feature( $slug ) ) {
-			WP_CLI::error( sprintf( 'Feature "%s" not found.', $slug ) );
-
-			return;
-		}
-
+		$slug   = $args[0];
 		$result = $this->manager->is_enabled( $slug );
 
 		if ( is_wp_error( $result ) ) {
 			WP_CLI::error( $result->get_error_message() );
 
-			return;
+			return; // WP_CLI::error() exits, but PHPStan needs this for type narrowing.
 		}
 
 		if ( $result ) {
@@ -291,14 +284,14 @@ class Feature extends WP_CLI_Command {
 	 * @return void
 	 */
 	public function enable( array $args, array $assoc_args ): void {
-		$slug   = $args[0];
-		$result = $this->manager->enable( $slug );
+		$slug    = $args[0];
+		$feature = $this->manager->enable( $slug );
 
-		if ( is_wp_error( $result ) ) {
-			WP_CLI::error( $result->get_error_message() );
+		if ( is_wp_error( $feature ) ) {
+			WP_CLI::error( $feature->get_error_message() );
+		} else {
+			WP_CLI::success( sprintf( 'Feature "%s" enabled.', $slug ) );
 		}
-
-		WP_CLI::success( sprintf( 'Feature "%s" enabled.', $slug ) );
 	}
 
 	/**
@@ -320,14 +313,14 @@ class Feature extends WP_CLI_Command {
 	 * @return void
 	 */
 	public function disable( array $args, array $assoc_args ): void {
-		$slug   = $args[0];
-		$result = $this->manager->disable( $slug );
+		$slug    = $args[0];
+		$feature = $this->manager->disable( $slug );
 
-		if ( is_wp_error( $result ) ) {
-			WP_CLI::error( $result->get_error_message() );
+		if ( is_wp_error( $feature ) ) {
+			WP_CLI::error( $feature->get_error_message() );
+		} else {
+			WP_CLI::success( sprintf( 'Feature "%s" disabled.', $slug ) );
 		}
-
-		WP_CLI::success( sprintf( 'Feature "%s" disabled.', $slug ) );
 	}
 
 	/**
@@ -362,12 +355,10 @@ class Feature extends WP_CLI_Command {
 	 * @return array<string, mixed>
 	 */
 	private function feature_to_display_item( Feature_Type $feature ): array {
-		$is_enabled = $this->manager->is_enabled( $feature->get_slug() );
-
 		$item = $feature->to_array();
 
 		$item['is_available'] = $this->to_display_bool( ! empty( $item['is_available'] ) );
-		$item['is_enabled']   = $this->to_display_bool( $is_enabled === true );
+		$item['is_enabled']   = $this->to_display_bool( ! empty( $item['is_enabled'] ) );
 		$item['is_dot_org']   = $this->to_display_bool( ! empty( $item['is_dot_org'] ) );
 
 		foreach ( $item as $key => $value ) {

--- a/src/Uplink/Features/Error_Code.php
+++ b/src/Uplink/Features/Error_Code.php
@@ -193,6 +193,24 @@ class Error_Code {
 	public const THEME_OWNERSHIP_MISMATCH = 'stellarwp-uplink-theme-ownership-mismatch';
 
 	/**
+	 * A feature could not be enabled (strategy threw an exception).
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string
+	 */
+	public const FEATURE_ENABLE_FAILED = 'stellarwp-uplink-feature-enable-failed';
+
+	/**
+	 * A feature could not be disabled (strategy threw an exception).
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string
+	 */
+	public const FEATURE_DISABLE_FAILED = 'stellarwp-uplink-feature-disable-failed';
+
+	/**
 	 * A catalog feature has a type with no registered Feature subclass.
 	 *
 	 * @since 3.0.0
@@ -231,7 +249,9 @@ class Error_Code {
 
 			// 422 Unprocessable Entity — the request was understood but the operation
 			// could not be completed (requirements not met, install/activation failure,
-			// missing download link, or unexpected package structure).
+			// missing download link, unexpected package structure, or enable/disable failure).
+			self::FEATURE_ENABLE_FAILED          => 422,
+			self::FEATURE_DISABLE_FAILED         => 422,
 			self::REQUIREMENTS_NOT_MET           => 422,
 			self::INSTALL_FAILED                 => 422,
 			self::ACTIVATION_FATAL               => 422,

--- a/src/Uplink/Features/Manager.php
+++ b/src/Uplink/Features/Manager.php
@@ -5,6 +5,7 @@ namespace StellarWP\Uplink\Features;
 use StellarWP\Uplink\Features\Strategy\Strategy_Factory;
 use StellarWP\Uplink\Features\Types\Feature;
 use StellarWP\Uplink\Features\Error_Code;
+use Throwable;
 use WP_Error;
 
 /**
@@ -82,10 +83,16 @@ class Manager {
 	 *
 	 * @param string $slug The feature slug.
 	 *
-	 * @return true|WP_Error True on success, WP_Error on failure.
+	 * @return Feature|WP_Error The feature with updated is_enabled state, or WP_Error on failure.
 	 */
 	public function enable( string $slug ) {
-		$feature = $this->get_feature( $slug );
+		$features = $this->repository->get( $this->key, $this->domain );
+
+		if ( is_wp_error( $features ) ) {
+			return $features;
+		}
+
+		$feature = $features->get( $slug );
 
 		if ( ! $feature ) {
 			return new WP_Error(
@@ -93,8 +100,6 @@ class Manager {
 				sprintf( 'Feature "%s" not found in the catalog.', $slug )
 			);
 		}
-
-		$strategy = $this->strategy_factory->make( $feature );
 
 		/**
 		 * Fires before a feature is enabled.
@@ -118,10 +123,28 @@ class Manager {
 		 */
 		do_action( "stellarwp/uplink/{$slug}/feature_enabling", $feature->to_array() );
 
-		$result = $strategy->enable();
+		try {
+			$strategy = $this->strategy_factory->make( $feature );
+
+			$result = $strategy->enable();
+		} catch ( Throwable $e ) {
+			return new WP_Error(
+				Error_Code::FEATURE_ENABLE_FAILED,
+				$e->getMessage()
+			);
+		}
 
 		if ( is_wp_error( $result ) ) {
 			return $result;
+		}
+
+		$feature = $this->get( $slug );
+
+		if ( ! $feature ) {
+			return new WP_Error(
+				Error_Code::FEATURE_NOT_FOUND,
+				sprintf( 'Feature "%s" not found after enabling.', $slug )
+			);
 		}
 
 		/**
@@ -146,7 +169,7 @@ class Manager {
 		 */
 		do_action( "stellarwp/uplink/{$slug}/feature_enabled", $feature->to_array() );
 
-		return true;
+		return $feature;
 	}
 
 	/**
@@ -159,10 +182,16 @@ class Manager {
 	 *
 	 * @param string $slug The feature slug.
 	 *
-	 * @return true|WP_Error True on success, WP_Error on failure.
+	 * @return Feature|WP_Error The feature with updated is_enabled state, or WP_Error on failure.
 	 */
 	public function disable( string $slug ) {
-		$feature = $this->get_feature( $slug );
+		$features = $this->repository->get( $this->key, $this->domain );
+
+		if ( is_wp_error( $features ) ) {
+			return $features;
+		}
+
+		$feature = $features->get( $slug );
 
 		if ( ! $feature ) {
 			return new WP_Error(
@@ -170,8 +199,6 @@ class Manager {
 				sprintf( 'Feature "%s" not found in the catalog.', $slug )
 			);
 		}
-
-		$strategy = $this->strategy_factory->make( $feature );
 
 		/**
 		 * Fires before a feature is disabled.
@@ -195,10 +222,28 @@ class Manager {
 		 */
 		do_action( "stellarwp/uplink/{$slug}/feature_disabling", $feature->to_array() );
 
-		$result = $strategy->disable();
+		try {
+			$strategy = $this->strategy_factory->make( $feature );
+
+			$result = $strategy->disable();
+		} catch ( Throwable $e ) {
+			return new WP_Error(
+				Error_Code::FEATURE_DISABLE_FAILED,
+				$e->getMessage()
+			);
+		}
 
 		if ( is_wp_error( $result ) ) {
 			return $result;
+		}
+
+		$feature = $this->get( $slug );
+
+		if ( ! $feature ) {
+			return new WP_Error(
+				Error_Code::FEATURE_NOT_FOUND,
+				sprintf( 'Feature "%s" not found after disabling.', $slug )
+			);
 		}
 
 		/**
@@ -223,7 +268,7 @@ class Manager {
 		 */
 		do_action( "stellarwp/uplink/{$slug}/feature_disabled", $feature->to_array() );
 
-		return true;
+		return $feature;
 	}
 
 	/**
@@ -233,31 +278,57 @@ class Manager {
 	 *
 	 * @param string $slug The feature slug.
 	 *
-	 * @return bool|WP_Error
+	 * @return bool|WP_Error True if enabled, false if disabled, WP_Error on failure.
 	 */
 	public function is_enabled( string $slug ) {
-		$features = $this->repository->get( $this->key, $this->domain );
+		$features = $this->get_all();
 
 		if ( is_wp_error( $features ) ) {
-			return new WP_Error(
-				Error_Code::FEATURE_CHECK_FAILED,
-				$features->get_error_message()
-			);
+			return $features;
 		}
 
 		$feature = $features->get( $slug );
 
 		if ( ! $feature ) {
-			return false;
+			return new WP_Error(
+				Error_Code::FEATURE_NOT_FOUND,
+				sprintf( 'Feature "%s" not found in the catalog.', $slug )
+			);
 		}
 
-		$strategy = $this->strategy_factory->make( $feature );
-
-		return $strategy->is_active();
+		return $feature->is_enabled();
 	}
 
 	/**
-	 * Checks whether a feature exists in the cached catalog.
+	 * Checks whether a feature is available for the current site's tier.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $slug The feature slug.
+	 *
+	 * @return bool|WP_Error True if available, false if not, WP_Error on failure.
+	 */
+	public function is_available( string $slug ) {
+		$features = $this->get_all();
+
+		if ( is_wp_error( $features ) ) {
+			return $features;
+		}
+
+		$feature = $features->get( $slug );
+
+		if ( ! $feature ) {
+			return new WP_Error(
+				Error_Code::FEATURE_NOT_FOUND,
+				sprintf( 'Feature "%s" not found in the catalog.', $slug )
+			);
+		}
+
+		return $feature->is_available();
+	}
+
+	/**
+	 * Checks whether a feature exists in the catalog.
 	 *
 	 * @since 3.0.0
 	 *
@@ -265,32 +336,37 @@ class Manager {
 	 *
 	 * @return bool|WP_Error
 	 */
-	public function is_available( string $slug ) {
+	public function exists( string $slug ) {
 		$features = $this->repository->get( $this->key, $this->domain );
 
 		if ( is_wp_error( $features ) ) {
-			return new WP_Error(
-				Error_Code::FEATURE_CHECK_FAILED,
-				$features->get_error_message()
-			);
+			return $features;
 		}
 
 		return $features->get( $slug ) !== null;
 	}
 
 	/**
-	 * Gets the feature collection from the catalog.
+	 * Gets the feature collection from the catalog with live enabled state.
 	 *
 	 * @since 3.0.0
 	 *
 	 * @return Feature_Collection|WP_Error
 	 */
-	public function get_features() {
-		return $this->repository->get( $this->key, $this->domain );
+	public function get_all() {
+		$features = $this->repository->get( $this->key, $this->domain );
+
+		if ( is_wp_error( $features ) ) {
+			return $features;
+		}
+
+		$this->stamp_enabled_state( $features );
+
+		return $features;
 	}
 
 	/**
-	 * Looks up a feature by slug from the cached catalog.
+	 * Looks up a feature by slug from the cached catalog with live enabled state.
 	 *
 	 * Returns null when the feature is not found or when the API
 	 * request fails, since the catalog is unavailable.
@@ -301,13 +377,37 @@ class Manager {
 	 *
 	 * @return Feature|null
 	 */
-	public function get_feature( string $slug ): ?Feature {
-		$features = $this->repository->get( $this->key, $this->domain );
+	public function get( string $slug ): ?Feature {
+		$features = $this->get_all();
 
 		if ( is_wp_error( $features ) ) {
 			return null;
 		}
 
 		return $features->get( $slug );
+	}
+
+	/**
+	 * Stamps live enabled state onto every feature in the collection.
+	 *
+	 * The Feature_Collection may come from a transient cache where
+	 * is_enabled values are stale. This method overwrites each
+	 * feature's is_enabled with the current live state from its strategy.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param Feature_Collection $features The collection to stamp.
+	 *
+	 * @return void
+	 */
+	private function stamp_enabled_state( Feature_Collection $features ): void {
+		foreach ( $features as $feature ) {
+			$strategy           = $this->strategy_factory->make( $feature );
+			$class              = get_class( $feature );
+			$data               = $feature->to_array();
+			$data['is_enabled'] = $strategy->is_active();
+
+			$features->offsetSet( $feature->get_slug(), $class::from_array( $data ) );
+		}
 	}
 }

--- a/src/Uplink/Features/Types/Feature.php
+++ b/src/Uplink/Features/Types/Feature.php
@@ -163,6 +163,17 @@ abstract class Feature {
 	}
 
 	/**
+	 * Checks whether the feature is currently enabled/active.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return bool
+	 */
+	public function is_enabled(): bool {
+		return Cast::to_bool( $this->attributes['is_enabled'] ?? false );
+	}
+
+	/**
 	 * Gets the URL to the feature documentation or learn-more page.
 	 *
 	 * @since 3.0.0
@@ -190,6 +201,7 @@ abstract class Feature {
 			'name'              => Cast::to_string( $data['name'] ?? '' ),
 			'description'       => Cast::to_string( $data['description'] ?? '' ),
 			'is_available'      => Cast::to_bool( $data['is_available'] ?? false ),
+			'is_enabled'        => Cast::to_bool( $data['is_enabled'] ?? false ),
 			'documentation_url' => Cast::to_string( $data['documentation_url'] ?? '' ),
 		];
 	}

--- a/tests/wpunit/API/REST/V1/Feature_ControllerTest.php
+++ b/tests/wpunit/API/REST/V1/Feature_ControllerTest.php
@@ -46,26 +46,30 @@ final class Feature_ControllerTest extends UplinkTestCase {
 
 		$collection = new Feature_Collection();
 		$collection->add(
-			Plugin::from_array( [
-				'slug'              => 'feature-alpha',
-				'group'             => 'GroupA',
-				'tier'              => 'Tier 1',
-				'name'              => 'Feature Alpha',
-				'description'       => 'Alpha description',
-				'is_available'      => true,
-				'documentation_url' => 'https://example.com/alpha',
-			] )
+			Plugin::from_array(
+				[
+					'slug'              => 'feature-alpha',
+					'group'             => 'GroupA',
+					'tier'              => 'Tier 1',
+					'name'              => 'Feature Alpha',
+					'description'       => 'Alpha description',
+					'is_available'      => true,
+					'documentation_url' => 'https://example.com/alpha',
+				]
+			)
 		);
 		$collection->add(
-			Flag::from_array( [
-				'slug'              => 'feature-beta',
-				'group'             => 'GroupB',
-				'tier'              => 'Tier 2',
-				'name'              => 'Feature Beta',
-				'description'       => 'Beta description',
-				'is_available'      => false,
-				'documentation_url' => 'https://example.com/beta',
-			] )
+			Flag::from_array(
+				[
+					'slug'              => 'feature-beta',
+					'group'             => 'GroupB',
+					'tier'              => 'Tier 2',
+					'name'              => 'Feature Beta',
+					'description'       => 'Beta description',
+					'is_available'      => false,
+					'documentation_url' => 'https://example.com/beta',
+				]
+			)
 		);
 
 		$active = false;
@@ -463,7 +467,7 @@ final class Feature_ControllerTest extends UplinkTestCase {
 		);
 
 		$factory = $this->makeEmpty( Strategy_Factory::class );
-		$manager  = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
 
 		global $wp_rest_server;
 		$wp_rest_server = new WP_REST_Server();
@@ -729,7 +733,7 @@ final class Feature_ControllerTest extends UplinkTestCase {
 			]
 		);
 
-		$factory   = $this->makeEmpty( Strategy_Factory::class, [ 'make' => $error_strategy ] );
+		$factory    = $this->makeEmpty( Strategy_Factory::class, [ 'make' => $error_strategy ] );
 		$repository = $this->makeEmpty( Feature_Repository::class, [ 'get' => $this->manager->get_all() ] );
 		$manager    = new Manager( $repository, $factory, 'test-key', 'example.com' );
 
@@ -765,7 +769,7 @@ final class Feature_ControllerTest extends UplinkTestCase {
 		);
 
 		$factory = $this->makeEmpty( Strategy_Factory::class );
-		$manager  = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
 
 		global $wp_rest_server;
 		$wp_rest_server = new WP_REST_Server();
@@ -800,7 +804,7 @@ final class Feature_ControllerTest extends UplinkTestCase {
 			]
 		);
 
-		$factory   = $this->makeEmpty( Strategy_Factory::class, [ 'make' => $error_strategy ] );
+		$factory    = $this->makeEmpty( Strategy_Factory::class, [ 'make' => $error_strategy ] );
 		$repository = $this->makeEmpty( Feature_Repository::class, [ 'get' => $this->manager->get_all() ] );
 		$manager    = new Manager( $repository, $factory, 'test-key', 'example.com' );
 
@@ -838,7 +842,7 @@ final class Feature_ControllerTest extends UplinkTestCase {
 			]
 		);
 
-		$factory   = $this->makeEmpty( Strategy_Factory::class, [ 'make' => $error_strategy ] );
+		$factory    = $this->makeEmpty( Strategy_Factory::class, [ 'make' => $error_strategy ] );
 		$repository = $this->makeEmpty( Feature_Repository::class, [ 'get' => $this->manager->get_all() ] );
 		$manager    = new Manager( $repository, $factory, 'test-key', 'example.com' );
 

--- a/tests/wpunit/API/REST/V1/Feature_ControllerTest.php
+++ b/tests/wpunit/API/REST/V1/Feature_ControllerTest.php
@@ -10,6 +10,8 @@ use StellarWP\Uplink\Features\Manager;
 use StellarWP\Uplink\API\REST\V1\Feature_Controller;
 use StellarWP\Uplink\Features\Strategy\Strategy_Factory;
 use StellarWP\Uplink\Features\Types\Feature;
+use StellarWP\Uplink\Features\Types\Flag;
+use StellarWP\Uplink\Features\Types\Plugin;
 use StellarWP\Uplink\Tests\Traits\With_Uopz;
 use StellarWP\Uplink\Tests\UplinkTestCase;
 use WP_Error;
@@ -44,54 +46,26 @@ final class Feature_ControllerTest extends UplinkTestCase {
 
 		$collection = new Feature_Collection();
 		$collection->add(
-			$this->makeEmpty(
-				Feature::class,
-				[
-					'get_slug'              => 'feature-alpha',
-					'get_name'              => 'Feature Alpha',
-					'get_description'       => 'Alpha description',
-					'get_group'             => 'GroupA',
-					'get_tier'              => 'Tier 1',
-					'get_type'              => 'plugin',
-					'is_available'          => true,
-					'get_documentation_url' => 'https://example.com/alpha',
-					'to_array'              => [
-						'slug'              => 'feature-alpha',
-						'group'             => 'GroupA',
-						'tier'              => 'Tier 1',
-						'name'              => 'Feature Alpha',
-						'description'       => 'Alpha description',
-						'type'              => 'plugin',
-						'is_available'      => true,
-						'documentation_url' => 'https://example.com/alpha',
-					],
-				]
-			)
+			Plugin::from_array( [
+				'slug'              => 'feature-alpha',
+				'group'             => 'GroupA',
+				'tier'              => 'Tier 1',
+				'name'              => 'Feature Alpha',
+				'description'       => 'Alpha description',
+				'is_available'      => true,
+				'documentation_url' => 'https://example.com/alpha',
+			] )
 		);
 		$collection->add(
-			$this->makeEmpty(
-				Feature::class,
-				[
-					'get_slug'              => 'feature-beta',
-					'get_name'              => 'Feature Beta',
-					'get_description'       => 'Beta description',
-					'get_group'             => 'GroupB',
-					'get_tier'              => 'Tier 2',
-					'get_type'              => 'flag',
-					'is_available'          => false,
-					'get_documentation_url' => 'https://example.com/beta',
-					'to_array'              => [
-						'slug'              => 'feature-beta',
-						'group'             => 'GroupB',
-						'tier'              => 'Tier 2',
-						'name'              => 'Feature Beta',
-						'description'       => 'Beta description',
-						'type'              => 'flag',
-						'is_available'      => false,
-						'documentation_url' => 'https://example.com/beta',
-					],
-				]
-			)
+			Flag::from_array( [
+				'slug'              => 'feature-beta',
+				'group'             => 'GroupB',
+				'tier'              => 'Tier 2',
+				'name'              => 'Feature Beta',
+				'description'       => 'Beta description',
+				'is_available'      => false,
+				'documentation_url' => 'https://example.com/beta',
+			] )
 		);
 
 		$active = false;
@@ -756,7 +730,7 @@ final class Feature_ControllerTest extends UplinkTestCase {
 		);
 
 		$factory   = $this->makeEmpty( Strategy_Factory::class, [ 'make' => $error_strategy ] );
-		$repository = $this->makeEmpty( Feature_Repository::class, [ 'get' => $this->manager->get_features() ] );
+		$repository = $this->makeEmpty( Feature_Repository::class, [ 'get' => $this->manager->get_all() ] );
 		$manager    = new Manager( $repository, $factory, 'test-key', 'example.com' );
 
 		global $wp_rest_server;
@@ -827,7 +801,7 @@ final class Feature_ControllerTest extends UplinkTestCase {
 		);
 
 		$factory   = $this->makeEmpty( Strategy_Factory::class, [ 'make' => $error_strategy ] );
-		$repository = $this->makeEmpty( Feature_Repository::class, [ 'get' => $this->manager->get_features() ] );
+		$repository = $this->makeEmpty( Feature_Repository::class, [ 'get' => $this->manager->get_all() ] );
 		$manager    = new Manager( $repository, $factory, 'test-key', 'example.com' );
 
 		global $wp_rest_server;
@@ -865,7 +839,7 @@ final class Feature_ControllerTest extends UplinkTestCase {
 		);
 
 		$factory   = $this->makeEmpty( Strategy_Factory::class, [ 'make' => $error_strategy ] );
-		$repository = $this->makeEmpty( Feature_Repository::class, [ 'get' => $this->manager->get_features() ] );
+		$repository = $this->makeEmpty( Feature_Repository::class, [ 'get' => $this->manager->get_all() ] );
 		$manager    = new Manager( $repository, $factory, 'test-key', 'example.com' );
 
 		global $wp_rest_server;

--- a/tests/wpunit/CLI/Commands/FeatureTest.php
+++ b/tests/wpunit/CLI/Commands/FeatureTest.php
@@ -310,7 +310,7 @@ final class FeatureTest extends UplinkTestCase {
 	public function test_is_enabled_calls_error_for_nonexistent_feature(): void {
 		$this->command->is_enabled( [ 'nonexistent' ], [] );
 
-		$this->assertSame( 'Feature "nonexistent" not found.', $this->logger->last_error );
+		$this->assertStringContainsString( 'nonexistent', $this->logger->last_error );
 	}
 
 	// ------------------------------------------------------------------
@@ -318,7 +318,7 @@ final class FeatureTest extends UplinkTestCase {
 	// ------------------------------------------------------------------
 
 	public function test_feature_to_display_item_converts_booleans(): void {
-		$feature = $this->collection->get( 'test-flag' );
+		$feature = $this->manager->get( 'test-flag' );
 		$this->assertNotNull( $feature );
 
 		/** @var array<string, mixed> $item */
@@ -371,8 +371,8 @@ final class FeatureTest extends UplinkTestCase {
 		$this->assertSame( 'true', $item['is_dot_org'] );
 	}
 
-	public function test_feature_to_display_item_resolves_enabled_via_manager(): void {
-		$feature = $this->collection->get( 'test-flag' );
+	public function test_feature_to_display_item_reads_enabled_from_feature(): void {
+		$feature = $this->manager->get( 'test-flag' );
 		$this->assertNotNull( $feature );
 
 		/** @var array<string, mixed> $item */
@@ -388,7 +388,7 @@ final class FeatureTest extends UplinkTestCase {
 		$manager    = new Manager( $repository, $factory, 'test-key', 'example.com' );
 		$command    = new Feature_Command( $manager );
 
-		$feature = $this->collection->get( 'test-flag' );
+		$feature = $manager->get( 'test-flag' );
 		$this->assertNotNull( $feature );
 
 		/** @var array<string, mixed> $item */

--- a/tests/wpunit/Features/Error_CodeTest.php
+++ b/tests/wpunit/Features/Error_CodeTest.php
@@ -35,6 +35,8 @@ final class Error_CodeTest extends UplinkTestCase {
 			'PLUGINS_API_FAILED'             => [ Error_Code::PLUGINS_API_FAILED, 502 ],
 			'THEMES_API_FAILED'              => [ Error_Code::THEMES_API_FAILED, 502 ],
 			'UNKNOWN_FEATURE_TYPE'           => [ Error_Code::UNKNOWN_FEATURE_TYPE, 422 ],
+			'FEATURE_ENABLE_FAILED'          => [ Error_Code::FEATURE_ENABLE_FAILED, 422 ],
+			'FEATURE_DISABLE_FAILED'         => [ Error_Code::FEATURE_DISABLE_FAILED, 422 ],
 		];
 	}
 

--- a/tests/wpunit/Features/Feature_RepositoryTest.php
+++ b/tests/wpunit/Features/Feature_RepositoryTest.php
@@ -55,7 +55,7 @@ final class Feature_RepositoryTest extends UplinkTestCase {
 	 * Creates a Resolve_Feature_Collection with the given repository dependencies.
 	 *
 	 * @param Catalog_Repository $catalog  The catalog repository.
-	 * @param License_Repository $licensing The licensing repository.
+	 * @param License_Manager    $licensing The licensing manager.
 	 *
 	 * @return Resolve_Feature_Collection
 	 */

--- a/tests/wpunit/Features/FunctionsTest.php
+++ b/tests/wpunit/Features/FunctionsTest.php
@@ -8,7 +8,7 @@ use StellarWP\Uplink\Features\Feature_Collection;
 use StellarWP\Uplink\Features\Contracts\Strategy;
 use StellarWP\Uplink\Features\Manager;
 use StellarWP\Uplink\Features\Strategy\Strategy_Factory;
-use StellarWP\Uplink\Features\Types\Feature;
+use StellarWP\Uplink\Features\Types\Flag;
 use StellarWP\Uplink\Tests\UplinkTestCase;
 use WP_Error;
 
@@ -23,7 +23,14 @@ final class FunctionsTest extends UplinkTestCase {
 		parent::setUp();
 
 		$collection = new Feature_Collection();
-		$collection->add( $this->makeEmpty( Feature::class, [ 'get_slug' => 'test-feature' ] ) );
+		$collection->add( Flag::from_array( [
+			'slug'         => 'test-feature',
+			'name'         => 'Test Feature',
+			'description'  => '',
+			'group'        => 'test',
+			'tier'         => 'free',
+			'is_available' => true,
+		] ) );
 
 		$mock_strategy = $this->makeEmpty(
 			Strategy::class,
@@ -68,34 +75,87 @@ final class FunctionsTest extends UplinkTestCase {
 	}
 
 	/**
-	 * Tests is_feature_enabled returns false for a feature not in the catalog.
+	 * Tests is_feature_enabled returns WP_Error for a feature not in the catalog.
 	 *
 	 * @return void
 	 */
-	public function test_is_feature_enabled_returns_false_for_unknown_feature(): void {
-		$this->assertFalse( stellarwp_uplink_is_feature_enabled( 'nonexistent' ) );
+	public function test_is_feature_enabled_returns_wp_error_for_unknown_feature(): void {
+		$result = stellarwp_uplink_is_feature_enabled( 'nonexistent' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
 	}
 
 	/**
-	 * Tests is_feature_available returns true for a feature present in the catalog.
+	 * Tests is_feature_available returns true for a feature with is_available set.
 	 *
 	 * @return void
 	 */
-	public function test_is_feature_available_returns_true_for_catalog_feature(): void {
+	public function test_is_feature_available_returns_true_for_available_feature(): void {
 		$this->assertTrue( stellarwp_uplink_is_feature_available( 'test-feature' ) );
 	}
 
 	/**
-	 * Tests is_feature_available returns false for a feature not in the catalog.
+	 * Tests is_feature_available returns false for a feature with is_available unset.
 	 *
 	 * @return void
 	 */
-	public function test_is_feature_available_returns_false_for_unknown_feature(): void {
-		$this->assertFalse( stellarwp_uplink_is_feature_available( 'nonexistent' ) );
+	public function test_is_feature_available_returns_false_for_unavailable_feature(): void {
+		$collection = new Feature_Collection();
+		$collection->add( Flag::from_array( [
+			'slug'         => 'locked-feature',
+			'name'         => 'Locked Feature',
+			'description'  => '',
+			'group'        => 'test',
+			'tier'         => 'pro',
+			'is_available' => false,
+		] ) );
+
+		$mock_strategy = $this->makeEmpty(
+			Strategy::class,
+			[
+				'is_active' => false,
+			]
+		);
+
+		$factory = $this->makeEmpty(
+			Strategy_Factory::class,
+			[
+				'make' => $mock_strategy,
+			]
+		);
+
+		$repository = $this->makeEmpty(
+			Feature_Repository::class,
+			[
+				'get' => $collection,
+			]
+		);
+
+		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+
+		$this->container->bind(
+			Manager::class,
+			static function () use ( $manager ) {
+				return $manager;
+			}
+		);
+
+		$this->assertFalse( stellarwp_uplink_is_feature_available( 'locked-feature' ) );
 	}
 
 	/**
-	 * Tests that is_feature_enabled returns a WP_Error when the catalog returns a WP_Error.
+	 * Tests is_feature_available returns WP_Error for a feature not in the catalog.
+	 *
+	 * @return void
+	 */
+	public function test_is_feature_available_returns_wp_error_for_unknown_feature(): void {
+		$result = stellarwp_uplink_is_feature_available( 'nonexistent' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+	}
+
+	/**
+	 * Tests that is_feature_enabled returns WP_Error when the catalog returns a WP_Error.
 	 *
 	 * @return void
 	 */
@@ -122,7 +182,6 @@ final class FunctionsTest extends UplinkTestCase {
 
 		$result = stellarwp_uplink_is_feature_enabled( 'test-feature' );
 		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( Error_Code::FEATURE_CHECK_FAILED, $result->get_error_code() );
 	}
 
 	/**
@@ -153,6 +212,6 @@ final class FunctionsTest extends UplinkTestCase {
 
 		$result = stellarwp_uplink_is_feature_available( 'test-feature' );
 		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( Error_Code::FEATURE_CHECK_FAILED, $result->get_error_code() );
+		$this->assertSame( 'api_error', $result->get_error_code() );
 	}
 }

--- a/tests/wpunit/Features/FunctionsTest.php
+++ b/tests/wpunit/Features/FunctionsTest.php
@@ -2,7 +2,6 @@
 
 namespace StellarWP\Uplink\Tests\Features;
 
-use StellarWP\Uplink\Features\Error_Code;
 use StellarWP\Uplink\Features\Feature_Repository;
 use StellarWP\Uplink\Features\Feature_Collection;
 use StellarWP\Uplink\Features\Contracts\Strategy;
@@ -23,14 +22,18 @@ final class FunctionsTest extends UplinkTestCase {
 		parent::setUp();
 
 		$collection = new Feature_Collection();
-		$collection->add( Flag::from_array( [
-			'slug'         => 'test-feature',
-			'name'         => 'Test Feature',
-			'description'  => '',
-			'group'        => 'test',
-			'tier'         => 'free',
-			'is_available' => true,
-		] ) );
+		$collection->add(
+			Flag::from_array(
+				[
+					'slug'         => 'test-feature',
+					'name'         => 'Test Feature',
+					'description'  => '',
+					'group'        => 'test',
+					'tier'         => 'free',
+					'is_available' => true,
+				]
+			)
+		);
 
 		$mock_strategy = $this->makeEmpty(
 			Strategy::class,
@@ -101,14 +104,18 @@ final class FunctionsTest extends UplinkTestCase {
 	 */
 	public function test_is_feature_available_returns_false_for_unavailable_feature(): void {
 		$collection = new Feature_Collection();
-		$collection->add( Flag::from_array( [
-			'slug'         => 'locked-feature',
-			'name'         => 'Locked Feature',
-			'description'  => '',
-			'group'        => 'test',
-			'tier'         => 'pro',
-			'is_available' => false,
-		] ) );
+		$collection->add(
+			Flag::from_array(
+				[
+					'slug'         => 'locked-feature',
+					'name'         => 'Locked Feature',
+					'description'  => '',
+					'group'        => 'test',
+					'tier'         => 'pro',
+					'is_available' => false,
+				]
+			)
+		);
 
 		$mock_strategy = $this->makeEmpty(
 			Strategy::class,

--- a/tests/wpunit/Features/ManagerTest.php
+++ b/tests/wpunit/Features/ManagerTest.php
@@ -54,7 +54,13 @@ final class ManagerTest extends UplinkTestCase {
 		delete_transient( 'stellarwp_uplink_feature_catalog' );
 
 		$this->collection = new Feature_Collection();
-		$this->collection->add( $this->makeEmpty( Feature::class, [ 'get_slug' => 'test-feature' ] ) );
+		$this->collection->add( Flag::from_array( [
+			'slug'         => 'test-feature',
+			'group'        => 'TestGroup',
+			'tier'         => 'Tier 1',
+			'name'         => 'Test Feature',
+			'is_available' => true,
+		] ) );
 
 		$repository = $this->makeEmpty(
 			Feature_Repository::class,
@@ -105,7 +111,7 @@ final class ManagerTest extends UplinkTestCase {
 	public function test_it_enables_a_feature(): void {
 		$result = $this->manager->enable( 'test-feature' );
 
-		$this->assertTrue( $result );
+		$this->assertInstanceOf( Feature::class, $result );
 	}
 
 	/**
@@ -128,7 +134,7 @@ final class ManagerTest extends UplinkTestCase {
 	public function test_it_disables_a_feature(): void {
 		$result = $this->manager->disable( 'test-feature' );
 
-		$this->assertTrue( $result );
+		$this->assertInstanceOf( Feature::class, $result );
 	}
 
 	/**
@@ -153,30 +159,15 @@ final class ManagerTest extends UplinkTestCase {
 	}
 
 	/**
-	 * Tests is_enabled returns false for a feature not in the catalog.
+	 * Tests is_enabled returns WP_Error for a feature not in the catalog.
 	 *
 	 * @return void
 	 */
-	public function test_is_enabled_returns_false_for_unknown_feature(): void {
-		$this->assertFalse( $this->manager->is_enabled( 'nonexistent' ) );
-	}
+	public function test_is_enabled_returns_wp_error_for_unknown_feature(): void {
+		$result = $this->manager->is_enabled( 'nonexistent' );
 
-	/**
-	 * Tests is_available returns true for a feature present in the catalog.
-	 *
-	 * @return void
-	 */
-	public function test_is_available_returns_true_for_catalog_feature(): void {
-		$this->assertTrue( $this->manager->is_available( 'test-feature' ) );
-	}
-
-	/**
-	 * Tests is_available returns false for a feature not in the catalog.
-	 *
-	 * @return void
-	 */
-	public function test_is_available_returns_false_for_unknown_feature(): void {
-		$this->assertFalse( $this->manager->is_available( 'nonexistent' ) );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( Error_Code::FEATURE_NOT_FOUND, $result->get_error_code() );
 	}
 
 	/**
@@ -185,7 +176,7 @@ final class ManagerTest extends UplinkTestCase {
 	 * @return void
 	 */
 	public function test_get_features_returns_collection(): void {
-		$features = $this->manager->get_features();
+		$features = $this->manager->get_all();
 
 		$this->assertInstanceOf( Feature_Collection::class, $features );
 		$this->assertSame( 1, $features->count() );
@@ -201,11 +192,11 @@ final class ManagerTest extends UplinkTestCase {
 
 		$manager = $this->container->get( Manager::class );
 
-		$flag = $manager->get_feature( 'kad-pattern-hub' );
+		$flag = $manager->get( 'kad-pattern-hub' );
 		$this->assertInstanceOf( Flag::class, $flag );
 		$this->assertSame( 'kad-pattern-hub', $flag->get_slug() );
 
-		$plugin = $manager->get_feature( 'kad-blocks-pro' );
+		$plugin = $manager->get( 'kad-blocks-pro' );
 		$this->assertInstanceOf( Plugin::class, $plugin );
 		$this->assertSame( 'kad-blocks-pro', $plugin->get_slug() );
 	}
@@ -221,13 +212,17 @@ final class ManagerTest extends UplinkTestCase {
 		$manager    = $this->container->get( Manager::class );
 		$option_key = 'stellarwp_uplink_feature_kad-pattern-hub_active';
 
-		// Enable — DB flag set, is_enabled agrees.
-		$this->assertTrue( $manager->enable( 'kad-pattern-hub' ) );
+		// Enable — DB flag set, returned feature and is_enabled agree.
+		$enabled = $manager->enable( 'kad-pattern-hub' );
+		$this->assertInstanceOf( Feature::class, $enabled );
+		$this->assertTrue( $enabled->is_enabled() );
 		$this->assertSame( '1', get_option( $option_key ) );
 		$this->assertTrue( $manager->is_enabled( 'kad-pattern-hub' ) );
 
-		// Disable — DB flag cleared, is_enabled agrees.
-		$this->assertTrue( $manager->disable( 'kad-pattern-hub' ) );
+		// Disable — DB flag cleared, returned feature and is_enabled agree.
+		$disabled = $manager->disable( 'kad-pattern-hub' );
+		$this->assertInstanceOf( Feature::class, $disabled );
+		$this->assertFalse( $disabled->is_enabled() );
 		$this->assertSame( '0', get_option( $option_key ) );
 		$this->assertFalse( $manager->is_enabled( 'kad-pattern-hub' ) );
 	}
@@ -437,11 +432,11 @@ final class ManagerTest extends UplinkTestCase {
 
 		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
 
-		$this->assertInstanceOf( WP_Error::class, $manager->get_features() );
+		$this->assertInstanceOf( WP_Error::class, $manager->get_all() );
 	}
 
 	/**
-	 * Tests that is_enabled returns a WP_Error when the catalog returns a WP_Error.
+	 * Tests that is_enabled returns WP_Error when the catalog returns a WP_Error.
 	 *
 	 * @return void
 	 */
@@ -460,12 +455,75 @@ final class ManagerTest extends UplinkTestCase {
 		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
 
 		$result = $manager->is_enabled( 'test-feature' );
+
 		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( Error_Code::FEATURE_CHECK_FAILED, $result->get_error_code() );
+		$this->assertSame( 'api_error', $result->get_error_code() );
 	}
 
 	/**
-	 * Tests that is_available returns a WP_Error when the catalog returns a WP_Error.
+	 * Tests is_available returns true for a feature with is_available set.
+	 *
+	 * @return void
+	 */
+	public function test_is_available_returns_true_for_available_feature(): void {
+		$this->assertTrue( $this->manager->is_available( 'test-feature' ) );
+	}
+
+	/**
+	 * Tests is_available returns false for a feature with is_available unset.
+	 *
+	 * @return void
+	 */
+	public function test_is_available_returns_false_for_unavailable_feature(): void {
+		$collection = new Feature_Collection();
+		$collection->add( Flag::from_array( [
+			'slug'         => 'locked-feature',
+			'group'        => 'TestGroup',
+			'tier'         => 'Pro',
+			'name'         => 'Locked Feature',
+			'is_available' => false,
+		] ) );
+
+		$strategy = $this->makeEmpty(
+			Strategy::class,
+			[
+				'is_active' => false,
+			]
+		);
+
+		$factory = $this->makeEmpty(
+			Strategy_Factory::class,
+			[
+				'make' => $strategy,
+			]
+		);
+
+		$repository = $this->makeEmpty(
+			Feature_Repository::class,
+			[
+				'get' => $collection,
+			]
+		);
+
+		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+
+		$this->assertFalse( $manager->is_available( 'locked-feature' ) );
+	}
+
+	/**
+	 * Tests is_available returns WP_Error for an unknown feature.
+	 *
+	 * @return void
+	 */
+	public function test_is_available_returns_wp_error_for_unknown_feature(): void {
+		$result = $this->manager->is_available( 'nonexistent' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( Error_Code::FEATURE_NOT_FOUND, $result->get_error_code() );
+	}
+
+	/**
+	 * Tests is_available returns WP_Error when the catalog errors.
 	 *
 	 * @return void
 	 */
@@ -483,9 +541,117 @@ final class ManagerTest extends UplinkTestCase {
 
 		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
 
-		$result = $manager->is_available( 'test-feature' );
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( Error_Code::FEATURE_CHECK_FAILED, $result->get_error_code() );
+		$this->assertInstanceOf( WP_Error::class, $manager->is_available( 'test-feature' ) );
+	}
+
+	/**
+	 * Tests that exists returns true for a feature in the catalog.
+	 *
+	 * @return void
+	 */
+	public function test_exists_returns_true_for_catalog_feature(): void {
+		$this->assertTrue( $this->manager->exists( 'test-feature' ) );
+	}
+
+	/**
+	 * Tests that exists returns false for a feature not in the catalog.
+	 *
+	 * @return void
+	 */
+	public function test_exists_returns_false_for_unknown_feature(): void {
+		$this->assertFalse( $this->manager->exists( 'nonexistent' ) );
+	}
+
+	/**
+	 * Tests that exists returns WP_Error when the catalog errors.
+	 *
+	 * @return void
+	 */
+	public function test_exists_returns_wp_error_when_catalog_errors(): void {
+		$error = new WP_Error( 'api_error', 'Could not fetch features.' );
+
+		$repository = $this->makeEmpty(
+			Feature_Repository::class,
+			[
+				'get' => $error,
+			]
+		);
+
+		$factory = $this->makeEmpty( Strategy_Factory::class );
+
+		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+
+		$this->assertInstanceOf( WP_Error::class, $manager->exists( 'test-feature' ) );
+	}
+
+	/**
+	 * Tests that get returns null when the catalog errors.
+	 *
+	 * @return void
+	 */
+	public function test_get_returns_null_when_catalog_errors(): void {
+		$error = new WP_Error( 'api_error', 'Could not fetch features.' );
+
+		$repository = $this->makeEmpty(
+			Feature_Repository::class,
+			[
+				'get' => $error,
+			]
+		);
+
+		$factory = $this->makeEmpty( Strategy_Factory::class );
+
+		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+
+		$this->assertNull( $manager->get( 'test-feature' ) );
+	}
+
+	/**
+	 * Tests that enable returns a Feature with is_enabled stamped.
+	 *
+	 * @return void
+	 */
+	public function test_enable_returns_feature_with_enabled_state(): void {
+		$result = $this->manager->enable( 'test-feature' );
+
+		$this->assertInstanceOf( Feature::class, $result );
+		$this->assertTrue( $result->is_enabled() );
+	}
+
+	/**
+	 * Tests that disable returns a Feature with is_enabled stamped.
+	 *
+	 * @return void
+	 */
+	public function test_disable_returns_feature_with_disabled_state(): void {
+		$inactive_strategy = $this->makeEmpty(
+			Strategy::class,
+			[
+				'disable'   => true,
+				'is_active' => false,
+			]
+		);
+
+		$factory = $this->makeEmpty(
+			Strategy_Factory::class,
+			[
+				'make' => $inactive_strategy,
+			]
+		);
+
+		$repository = $this->makeEmpty(
+			Feature_Repository::class,
+			[
+				'get' => $this->collection,
+			]
+		);
+
+		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+
+		$result = $manager->disable( 'test-feature' );
+
+		$this->assertInstanceOf( Feature::class, $result );
+		$this->assertFalse( $result->is_enabled() );
 	}
 
 	/**

--- a/tests/wpunit/Features/ManagerTest.php
+++ b/tests/wpunit/Features/ManagerTest.php
@@ -54,13 +54,17 @@ final class ManagerTest extends UplinkTestCase {
 		delete_transient( 'stellarwp_uplink_feature_catalog' );
 
 		$this->collection = new Feature_Collection();
-		$this->collection->add( Flag::from_array( [
-			'slug'         => 'test-feature',
-			'group'        => 'TestGroup',
-			'tier'         => 'Tier 1',
-			'name'         => 'Test Feature',
-			'is_available' => true,
-		] ) );
+		$this->collection->add(
+			Flag::from_array(
+				[
+					'slug'         => 'test-feature',
+					'group'        => 'TestGroup',
+					'tier'         => 'Tier 1',
+					'name'         => 'Test Feature',
+					'is_available' => true,
+				]
+			)
+		);
 
 		$repository = $this->makeEmpty(
 			Feature_Repository::class,
@@ -476,13 +480,17 @@ final class ManagerTest extends UplinkTestCase {
 	 */
 	public function test_is_available_returns_false_for_unavailable_feature(): void {
 		$collection = new Feature_Collection();
-		$collection->add( Flag::from_array( [
-			'slug'         => 'locked-feature',
-			'group'        => 'TestGroup',
-			'tier'         => 'Pro',
-			'name'         => 'Locked Feature',
-			'is_available' => false,
-		] ) );
+		$collection->add(
+			Flag::from_array(
+				[
+					'slug'         => 'locked-feature',
+					'group'        => 'TestGroup',
+					'tier'         => 'Pro',
+					'name'         => 'Locked Feature',
+					'is_available' => false,
+				]
+			)
+		);
 
 		$strategy = $this->makeEmpty(
 			Strategy::class,

--- a/tests/wpunit/Features/Types/FeatureTest.php
+++ b/tests/wpunit/Features/Types/FeatureTest.php
@@ -30,6 +30,7 @@ final class FeatureTest extends UplinkTestCase {
 			'description'       => 'A test feature.',
 			'type'              => 'test-type',
 			'is_available'      => true,
+			'is_enabled'        => false,
 			'documentation_url' => 'https://example.com/docs',
 		] ) extends Feature {
 
@@ -50,8 +51,9 @@ final class FeatureTest extends UplinkTestCase {
 						'description'       => $data['description'] ?? '',
 						'type'              => $data['type'] ?? 'test-type',
 						'is_available'      => $data['is_available'],
+						'is_enabled'        => $data['is_enabled'] ?? false,
 						'documentation_url' => $data['documentation_url'] ?? '',
-					] 
+					]
 				);
 			}
 		};
@@ -121,6 +123,31 @@ final class FeatureTest extends UplinkTestCase {
 	}
 
 	/**
+	 * Tests that is_enabled defaults to false.
+	 *
+	 * @return void
+	 */
+	public function test_is_enabled_defaults_to_false(): void {
+		$this->assertFalse( $this->feature->is_enabled() );
+	}
+
+	/**
+	 * Tests that is_enabled is preserved through from_array round-trip.
+	 *
+	 * @return void
+	 */
+	public function test_is_enabled_round_trips_through_from_array(): void {
+		$data                = $this->feature->to_array();
+		$data['is_enabled'] = true;
+
+		$rebuilt = $this->feature::from_array( $data );
+
+		$this->assertTrue( $rebuilt->is_enabled() );
+		$this->assertTrue( $rebuilt->to_array()['is_enabled'] );
+		$this->assertFalse( $this->feature->is_enabled(), 'Original should be unchanged.' );
+	}
+
+	/**
 	 * Tests that get_documentation_url returns the URL passed to the constructor.
 	 *
 	 * @return void
@@ -146,9 +173,10 @@ final class FeatureTest extends UplinkTestCase {
 				'description'       => 'A test feature.',
 				'type'              => 'test-type',
 				'is_available'      => true,
+				'is_enabled'        => false,
 				'documentation_url' => 'https://example.com/docs',
 			],
-			$result 
+			$result
 		);
 	}
 

--- a/tests/wpunit/Features/Types/FlagTest.php
+++ b/tests/wpunit/Features/Types/FlagTest.php
@@ -83,6 +83,7 @@ final class FlagTest extends UplinkTestCase {
 			'description'       => 'Test feature description.',
 			'type'              => 'flag',
 			'is_available'      => true,
+			'is_enabled'        => false,
 			'documentation_url' => 'https://example.com/docs',
 		];
 

--- a/tests/wpunit/Features/Types/PluginTest.php
+++ b/tests/wpunit/Features/Types/PluginTest.php
@@ -137,10 +137,11 @@ final class PluginTest extends UplinkTestCase {
 			'name'              => 'Test Feature',
 			'description'       => 'Test feature description.',
 			'type'              => 'plugin',
+			'is_available'      => true,
+			'is_enabled'        => false,
+			'documentation_url' => 'https://example.com/docs',
 			'plugin_file'       => 'test-feature/test-feature.php',
 			'plugin_slug'       => '',
-			'is_available'      => true,
-			'documentation_url' => 'https://example.com/docs',
 			'authors'           => [ 'StellarWP' ],
 			'is_dot_org'        => false,
 		];

--- a/tests/wpunit/Features/Types/ThemeTest.php
+++ b/tests/wpunit/Features/Types/ThemeTest.php
@@ -130,6 +130,7 @@ final class ThemeTest extends UplinkTestCase {
 			'description'       => 'Test theme description.',
 			'type'              => 'theme',
 			'is_available'      => true,
+			'is_enabled'        => false,
 			'documentation_url' => 'https://example.com/docs',
 			'authors'           => [ 'StellarWP' ],
 			'is_dot_org'        => false,


### PR DESCRIPTION
🎫 [SCON-309]

### Problem

Every Feature has two independent states per the docs: is_available (license tier qualifies) and is_enabled (actively turned on for this site). But only is_available is part of the Feature object. is_enabled is computed separately by Manager::is_enabled() and bolted on at the REST boundary in Feature_Controller::prepare_feature_data().
This means the Feature object is incomplete. Any consumer outside the REST controller (global functions, cross-instance hooks, thin instance queries) has to go through the Manager to determine enabled state rather than reading it from the Feature they already have. Plugin and Theme features are the most affected since their source of truth is live WordPress state (is_plugin_active(), wp_get_theme()->exists()), but that state never makes it onto the Feature object.

### Artifact

https://www.loom.com/share/5155a64af0214c9b8d31cac2b7763d9b

### Notes

Many things can be done in different ways, I was debating with myself, so I'm fine if we want to change a lot. I also want to make sure I achieved what was needed.



[SCON-309]: https://stellarwp.atlassian.net/browse/SCON-309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ