### PR TITLE
refactor: update catalog storage to match licensing

### DIFF
--- a/src/Uplink/Catalog/Catalog_Repository.php
+++ b/src/Uplink/Catalog/Catalog_Repository.php
@@ -6,7 +6,7 @@ use StellarWP\Uplink\Catalog\Contracts\Catalog_Client;
 use WP_Error;
 
 /**
- * Transient-cached repository for the product catalog.
+ * Option-backed repository for the product catalog.
  *
  * This is the public API that the rest of Uplink uses — it never
  * exposes the client directly.
@@ -16,22 +16,58 @@ use WP_Error;
 final class Catalog_Repository {
 
 	/**
-	 * Transient key for the cached catalog.
+	 * Option name for the catalog state envelope.
+	 *
+	 * Stores an associative array with four keys:
+	 *   - collection      (array|null)     Catalog_Collection::to_array() from the last
+	 *                                     successful API fetch, or null if never fetched.
+	 *   - last_success_at (int|null)      Unix timestamp of the last successful fetch.
+	 *   - last_failure_at (int|null)      Unix timestamp of the most recent failed fetch,
+	 *                                     or null if no failure has occurred.
+	 *   - last_error      (WP_Error|null) Error from the most recent failed attempt, or
+	 *                                     null when the last fetch succeeded.
 	 *
 	 * @since 3.0.0
 	 *
 	 * @var string
 	 */
-	public const TRANSIENT_KEY = 'stellarwp_uplink_catalog';
+	public const CATALOG_STATE_OPTION_NAME = 'stellarwp_uplink_catalog_state';
 
 	/**
-	 * Default cache duration in seconds (12 hours).
+	 * State envelope key for the serialized catalog collection array.
 	 *
 	 * @since 3.0.0
 	 *
-	 * @var int
+	 * @var string
 	 */
-	private const CACHE_DURATION = HOUR_IN_SECONDS * 12;
+	private const STATE_KEY_COLLECTION = 'collection';
+
+	/**
+	 * State envelope key for the last successful fetch timestamp.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string
+	 */
+	private const STATE_KEY_LAST_SUCCESS_AT = 'last_success_at';
+
+	/**
+	 * State envelope key for the last failed fetch timestamp.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string
+	 */
+	private const STATE_KEY_LAST_FAILURE_AT = 'last_failure_at';
+
+	/**
+	 * State envelope key for the last fetch error.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string
+	 */
+	private const STATE_KEY_LAST_ERROR = 'last_error';
 
 	/**
 	 * The catalog client.
@@ -54,42 +90,39 @@ final class Catalog_Repository {
 	}
 
 	/**
-	 * Gets the full catalog, using the transient cache when available.
+	 * Gets the full catalog, using the stored option when available.
+	 *
+	 * Returns the stored collection if one exists (even if a later fetch failed).
+	 * Otherwise fetches from the API, which covers the first-ever request and
+	 * error-only state.
 	 *
 	 * @since 3.0.0
 	 *
 	 * @return Catalog_Collection|WP_Error
 	 */
 	public function get() {
-		$cached = get_transient( self::TRANSIENT_KEY );
+		$state = $this->read_catalog_state();
 
-		if ( is_wp_error( $cached ) ) {
-			return $cached;
-		}
-
-		if ( is_array( $cached ) ) {
-			/** @var array<array<string, mixed>> $cached */
-			return Catalog_Collection::from_array( $cached );
+		if ( is_array( $state[ self::STATE_KEY_COLLECTION ] ) ) {
+			return Catalog_Collection::from_array( $state[ self::STATE_KEY_COLLECTION ] );
 		}
 
 		return $this->fetch();
 	}
 
 	/**
-	 * Deletes the transient cache and re-fetches from the client.
+	 * Always fetches from the API, bypassing stored state.
 	 *
 	 * @since 3.0.0
 	 *
 	 * @return Catalog_Collection|WP_Error
 	 */
 	public function refresh() {
-		delete_transient( self::TRANSIENT_KEY );
-
 		return $this->fetch();
 	}
 
 	/**
-	 * Fetches from the client and caches the result.
+	 * Fetches from the client and persists the result.
 	 *
 	 * @since 3.0.0
 	 *
@@ -97,13 +130,133 @@ final class Catalog_Repository {
 	 */
 	protected function fetch() {
 		$result = $this->client->get_catalog();
-
-		if ( $result instanceof Catalog_Collection ) {
-			set_transient( self::TRANSIENT_KEY, $result->to_array(), self::CACHE_DURATION );
-		} elseif ( is_wp_error( $result ) ) {
-			set_transient( self::TRANSIENT_KEY, $result, self::CACHE_DURATION );
-		}
+		$this->set_catalog( $result );
 
 		return $result;
+	}
+
+	/**
+	 * Persist the catalog collection or a fetch error to the state option.
+	 *
+	 * On success (Catalog_Collection): updates collection and last_success_at,
+	 * clears last_error.
+	 *
+	 * On failure (WP_Error): stores last_error and last_failure_at only. The
+	 * existing collection is preserved so callers can still use the last
+	 * known-good catalog.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param Catalog_Collection|WP_Error $data The catalog or fetch error to store.
+	 *
+	 * @return void
+	 */
+	public function set_catalog( $data ): void {
+		if ( $data instanceof Catalog_Collection ) {
+			$state                                    = $this->read_catalog_state();
+			$state[ self::STATE_KEY_COLLECTION ]      = $data->to_array();
+			$state[ self::STATE_KEY_LAST_SUCCESS_AT ] = time();
+			$state[ self::STATE_KEY_LAST_ERROR ]      = null;
+			update_option( self::CATALOG_STATE_OPTION_NAME, $state, false );
+
+			return;
+		}
+
+		if ( is_wp_error( $data ) ) {
+			$state                                    = $this->read_catalog_state();
+			$state[ self::STATE_KEY_LAST_ERROR ]      = $data;
+			$state[ self::STATE_KEY_LAST_FAILURE_AT ] = time();
+			update_option( self::CATALOG_STATE_OPTION_NAME, $state, false );
+		}
+	}
+
+	/**
+	 * Delete the entire catalog state option.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return void
+	 */
+	public function delete_catalog(): void {
+		delete_option( self::CATALOG_STATE_OPTION_NAME );
+	}
+
+	/**
+	 * Unix timestamp of the last successful catalog fetch, or null if never fetched.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return int|null
+	 */
+	public function get_last_success_at(): ?int {
+		$value = $this->read_catalog_state()[ self::STATE_KEY_LAST_SUCCESS_AT ];
+
+		return is_int( $value ) ? $value : null;
+	}
+
+	/**
+	 * Unix timestamp of the most recent failed catalog fetch, or null if no
+	 * failure has occurred.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return int|null
+	 */
+	public function get_last_failure_at(): ?int {
+		$value = $this->read_catalog_state()[ self::STATE_KEY_LAST_FAILURE_AT ];
+
+		return is_int( $value ) ? $value : null;
+	}
+
+	/**
+	 * WP_Error from the most recent failed fetch attempt, or null if the last
+	 * fetch was successful (or no fetch has occurred).
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return WP_Error|null
+	 */
+	public function get_last_error(): ?WP_Error {
+		$error = $this->read_catalog_state()[ self::STATE_KEY_LAST_ERROR ];
+
+		return $error instanceof WP_Error ? $error : null;
+	}
+
+	/**
+	 * Read the raw catalog state array from the option, returning a zeroed
+	 * default when nothing has been stored.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return array{collection: array<array<string,mixed>>|null, last_success_at: int|null, last_failure_at: int|null, last_error: WP_Error|null}
+	 */
+	private function read_catalog_state(): array {
+		$raw = get_option( self::CATALOG_STATE_OPTION_NAME, null );
+
+		if ( ! is_array( $raw ) ) {
+			return [
+				self::STATE_KEY_COLLECTION      => null,
+				self::STATE_KEY_LAST_SUCCESS_AT => null,
+				self::STATE_KEY_LAST_FAILURE_AT => null,
+				self::STATE_KEY_LAST_ERROR      => null,
+			];
+		}
+
+		$collection = null;
+		if ( isset( $raw[ self::STATE_KEY_COLLECTION ] ) && is_array( $raw[ self::STATE_KEY_COLLECTION ] ) ) {
+			/** @var array<array<string, mixed>> $collection */
+			$collection = $raw[ self::STATE_KEY_COLLECTION ];
+		}
+
+		$last_success_at = isset( $raw[ self::STATE_KEY_LAST_SUCCESS_AT ] ) && is_int( $raw[ self::STATE_KEY_LAST_SUCCESS_AT ] ) ? $raw[ self::STATE_KEY_LAST_SUCCESS_AT ] : null;
+		$last_failure_at = isset( $raw[ self::STATE_KEY_LAST_FAILURE_AT ] ) && is_int( $raw[ self::STATE_KEY_LAST_FAILURE_AT ] ) ? $raw[ self::STATE_KEY_LAST_FAILURE_AT ] : null;
+		$last_error      = isset( $raw[ self::STATE_KEY_LAST_ERROR ] ) && $raw[ self::STATE_KEY_LAST_ERROR ] instanceof WP_Error ? $raw[ self::STATE_KEY_LAST_ERROR ] : null;
+
+		return [
+			self::STATE_KEY_COLLECTION      => $collection,
+			self::STATE_KEY_LAST_SUCCESS_AT => $last_success_at,
+			self::STATE_KEY_LAST_FAILURE_AT => $last_failure_at,
+			self::STATE_KEY_LAST_ERROR      => $last_error,
+		];
 	}
 }

--- a/src/Uplink/Catalog/Provider.php
+++ b/src/Uplink/Catalog/Provider.php
@@ -41,7 +41,7 @@ final class Provider extends Abstract_Provider {
 		add_action(
 			'stellarwp/uplink/unified_license_key_changed',
 			static function () {
-				delete_transient( Catalog_Repository::TRANSIENT_KEY );
+				delete_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME );
 			}
 		);
 	}

--- a/tests/wpunit/API/REST/V1/Catalog_ControllerTest.php
+++ b/tests/wpunit/API/REST/V1/Catalog_ControllerTest.php
@@ -23,7 +23,7 @@ final class Catalog_ControllerTest extends UplinkTestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		delete_transient( Catalog_Repository::TRANSIENT_KEY );
+		delete_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME );
 
 		$client     = $this->make_client( $this->build_catalog_from_fixture() );
 		$repository = new Catalog_Repository( $client );
@@ -54,7 +54,7 @@ final class Catalog_ControllerTest extends UplinkTestCase {
 		global $wp_rest_server;
 		$wp_rest_server = null;
 
-		delete_transient( Catalog_Repository::TRANSIENT_KEY );
+		delete_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME );
 
 		parent::tearDown();
 	}

--- a/tests/wpunit/Catalog/Catalog_RepositoryTest.php
+++ b/tests/wpunit/Catalog/Catalog_RepositoryTest.php
@@ -4,7 +4,6 @@ namespace StellarWP\Uplink\Tests\Catalog;
 
 use StellarWP\Uplink\Catalog\Catalog_Collection;
 use StellarWP\Uplink\Catalog\Catalog_Repository;
-use StellarWP\Uplink\Catalog\Error_Code;
 use StellarWP\Uplink\Catalog\Fixture_Client;
 use StellarWP\Uplink\Catalog\Results\Product_Catalog;
 use StellarWP\Uplink\Tests\UplinkTestCase;
@@ -20,11 +19,11 @@ final class Catalog_RepositoryTest extends UplinkTestCase {
 		$client           = new Fixture_Client( codecept_data_dir( 'catalog/default.json' ) );
 		$this->repository = new Catalog_Repository( $client );
 
-		delete_transient( Catalog_Repository::TRANSIENT_KEY );
+		delete_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME );
 	}
 
 	protected function tearDown(): void {
-		delete_transient( Catalog_Repository::TRANSIENT_KEY );
+		delete_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME );
 
 		parent::tearDown();
 	}
@@ -40,32 +39,39 @@ final class Catalog_RepositoryTest extends UplinkTestCase {
 		}
 	}
 
-	public function test_get_stores_in_transient(): void {
+	public function test_get_stores_in_option(): void {
 		$this->repository->get();
 
-		$cached = get_transient( Catalog_Repository::TRANSIENT_KEY );
+		$state = get_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME );
 
-		$this->assertIsArray( $cached );
-		$this->assertCount( 4, $cached );
+		$this->assertIsArray( $state );
+		$this->assertArrayHasKey( 'collection', $state );
+		$this->assertIsArray( $state['collection'] );
+		$this->assertCount( 4, $state['collection'] );
 	}
 
-	public function test_get_serves_from_transient(): void {
+	public function test_get_serves_from_option(): void {
 		$stale = [
-			[
-				'product_slug' => 'cached-product',
-				'tiers'        => [
-					[
-						'slug'         => 'basic',
-						'name'         => 'Basic',
-						'rank'         => 1,
-						'purchase_url' => '',
+			'collection'      => [
+				[
+					'product_slug' => 'cached-product',
+					'tiers'        => [
+						[
+							'slug'         => 'basic',
+							'name'         => 'Basic',
+							'rank'         => 1,
+							'purchase_url' => '',
+						],
 					],
+					'features'     => [],
 				],
-				'features'     => [],
 			],
+			'last_success_at' => time(),
+			'last_failure_at' => null,
+			'last_error'      => null,
 		];
 
-		set_transient( Catalog_Repository::TRANSIENT_KEY, $stale );
+		update_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME, $stale );
 
 		$result = $this->repository->get();
 
@@ -81,31 +87,54 @@ final class Catalog_RepositoryTest extends UplinkTestCase {
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 
-		$cached = get_transient( Catalog_Repository::TRANSIENT_KEY );
+		$state = get_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME );
 
-		$this->assertInstanceOf( WP_Error::class, $cached );
+		$this->assertIsArray( $state );
+		$this->assertNull( $state['collection'] );
+		$this->assertInstanceOf( WP_Error::class, $state['last_error'] );
 	}
 
-	public function test_get_returns_cached_wp_error(): void {
-		$error = new WP_Error( Error_Code::INVALID_RESPONSE, 'Cached error' );
-		set_transient( Catalog_Repository::TRANSIENT_KEY, $error );
+	public function test_get_preserves_collection_on_error(): void {
+		// Seed a valid collection first via a successful fetch.
+		$this->repository->get();
 
+		$state = get_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME );
+		$this->assertIsArray( $state['collection'] );
+		$this->assertCount( 4, $state['collection'] );
+
+		// Now refresh with a bad client — simulates an API failure.
+		$bad_client  = new Fixture_Client( '/tmp/does-not-exist-' . uniqid() . '.json' );
+		$bad_repo    = new Catalog_Repository( $bad_client );
+
+		// Manually trigger a failed set_catalog to share the same option.
+		$error = $bad_client->get_catalog();
+		$this->repository->set_catalog( $error );
+
+		// get() should still return the previously stored collection.
 		$result = $this->repository->get();
 
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'Cached error', $result->get_error_message() );
+		$this->assertInstanceOf( Catalog_Collection::class, $result );
+		$this->assertCount( 4, $result );
+
+		// The error is also persisted alongside the preserved collection.
+		$this->assertInstanceOf( WP_Error::class, $this->repository->get_last_error() );
 	}
 
 	public function test_refresh_clears_and_refetches(): void {
 		$stale = [
-			[
-				'product_slug' => 'stale-product',
-				'tiers'        => [],
-				'features'     => [],
+			'collection'      => [
+				[
+					'product_slug' => 'stale-product',
+					'tiers'        => [],
+					'features'     => [],
+				],
 			],
+			'last_success_at' => time() - 100,
+			'last_failure_at' => null,
+			'last_error'      => null,
 		];
 
-		set_transient( Catalog_Repository::TRANSIENT_KEY, $stale );
+		update_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME, $stale );
 
 		$result = $this->repository->refresh();
 

--- a/tests/wpunit/Catalog/Catalog_RepositoryTest.php
+++ b/tests/wpunit/Catalog/Catalog_RepositoryTest.php
@@ -4,6 +4,7 @@ namespace StellarWP\Uplink\Tests\Catalog;
 
 use StellarWP\Uplink\Catalog\Catalog_Collection;
 use StellarWP\Uplink\Catalog\Catalog_Repository;
+use StellarWP\Uplink\Catalog\Contracts\Catalog_Client;
 use StellarWP\Uplink\Catalog\Fixture_Client;
 use StellarWP\Uplink\Catalog\Results\Product_Catalog;
 use StellarWP\Uplink\Tests\UplinkTestCase;
@@ -102,13 +103,10 @@ final class Catalog_RepositoryTest extends UplinkTestCase {
 		$this->assertIsArray( $state['collection'] );
 		$this->assertCount( 4, $state['collection'] );
 
-		// Now refresh with a bad client — simulates an API failure.
-		$bad_client  = new Fixture_Client( '/tmp/does-not-exist-' . uniqid() . '.json' );
-		$bad_repo    = new Catalog_Repository( $bad_client );
-
-		// Manually trigger a failed set_catalog to share the same option.
-		$error = $bad_client->get_catalog();
-		$this->repository->set_catalog( $error );
+		// Simulate an API failure using a mock client — refresh writes to the shared option.
+		$error      = new WP_Error( 'catalog_error', 'API unavailable.' );
+		$bad_client = $this->makeEmpty( Catalog_Client::class, [ 'get_catalog' => $error ] );
+		( new Catalog_Repository( $bad_client ) )->refresh();
 
 		// get() should still return the previously stored collection.
 		$result = $this->repository->get();

--- a/tests/wpunit/Features/Feature_RepositoryTest.php
+++ b/tests/wpunit/Features/Feature_RepositoryTest.php
@@ -34,7 +34,7 @@ final class Feature_RepositoryTest extends UplinkTestCase {
 		parent::setUp();
 
 		delete_transient( Feature_Repository::TRANSIENT_KEY );
-		delete_transient( Catalog_Repository::TRANSIENT_KEY );
+		delete_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME );
 		delete_option( License_Repository::PRODUCTS_STATE_OPTION_NAME );
 	}
 
@@ -45,7 +45,7 @@ final class Feature_RepositoryTest extends UplinkTestCase {
 	 */
 	protected function tearDown(): void {
 		delete_transient( Feature_Repository::TRANSIENT_KEY );
-		delete_transient( Catalog_Repository::TRANSIENT_KEY );
+		delete_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME );
 		delete_option( License_Repository::PRODUCTS_STATE_OPTION_NAME );
 
 		parent::tearDown();

--- a/tests/wpunit/Features/ManagerTest.php
+++ b/tests/wpunit/Features/ManagerTest.php
@@ -101,7 +101,7 @@ final class ManagerTest extends UplinkTestCase {
 		delete_option( 'stellarwp_uplink_feature_kad-pattern-hub_active' );
 		delete_option( License_Repository::KEY_OPTION_NAME );
 		delete_transient( Feature_Repository::TRANSIENT_KEY );
-		delete_transient( Catalog_Repository::TRANSIENT_KEY );
+		delete_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME );
 		delete_option( License_Repository::PRODUCTS_STATE_OPTION_NAME );
 
 		parent::tearDown();

--- a/tests/wpunit/Licensing/Repositories/License_Key_Cache_InvalidationTest.php
+++ b/tests/wpunit/Licensing/Repositories/License_Key_Cache_InvalidationTest.php
@@ -62,7 +62,7 @@ final class License_Key_Cache_InvalidationTest extends UplinkTestCase {
 		add_action(
 			'stellarwp/uplink/unified_license_key_changed',
 			static function () {
-				delete_transient( Catalog_Repository::TRANSIENT_KEY );
+				delete_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME );
 			}
 		);
 		add_action(
@@ -73,7 +73,7 @@ final class License_Key_Cache_InvalidationTest extends UplinkTestCase {
 		);
 
 		delete_option( License_Repository::PRODUCTS_STATE_OPTION_NAME );
-		delete_transient( Catalog_Repository::TRANSIENT_KEY );
+		delete_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME );
 		delete_transient( Feature_Repository::TRANSIENT_KEY );
 		delete_option( License_Repository::KEY_OPTION_NAME );
 	}
@@ -82,7 +82,7 @@ final class License_Key_Cache_InvalidationTest extends UplinkTestCase {
 		remove_all_filters( 'stellarwp/uplink/unified_license_key_changed' );
 
 		delete_option( License_Repository::PRODUCTS_STATE_OPTION_NAME );
-		delete_transient( Catalog_Repository::TRANSIENT_KEY );
+		delete_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME );
 		delete_transient( Feature_Repository::TRANSIENT_KEY );
 		delete_option( License_Repository::KEY_OPTION_NAME );
 
@@ -110,22 +110,27 @@ final class License_Key_Cache_InvalidationTest extends UplinkTestCase {
 	}
 
 	public function test_catalog_repository_fetches_fresh_after_key_change(): void {
-		// Seed a stale catalog array with a single fake product.
-		$stale = [
-			[
-				'product_slug' => 'stale-product',
-				'tiers'        => [],
-				'features'     => [],
+		// Seed a stale catalog state with a single fake product.
+		$stale_state = [
+			'collection'      => [
+				[
+					'product_slug' => 'stale-product',
+					'tiers'        => [],
+					'features'     => [],
+				],
 			],
+			'last_success_at' => time() - 100,
+			'last_failure_at' => null,
+			'last_error'      => null,
 		];
-		set_transient( Catalog_Repository::TRANSIENT_KEY, $stale );
+		update_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME, $stale_state );
 
 		// Confirm the stale cache is served.
 		$cached = $this->catalog_repository->get();
 		$this->assertCount( 1, $cached );
 		$this->assertNotNull( $cached->get( 'stale-product' ) );
 
-		// Change the license key — invalidates the catalog transient.
+		// Change the license key — invalidates the catalog option.
 		$this->license_repository->store_key( 'LWSW-UNIFIED-BASIC-2026' );
 
 		// Fresh fetch should return the real catalog, not the stale single-product one.
@@ -180,14 +185,14 @@ final class License_Key_Cache_InvalidationTest extends UplinkTestCase {
 		$this->feature_repository->get( 'LWSW-UNIFIED-KAD-PRO-2026', 'example.com' );
 
 		$this->assertInstanceOf( Product_Collection::class, $this->license_repository->get_products() );
-		$this->assertNotFalse( get_transient( Catalog_Repository::TRANSIENT_KEY ) );
+		$this->assertNotFalse( get_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME ) );
 		$this->assertNotFalse( get_transient( Feature_Repository::TRANSIENT_KEY ) );
 
-		// Storing a new key should clear all three transients.
+		// Storing a new key should clear the catalog option and feature transient.
 		$this->license_repository->store_key( 'LWSW-UNIFIED-BASIC-2026' );
 
 		$this->assertNull( $this->license_repository->get_products() );
-		$this->assertFalse( get_transient( Catalog_Repository::TRANSIENT_KEY ) );
+		$this->assertFalse( get_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME ) );
 		$this->assertFalse( get_transient( Feature_Repository::TRANSIENT_KEY ) );
 	}
 
@@ -200,14 +205,14 @@ final class License_Key_Cache_InvalidationTest extends UplinkTestCase {
 		$this->feature_repository->get( 'LWSW-UNIFIED-KAD-PRO-2026', 'example.com' );
 
 		$this->assertInstanceOf( Product_Collection::class, $this->license_repository->get_products() );
-		$this->assertNotFalse( get_transient( Catalog_Repository::TRANSIENT_KEY ) );
+		$this->assertNotFalse( get_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME ) );
 		$this->assertNotFalse( get_transient( Feature_Repository::TRANSIENT_KEY ) );
 
-		// Deleting the key should clear all three transients.
+		// Deleting the key should clear the catalog option and feature transient.
 		$this->license_repository->delete_key();
 
 		$this->assertNull( $this->license_repository->get_products() );
-		$this->assertFalse( get_transient( Catalog_Repository::TRANSIENT_KEY ) );
+		$this->assertFalse( get_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME ) );
 		$this->assertFalse( get_transient( Feature_Repository::TRANSIENT_KEY ) );
 	}
 
@@ -223,7 +228,7 @@ final class License_Key_Cache_InvalidationTest extends UplinkTestCase {
 		$this->license_repository->store_key( 'LWSW-UNIFIED-PRO-2026' );
 
 		$this->assertInstanceOf( Product_Collection::class, $this->license_repository->get_products() );
-		$this->assertNotFalse( get_transient( Catalog_Repository::TRANSIENT_KEY ) );
+		$this->assertNotFalse( get_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME ) );
 		$this->assertNotFalse( get_transient( Feature_Repository::TRANSIENT_KEY ) );
 	}
 }


### PR DESCRIPTION
Resolves: [SCON-303]

## Description

This PR updates the way we store catalog  information.  Previously there was a flat structure that stored just the catalog collection or error within a transient. Now we are storing the data in `wp_option` and including extra information like `last_success_at`, `last_failure_at` and `last_error` that live alongside the collection.

Here's a visual of the data:

```php
stellarwp_uplink_catalog_state = [
    'collection' => [
        [
            'product_slug' => 'give'
            'tiers' => [
                [
                    'tier_slug' => 'give-pro',
                    'tier_name' => 'Give Pro',
                    'tier_description' => 'Give Pro is a premium version of Give that adds additional features and functionality.',
                ],
            ],
            'features' => [
        ],
    ],
    'last_success_at' => 1715328000,
    'last_failure_at' => null,
    'last_error' => null,
]
```

**Next**
- Update the existing REST API controllers to add throttling and respect error states


[SCON-303]: https://stellarwp.atlassian.net/browse/SCON-303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ