### PR TITLE
feature: add error throttling to license api

### DIFF
--- a/src/Uplink/API/REST/V1/License_Controller.php
+++ b/src/Uplink/API/REST/V1/License_Controller.php
@@ -160,22 +160,31 @@ final class License_Controller extends WP_REST_Controller {
 	/**
 	 * Returns the current unified license key and its associated products.
 	 *
-	 * Always returns 200. The key field will be null if no key is stored
-	 * and none is discoverable from the product registry.
+	 * Returns 200 on success. Returns a WP_Error if the API call fails or a
+	 * recent failure is still within the throttle window. The key field will
+	 * be null if no key is stored and none is discoverable from the product
+	 * registry.
 	 *
 	 * @since 3.0.0
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 *
-	 * @return WP_REST_Response
+	 * @return WP_REST_Response|WP_Error
 	 */
-	public function get_item( $request ): WP_REST_Response {
-		$domain   = $this->site_data->get_domain();
-		$key      = $this->manager->get_key();
+	public function get_item( $request ) {
+		$domain = $this->site_data->get_domain();
+		$key    = $this->manager->get_key();
+
+		if ( $key === null ) {
+			return new WP_REST_Response(
+				License_Response::make( null, new Product_Collection() )
+			);
+		}
+
 		$products = $this->manager->get_products( $domain );
 
 		if ( is_wp_error( $products ) ) {
-			$products = new Product_Collection();
+			return $products;
 		}
 
 		return new WP_REST_Response(

--- a/src/Uplink/Licensing/License_Manager.php
+++ b/src/Uplink/Licensing/License_Manager.php
@@ -23,9 +23,27 @@ use WP_Error;
  *      the first registered product with an embedded key wins and it is
  *      auto-stored for subsequent requests.
  *
+ * Any method that would call the remote API first checks whether a recent
+ * failure is within the ERROR_THROTTLE_TTL window. When throttled, the
+ * cached WP_Error is returned immediately without hitting the upstream
+ * service. The throttle resets automatically on the next successful call.
+ *
  * @since 3.0.0
  */
 final class License_Manager {
+
+	/**
+	 * How long (in seconds) to suppress outbound API calls after a failure.
+	 *
+	 * When a remote API call fails, subsequent calls that would hit the API
+	 * again are short-circuited and return the cached error until this window
+	 * expires. This prevents hammering a degraded upstream service.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var int
+	 */
+	const ERROR_THROTTLE_TTL = 60;
 
 	/**
 	 * @since 3.0.0
@@ -136,6 +154,12 @@ final class License_Manager {
 			);
 		}
 
+		$throttled = $this->get_throttled_error();
+
+		if ( $throttled !== null ) {
+			return $throttled;
+		}
+
 		/** @var Product_Entry[]|WP_Error $result */
 		$result = $this->client->get_products( $key, $domain );
 
@@ -145,6 +169,8 @@ final class License_Manager {
 			if ( ! is_array( $data ) || empty( $data['status'] ) ) {
 				$result->add_data( [ 'status' => 500 ] );
 			}
+
+			$this->repository->set_products( $result );
 
 			return $result;
 		}
@@ -187,6 +213,12 @@ final class License_Manager {
 			);
 		}
 
+		$throttled = $this->get_throttled_error();
+
+		if ( $throttled !== null ) {
+			return $throttled;
+		}
+
 		$result = $this->client->validate( $key, $domain, $product_slug );
 
 		if ( is_wp_error( $result ) ) {
@@ -195,6 +227,8 @@ final class License_Manager {
 			if ( ! is_array( $data ) || empty( $data['status'] ) ) {
 				$result->add_data( [ 'status' => 500 ] );
 			}
+
+			$this->repository->set_products( $result );
 
 			return $result;
 		}
@@ -261,6 +295,12 @@ final class License_Manager {
 			return $cached;
 		}
 
+		$throttled = $this->get_throttled_error();
+
+		if ( $throttled !== null ) {
+			return $throttled;
+		}
+
 		return $this->fetch_and_cache( $key, $domain );
 	}
 
@@ -324,6 +364,52 @@ final class License_Manager {
 		}
 
 		return Product_Collection::from_array( $result );
+	}
+
+	/**
+	 * Unix timestamp of the most recent failed API call, or null if no failure
+	 * has occurred since the last successful call.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return int|null
+	 */
+	public function get_last_failure_at(): ?int {
+		return $this->repository->get_products_last_failure_at();
+	}
+
+	/**
+	 * WP_Error from the most recent failed API call, or null if the last call
+	 * was successful (or no call has occurred).
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return WP_Error|null
+	 */
+	public function get_last_error(): ?WP_Error {
+		return $this->repository->get_products_last_error();
+	}
+
+	/**
+	 * Returns the cached WP_Error if a recent API failure is within the
+	 * ERROR_THROTTLE_TTL window, or null if the call should proceed.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return WP_Error|null
+	 */
+	private function get_throttled_error(): ?WP_Error {
+		$failure_at = $this->repository->get_products_last_failure_at();
+
+		if ( $failure_at === null ) {
+			return null;
+		}
+
+		if ( ( time() - $failure_at ) > self::ERROR_THROTTLE_TTL ) {
+			return null;
+		}
+
+		return $this->repository->get_products_last_error();
 	}
 
 	/**

--- a/src/Uplink/Licensing/Repositories/License_Repository.php
+++ b/src/Uplink/Licensing/Repositories/License_Repository.php
@@ -359,23 +359,6 @@ final class License_Repository {
 	}
 
 	/**
-	 * Clear the last error and last failure timestamp from the license state.
-	 *
-	 * Called after a successful API response to reset the throttle window so
-	 * future errors start a fresh throttle period.
-	 *
-	 * @since 3.0.0
-	 *
-	 * @return void
-	 */
-	public function clear_error_state(): void {
-		$state                                    = $this->read_products_state();
-		$state[ self::STATE_KEY_LAST_ERROR ]      = null;
-		$state[ self::STATE_KEY_LAST_FAILURE_AT ] = null;
-		update_option( self::PRODUCTS_STATE_OPTION_NAME, $state, false );
-	}
-
-	/**
 	 * Read the raw license state array from the option, returning a zeroed
 	 * default when nothing has been stored.
 	 *

--- a/src/Uplink/Licensing/Repositories/License_Repository.php
+++ b/src/Uplink/Licensing/Repositories/License_Repository.php
@@ -292,6 +292,7 @@ final class License_Repository {
 			$state[ self::STATE_KEY_COLLECTION ]      = $data->to_array();
 			$state[ self::STATE_KEY_LAST_SUCCESS_AT ] = time();
 			$state[ self::STATE_KEY_LAST_ERROR ]      = null;
+			$state[ self::STATE_KEY_LAST_FAILURE_AT ] = null;
 			update_option( self::PRODUCTS_STATE_OPTION_NAME, $state, false );
 
 			return;
@@ -355,6 +356,23 @@ final class License_Repository {
 		$error = $this->read_products_state()[ self::STATE_KEY_LAST_ERROR ];
 
 		return $error instanceof WP_Error ? $error : null;
+	}
+
+	/**
+	 * Clear the last error and last failure timestamp from the license state.
+	 *
+	 * Called after a successful API response to reset the throttle window so
+	 * future errors start a fresh throttle period.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return void
+	 */
+	public function clear_error_state(): void {
+		$state                                    = $this->read_products_state();
+		$state[ self::STATE_KEY_LAST_ERROR ]      = null;
+		$state[ self::STATE_KEY_LAST_FAILURE_AT ] = null;
+		update_option( self::PRODUCTS_STATE_OPTION_NAME, $state, false );
 	}
 
 	/**

--- a/tests/wpunit/API/REST/V1/License_ControllerTest.php
+++ b/tests/wpunit/API/REST/V1/License_ControllerTest.php
@@ -11,6 +11,7 @@ use StellarWP\Uplink\API\REST\V1\License_Controller;
 use StellarWP\Uplink\Site\Data;
 use StellarWP\Uplink\Tests\Traits\With_Uopz;
 use StellarWP\Uplink\Tests\UplinkTestCase;
+use WP_Error;
 use WP_REST_Request;
 use WP_REST_Server;
 
@@ -20,6 +21,7 @@ final class License_ControllerTest extends UplinkTestCase {
 
 	private WP_REST_Server $server;
 	private License_Manager $manager;
+	private License_Repository $repository;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -27,9 +29,9 @@ final class License_ControllerTest extends UplinkTestCase {
 		delete_option( License_Repository::KEY_OPTION_NAME );
 		delete_option( License_Repository::PRODUCTS_STATE_OPTION_NAME );
 
-		$repository    = new License_Repository();
-		$registry      = new Product_Registry();
-		$this->manager = new License_Manager( $repository, $registry, new Fixture_Client( codecept_data_dir( 'licensing' ) ) );
+		$this->repository = new License_Repository();
+		$registry         = new Product_Registry();
+		$this->manager    = new License_Manager( $this->repository, $registry, new Fixture_Client( codecept_data_dir( 'licensing' ) ) );
 
 		/** @var WP_REST_Server $wp_rest_server */
 		global $wp_rest_server;
@@ -372,5 +374,59 @@ final class License_ControllerTest extends UplinkTestCase {
 
 	public function test_store_error_code_constant(): void {
 		$this->assertSame( 'stellarwp-uplink-store-failed', Error_Code::STORE_FAILED );
+	}
+
+	// -------------------------------------------------------------------------
+	// Error throttling
+	// -------------------------------------------------------------------------
+
+	public function test_get_returns_error_when_throttled(): void {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$this->manager->store_key( 'LWSW-UNIFIED-PRO-2026' );
+
+		// Write error state at a fixed time, then advance within the TTL.
+		$this->set_fn_return( 'time', 1000000 );
+		$this->repository->set_products( new WP_Error( Error_Code::INVALID_KEY, 'API failure', [ 'status' => 400 ] ) );
+		$this->set_fn_return( 'time', 1000030 );
+
+		$request  = new WP_REST_Request( 'GET', '/stellarwp/uplink/v1/license' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	public function test_store_returns_error_when_throttled(): void {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		// Write error state at a fixed time, then advance within the TTL.
+		$this->set_fn_return( 'time', 1000000 );
+		$this->repository->set_products( new WP_Error( Error_Code::INVALID_KEY, 'API failure', [ 'status' => 400 ] ) );
+		$this->set_fn_return( 'time', 1000030 );
+
+		$request = new WP_REST_Request( 'POST', '/stellarwp/uplink/v1/license' );
+		$request->set_param( 'key', 'LWSW-UNIFIED-PRO-2026' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	public function test_validate_returns_error_when_throttled(): void {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$this->manager->store_key( 'LWSW-UNIFIED-PRO-2026' );
+
+		// Write error state at a fixed time, then advance within the TTL.
+		$this->set_fn_return( 'time', 1000000 );
+		$this->repository->set_products( new WP_Error( Error_Code::INVALID_KEY, 'API failure', [ 'status' => 400 ] ) );
+		$this->set_fn_return( 'time', 1000030 );
+
+		$request = new WP_REST_Request( 'POST', '/stellarwp/uplink/v1/license/validate' );
+		$request->set_param( 'product_slug', 'give' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
 	}
 }

--- a/tests/wpunit/API/REST/V1/License_ControllerTest.php
+++ b/tests/wpunit/API/REST/V1/License_ControllerTest.php
@@ -394,6 +394,8 @@ final class License_ControllerTest extends UplinkTestCase {
 		$response = $this->server->dispatch( $request );
 
 		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( Error_Code::INVALID_KEY, $response->get_data()['code'] );
+		$this->assertSame( 'API failure', $response->get_data()['message'] );
 	}
 
 	public function test_store_returns_error_when_throttled(): void {
@@ -410,6 +412,8 @@ final class License_ControllerTest extends UplinkTestCase {
 		$response = $this->server->dispatch( $request );
 
 		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( Error_Code::INVALID_KEY, $response->get_data()['code'] );
+		$this->assertSame( 'API failure', $response->get_data()['message'] );
 	}
 
 	public function test_validate_returns_error_when_throttled(): void {
@@ -428,5 +432,7 @@ final class License_ControllerTest extends UplinkTestCase {
 		$response = $this->server->dispatch( $request );
 
 		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( Error_Code::INVALID_KEY, $response->get_data()['code'] );
+		$this->assertSame( 'API failure', $response->get_data()['message'] );
 	}
 }

--- a/tests/wpunit/Licensing/License_ManagerTest.php
+++ b/tests/wpunit/Licensing/License_ManagerTest.php
@@ -10,6 +10,7 @@ use StellarWP\Uplink\Licensing\Product_Collection;
 use StellarWP\Uplink\Licensing\Registry\Product_Registry;
 use StellarWP\Uplink\Licensing\Repositories\License_Repository;
 use StellarWP\Uplink\Licensing\Results\Validation_Result;
+use StellarWP\Uplink\Tests\Traits\With_Uopz;
 use StellarWP\Uplink\Tests\UplinkTestCase;
 use WP_Error;
 
@@ -18,13 +19,17 @@ use WP_Error;
  */
 final class License_ManagerTest extends UplinkTestCase {
 
+	use With_Uopz;
+
 	private License_Manager $manager;
+	private License_Repository $repository;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->manager = new License_Manager(
-			new License_Repository(),
+		$this->repository = new License_Repository();
+		$this->manager    = new License_Manager(
+			$this->repository,
 			new Product_Registry(),
 			new Fixture_Client( codecept_data_dir( 'licensing' ) )
 		);
@@ -323,5 +328,119 @@ final class License_ManagerTest extends UplinkTestCase {
 		$this->assertNotNull( $result->get( 'give' ) );
 		$this->assertNotNull( $result->get( 'the-events-calendar' ) );
 		$this->assertNotNull( $result->get( 'kadence' ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// Error throttling
+	// -------------------------------------------------------------------------
+
+	public function test_get_products_returns_cached_error_when_within_throttle_window(): void {
+		$this->manager->store_key( 'LWSW-UNIFIED-PRO-2026' );
+
+		// Write error state at a fixed time.
+		$this->set_fn_return( 'time', 1000000 );
+		$this->repository->set_products( new WP_Error( Error_Code::INVALID_KEY, 'API failure' ) );
+
+		// Advance to 30 s later — still within the 60 s TTL.
+		$this->set_fn_return( 'time', 1000030 );
+
+		$result = $this->manager->get_products( 'example.com' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( Error_Code::INVALID_KEY, $result->get_error_code() );
+	}
+
+	public function test_get_products_retries_api_after_throttle_window_expires(): void {
+		$this->manager->store_key( 'LWSW-UNIFIED-PRO-2026' );
+
+		// Write error state at a fixed time.
+		$this->set_fn_return( 'time', 1000000 );
+		$this->repository->set_products( new WP_Error( Error_Code::INVALID_KEY, 'API failure' ) );
+
+		// Advance past the 60 s TTL.
+		$this->set_fn_return( 'time', 1000061 );
+
+		$result = $this->manager->get_products( 'example.com' );
+
+		$this->assertInstanceOf( Product_Collection::class, $result );
+	}
+
+	public function test_validate_and_store_returns_cached_error_when_within_throttle_window(): void {
+		// Write error state at a fixed time.
+		$this->set_fn_return( 'time', 1000000 );
+		$this->repository->set_products( new WP_Error( Error_Code::INVALID_KEY, 'API failure' ) );
+
+		// Advance to 30 s later — still within the 60 s TTL.
+		$this->set_fn_return( 'time', 1000030 );
+
+		$result = $this->manager->validate_and_store( 'LWSW-UNIFIED-PRO-2026', 'example.com' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( Error_Code::INVALID_KEY, $result->get_error_code() );
+	}
+
+	public function test_validate_and_store_retries_api_after_throttle_window_expires(): void {
+		// Write error state at a fixed time.
+		$this->set_fn_return( 'time', 1000000 );
+		$this->repository->set_products( new WP_Error( Error_Code::INVALID_KEY, 'API failure' ) );
+
+		// Advance past the 60 s TTL.
+		$this->set_fn_return( 'time', 1000061 );
+
+		$result = $this->manager->validate_and_store( 'LWSW-UNIFIED-PRO-2026', 'example.com' );
+
+		$this->assertIsArray( $result );
+		$this->assertNotEmpty( $result );
+	}
+
+	public function test_validate_product_returns_cached_error_when_within_throttle_window(): void {
+		$this->manager->store_key( 'LWSW-UNIFIED-PRO-2026' );
+
+		// Write error state at a fixed time.
+		$this->set_fn_return( 'time', 1000000 );
+		$this->repository->set_products( new WP_Error( Error_Code::INVALID_KEY, 'API failure' ) );
+
+		// Advance to 30 s later — still within the 60 s TTL.
+		$this->set_fn_return( 'time', 1000030 );
+
+		$result = $this->manager->validate_product( 'example.com', 'give' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( Error_Code::INVALID_KEY, $result->get_error_code() );
+	}
+
+	public function test_validate_product_retries_api_after_throttle_window_expires(): void {
+		$this->manager->store_key( 'LWSW-UNIFIED-PRO-2026' );
+
+		// Write error state at a fixed time.
+		$this->set_fn_return( 'time', 1000000 );
+		$this->repository->set_products( new WP_Error( Error_Code::INVALID_KEY, 'API failure' ) );
+
+		// Advance past the 60 s TTL.
+		$this->set_fn_return( 'time', 1000061 );
+
+		$result = $this->manager->validate_product( 'example.com', 'give' );
+
+		$this->assertInstanceOf( Validation_Result::class, $result );
+		$this->assertTrue( $result->is_valid() );
+	}
+
+	public function test_successful_call_clears_error_state(): void {
+		$this->manager->store_key( 'LWSW-UNIFIED-PRO-2026' );
+
+		// Write error state at a fixed time.
+		$this->set_fn_return( 'time', 1000000 );
+		$this->repository->set_products( new WP_Error( Error_Code::INVALID_KEY, 'API failure' ) );
+
+		$this->assertNotNull( $this->repository->get_products_last_failure_at() );
+		$this->assertNotNull( $this->repository->get_products_last_error() );
+
+		// Advance past TTL so the request is not throttled and reaches the API.
+		$this->set_fn_return( 'time', 1000061 );
+
+		$this->manager->get_products( 'example.com' );
+
+		$this->assertNull( $this->repository->get_products_last_failure_at() );
+		$this->assertNull( $this->repository->get_products_last_error() );
 	}
 }

--- a/tests/wpunit/Licensing/Repositories/License_RepositoryTest.php
+++ b/tests/wpunit/Licensing/Repositories/License_RepositoryTest.php
@@ -293,10 +293,10 @@ final class License_RepositoryTest extends UplinkTestCase {
 		$this->assertGreaterThanOrEqual( $before, $last_failure_at );
 	}
 
-	public function test_get_products_last_failure_at_not_updated_on_success(): void {
+	public function test_set_products_collection_clears_last_failure_at(): void {
 		$this->repository->set_products( new WP_Error( Error_Code::INVALID_KEY, 'fail' ) );
 
-		$first_last_failure_at = $this->repository->get_products_last_failure_at();
+		$this->assertNotNull( $this->repository->get_products_last_failure_at() );
 
 		$this->repository->set_products(
 			Product_Collection::from_array(
@@ -317,7 +317,7 @@ final class License_RepositoryTest extends UplinkTestCase {
 			)
 		);
 
-		$this->assertSame( $first_last_failure_at, $this->repository->get_products_last_failure_at() );
+		$this->assertNull( $this->repository->get_products_last_failure_at() );
 	}
 
 	public function test_get_products_last_error_returns_null_when_no_error(): void {
@@ -373,6 +373,56 @@ final class License_RepositoryTest extends UplinkTestCase {
 		$this->repository->delete_products();
 
 		$this->assertNull( $this->repository->get_products() );
+	}
+
+	// -------------------------------------------------------------------------
+	// clear_error_state()
+	// -------------------------------------------------------------------------
+
+	public function test_clear_error_state_clears_last_error_and_last_failure_at(): void {
+		$this->repository->set_products( new WP_Error( Error_Code::INVALID_KEY, 'API failure' ) );
+
+		$this->assertNotNull( $this->repository->get_products_last_error() );
+		$this->assertNotNull( $this->repository->get_products_last_failure_at() );
+
+		$this->repository->clear_error_state();
+
+		$this->assertNull( $this->repository->get_products_last_error() );
+		$this->assertNull( $this->repository->get_products_last_failure_at() );
+	}
+
+	public function test_clear_error_state_preserves_collection_and_last_success_at(): void {
+		$collection = Product_Collection::from_array(
+			[
+				Product_Entry::from_array(
+					[
+						'product_slug' => 'give',
+						'tier'         => 'give-pro',
+						'status'       => 'active',
+						'expires'      => '2026-12-31 23:59:59',
+					]
+				),
+			]
+		);
+
+		$this->repository->set_products( $collection );
+		$last_success_at = $this->repository->get_products_last_success_at();
+
+		// Simulate a subsequent failure, then clear.
+		$this->repository->set_products( new WP_Error( Error_Code::INVALID_KEY, 'fail' ) );
+		$this->repository->clear_error_state();
+
+		$result = $this->repository->get_products();
+		$this->assertInstanceOf( Product_Collection::class, $result );
+		$this->assertSame( 'give', $result->get( 'give' )->get_product_slug() );
+		$this->assertSame( $last_success_at, $this->repository->get_products_last_success_at() );
+	}
+
+	public function test_clear_error_state_is_noop_when_nothing_stored(): void {
+		$this->repository->clear_error_state();
+
+		$this->assertNull( $this->repository->get_products_last_error() );
+		$this->assertNull( $this->repository->get_products_last_failure_at() );
 	}
 
 	// -------------------------------------------------------------------------

--- a/tests/wpunit/Licensing/Repositories/License_RepositoryTest.php
+++ b/tests/wpunit/Licensing/Repositories/License_RepositoryTest.php
@@ -376,56 +376,6 @@ final class License_RepositoryTest extends UplinkTestCase {
 	}
 
 	// -------------------------------------------------------------------------
-	// clear_error_state()
-	// -------------------------------------------------------------------------
-
-	public function test_clear_error_state_clears_last_error_and_last_failure_at(): void {
-		$this->repository->set_products( new WP_Error( Error_Code::INVALID_KEY, 'API failure' ) );
-
-		$this->assertNotNull( $this->repository->get_products_last_error() );
-		$this->assertNotNull( $this->repository->get_products_last_failure_at() );
-
-		$this->repository->clear_error_state();
-
-		$this->assertNull( $this->repository->get_products_last_error() );
-		$this->assertNull( $this->repository->get_products_last_failure_at() );
-	}
-
-	public function test_clear_error_state_preserves_collection_and_last_success_at(): void {
-		$collection = Product_Collection::from_array(
-			[
-				Product_Entry::from_array(
-					[
-						'product_slug' => 'give',
-						'tier'         => 'give-pro',
-						'status'       => 'active',
-						'expires'      => '2026-12-31 23:59:59',
-					]
-				),
-			]
-		);
-
-		$this->repository->set_products( $collection );
-		$last_success_at = $this->repository->get_products_last_success_at();
-
-		// Simulate a subsequent failure, then clear.
-		$this->repository->set_products( new WP_Error( Error_Code::INVALID_KEY, 'fail' ) );
-		$this->repository->clear_error_state();
-
-		$result = $this->repository->get_products();
-		$this->assertInstanceOf( Product_Collection::class, $result );
-		$this->assertSame( 'give', $result->get( 'give' )->get_product_slug() );
-		$this->assertSame( $last_success_at, $this->repository->get_products_last_success_at() );
-	}
-
-	public function test_clear_error_state_is_noop_when_nothing_stored(): void {
-		$this->repository->clear_error_state();
-
-		$this->assertNull( $this->repository->get_products_last_error() );
-		$this->assertNull( $this->repository->get_products_last_failure_at() );
-	}
-
-	// -------------------------------------------------------------------------
 	// get_product()
 	// -------------------------------------------------------------------------
 


### PR DESCRIPTION
Partially resolves: [SCON-261]

## Description

We decided to introduce error throttling into our REST APIs. This will ensure when a remote API call fails, subsequent calls that would hit the API again are short-circuited and return the cached error until the throttle window expires. This prevents hammering a degraded upstream service.

This PR is scoped to the License REST API specifically.

This was achieved by adding a new constant `ERROR_THROTTLE_TTL` to the License Manager that is used throughout the proxied methods that interact with the client.

[SCON-261]: https://stellarwp.atlassian.net/browse/SCON-261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ