### PR TITLE
feature: add error throttling to catalog api

### DIFF
--- a/src/Uplink/API/REST/V1/Catalog_Controller.php
+++ b/src/Uplink/API/REST/V1/Catalog_Controller.php
@@ -98,19 +98,13 @@ final class Catalog_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|\WP_Error
 	 */
 	public function get_items( $request ) {
-		$catalogs = $this->repository->get();
+		$catalog = $this->repository->get();
 
-		if ( is_wp_error( $catalogs ) ) {
-			return $catalogs;
+		if ( is_wp_error( $catalog ) ) {
+			return $catalog;
 		}
 
-		$data = [];
-
-		foreach ( $catalogs as $catalog ) {
-			$data[] = $catalog->to_array();
-		}
-
-		return new WP_REST_Response( $data );
+		return new WP_REST_Response( $catalog->to_array() );
 	}
 
 	/**

--- a/src/Uplink/Catalog/Catalog_Repository.php
+++ b/src/Uplink/Catalog/Catalog_Repository.php
@@ -11,9 +11,27 @@ use WP_Error;
  * This is the public API that the rest of Uplink uses — it never
  * exposes the client directly.
  *
+ * Any call that would hit the remote API first checks whether a recent
+ * failure is within the ERROR_THROTTLE_TTL window. When throttled, the
+ * cached WP_Error is returned immediately without hitting the upstream
+ * service. The throttle resets automatically on the next successful fetch.
+ *
  * @since 3.0.0
  */
 final class Catalog_Repository {
+
+	/**
+	 * How long (in seconds) to suppress outbound API calls after a failure.
+	 *
+	 * When a remote API call fails, subsequent calls that would hit the API
+	 * again are short-circuited and return the cached error until this window
+	 * expires. This prevents hammering a degraded upstream service.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var int
+	 */
+	const ERROR_THROTTLE_TTL = 60;
 
 	/**
 	 * Option name for the catalog state envelope.
@@ -107,6 +125,12 @@ final class Catalog_Repository {
 			return Catalog_Collection::from_array( $state[ self::STATE_KEY_COLLECTION ] );
 		}
 
+		$throttled = $this->get_throttled_error();
+
+		if ( $throttled !== null ) {
+			return $throttled;
+		}
+
 		return $this->fetch();
 	}
 
@@ -157,6 +181,7 @@ final class Catalog_Repository {
 			$state[ self::STATE_KEY_COLLECTION ]      = $data->to_array();
 			$state[ self::STATE_KEY_LAST_SUCCESS_AT ] = time();
 			$state[ self::STATE_KEY_LAST_ERROR ]      = null;
+			$state[ self::STATE_KEY_LAST_FAILURE_AT ] = null;
 			update_option( self::CATALOG_STATE_OPTION_NAME, $state, false );
 
 			return;
@@ -218,6 +243,31 @@ final class Catalog_Repository {
 	 */
 	public function get_last_error(): ?WP_Error {
 		$error = $this->read_catalog_state()[ self::STATE_KEY_LAST_ERROR ];
+
+		return $error instanceof WP_Error ? $error : null;
+	}
+
+	/**
+	 * Returns the cached WP_Error if a recent API failure is within the
+	 * ERROR_THROTTLE_TTL window, or null if the call should proceed.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return WP_Error|null
+	 */
+	private function get_throttled_error(): ?WP_Error {
+		$state      = $this->read_catalog_state();
+		$failure_at = $state[ self::STATE_KEY_LAST_FAILURE_AT ];
+
+		if ( ! is_int( $failure_at ) ) {
+			return null;
+		}
+
+		if ( ( time() - $failure_at ) > self::ERROR_THROTTLE_TTL ) {
+			return null;
+		}
+
+		$error = $state[ self::STATE_KEY_LAST_ERROR ];
 
 		return $error instanceof WP_Error ? $error : null;
 	}

--- a/tests/wpunit/API/REST/V1/Catalog_ControllerTest.php
+++ b/tests/wpunit/API/REST/V1/Catalog_ControllerTest.php
@@ -19,14 +19,15 @@ final class Catalog_ControllerTest extends UplinkTestCase {
 	use With_Uopz;
 
 	private WP_REST_Server $server;
+	private Catalog_Repository $repository;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		delete_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME );
 
-		$client     = $this->make_client( $this->build_catalog_from_fixture() );
-		$repository = new Catalog_Repository( $client );
+		$client           = $this->make_client( $this->build_catalog_from_fixture() );
+		$this->repository = new Catalog_Repository( $client );
 
 		/** @var WP_REST_Server $wp_rest_server */
 		global $wp_rest_server;
@@ -46,7 +47,7 @@ final class Catalog_ControllerTest extends UplinkTestCase {
 			true
 		);
 
-		$controller = new Catalog_Controller( $repository );
+		$controller = new Catalog_Controller( $this->repository );
 		$controller->register_routes();
 	}
 
@@ -101,6 +102,26 @@ final class Catalog_ControllerTest extends UplinkTestCase {
 		$response = $this->server->dispatch( $request );
 
 		$this->assertSame( 401, $response->get_status() );
+	}
+
+	// -------------------------------------------------------------------------
+	// Error throttling
+	// -------------------------------------------------------------------------
+
+	public function test_get_returns_error_when_throttled(): void {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		// Write error state at a fixed time, then advance within the TTL.
+		$this->set_fn_return( 'time', 1000000 );
+		$this->repository->set_catalog( new WP_Error( Error_Code::INVALID_RESPONSE, 'API unavailable.', [ 'status' => 502 ] ) );
+		$this->set_fn_return( 'time', 1000030 );
+
+		$request  = new WP_REST_Request( 'GET', '/stellarwp/uplink/v1/catalog' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 502, $response->get_status() );
+		$this->assertSame( Error_Code::INVALID_RESPONSE, $response->get_data()['code'] );
+		$this->assertSame( 'API unavailable.', $response->get_data()['message'] );
 	}
 
 	public function test_client_error_is_forwarded(): void {

--- a/tests/wpunit/Catalog/Catalog_RepositoryTest.php
+++ b/tests/wpunit/Catalog/Catalog_RepositoryTest.php
@@ -131,7 +131,7 @@ final class Catalog_RepositoryTest extends UplinkTestCase {
 
 		$this->assertNotNull( $this->repository->get_last_failure_at() );
 
-		$this->repository->get(); // triggers a successful fetch via the fixture client
+		$this->repository->refresh(); // bypasses throttle, triggers successful fetch via the fixture client
 
 		$this->assertNull( $this->repository->get_last_failure_at() );
 	}

--- a/tests/wpunit/Catalog/Catalog_RepositoryTest.php
+++ b/tests/wpunit/Catalog/Catalog_RepositoryTest.php
@@ -7,10 +7,14 @@ use StellarWP\Uplink\Catalog\Catalog_Repository;
 use StellarWP\Uplink\Catalog\Clients\Catalog_Client;
 use StellarWP\Uplink\Catalog\Clients\Fixture_Client;
 use StellarWP\Uplink\Catalog\Results\Product_Catalog;
+use StellarWP\Uplink\Catalog\Error_Code;
+use StellarWP\Uplink\Tests\Traits\With_Uopz;
 use StellarWP\Uplink\Tests\UplinkTestCase;
 use WP_Error;
 
 final class Catalog_RepositoryTest extends UplinkTestCase {
+
+	use With_Uopz;
 
 	private Catalog_Repository $repository;
 
@@ -116,6 +120,65 @@ final class Catalog_RepositoryTest extends UplinkTestCase {
 
 		// The error is also persisted alongside the preserved collection.
 		$this->assertInstanceOf( WP_Error::class, $this->repository->get_last_error() );
+	}
+
+	// -------------------------------------------------------------------------
+	// Error throttling
+	// -------------------------------------------------------------------------
+
+	public function test_set_catalog_collection_clears_last_failure_at(): void {
+		$this->repository->set_catalog( new WP_Error( Error_Code::INVALID_RESPONSE, 'API failure' ) );
+
+		$this->assertNotNull( $this->repository->get_last_failure_at() );
+
+		$this->repository->get(); // triggers a successful fetch via the fixture client
+
+		$this->assertNull( $this->repository->get_last_failure_at() );
+	}
+
+	public function test_get_returns_cached_error_when_within_throttle_window(): void {
+		// Write error state at a fixed time.
+		$this->set_fn_return( 'time', 1000000 );
+		$this->repository->set_catalog( new WP_Error( Error_Code::INVALID_RESPONSE, 'API failure' ) );
+
+		// Advance to 30 s later — still within the 60 s TTL.
+		$this->set_fn_return( 'time', 1000030 );
+
+		$result = $this->repository->get();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( Error_Code::INVALID_RESPONSE, $result->get_error_code() );
+	}
+
+	public function test_get_retries_api_after_throttle_window_expires(): void {
+		// Write error state at a fixed time.
+		$this->set_fn_return( 'time', 1000000 );
+		$this->repository->set_catalog( new WP_Error( Error_Code::INVALID_RESPONSE, 'API failure' ) );
+
+		// Advance past the 60 s TTL.
+		$this->set_fn_return( 'time', 1000061 );
+
+		$result = $this->repository->get();
+
+		$this->assertInstanceOf( Catalog_Collection::class, $result );
+		$this->assertCount( 4, $result );
+	}
+
+	public function test_successful_fetch_clears_error_state(): void {
+		// Write error state at a fixed time.
+		$this->set_fn_return( 'time', 1000000 );
+		$this->repository->set_catalog( new WP_Error( Error_Code::INVALID_RESPONSE, 'API failure' ) );
+
+		$this->assertNotNull( $this->repository->get_last_failure_at() );
+		$this->assertNotNull( $this->repository->get_last_error() );
+
+		// Advance past TTL so the request is not throttled and reaches the API.
+		$this->set_fn_return( 'time', 1000061 );
+
+		$this->repository->get();
+
+		$this->assertNull( $this->repository->get_last_failure_at() );
+		$this->assertNull( $this->repository->get_last_error() );
 	}
 
 	public function test_refresh_clears_and_refetches(): void {


### PR DESCRIPTION
Partially resolves: [SCON-261]

## Description

We decided to introduce error throttling into our REST APIs. This will ensure when a remote API call fails, subsequent calls that would hit the API again are short-circuited and return the cached error until the throttle window expires. This prevents hammering a degraded upstream service.

This PR is scoped to the Catalog REST API specifically.

This was achieved by adding a new constant `ERROR_THROTTLE_TTL` to the Catalog Repository that is used throughout the REST API client.

[SCON-261]: https://stellarwp.atlassian.net/browse/SCON-261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ