### PR TITLE
Refactor caching strategy in Feature_Repository to use in-memory cache | SCON-349

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -99,7 +99,7 @@ Actions fired before and after enable/disable, both globally and per-slug:
 
 ## Caching
 
-The `Feature_Repository` caches the resolved `Feature_Collection` in a transient (`stellarwp_uplink_feature_catalog`, 12h TTL). The cache includes a hash of the license key — if the key changes, the cache auto-invalidates. `refresh()` explicitly clears and re-resolves.
+The `Feature_Repository` caches the resolved `Feature_Collection` in memory for the current request. Resolution is cheap (iterates the cached catalog and licensing arrays), so no cross-request cache is needed. Fresh requests always resolve from the upstream caches (catalog and licensing), which are the single source of truth for staleness. `refresh()` clears the in-memory cache and re-resolves.
 
 ## Feature Collection
 

--- a/docs/uplink-v3.md
+++ b/docs/uplink-v3.md
@@ -112,13 +112,13 @@ The leader renders the Software Manager, a React-based admin page for managing a
 
 ## Caching
 
-All three data layers cache their results in WordPress transients with a 12-hour TTL:
+The data layers use different caching strategies:
 
-| Cache             | Transient key                         | Invalidation                    |
-| ----------------- | ------------------------------------- | ------------------------------- |
-| Licensed products | `stellarwp_uplink_licensing_products` | `License_Repository::refresh()` |
-| Product catalog   | `stellarwp_uplink_catalog`            | `Catalog_Repository::refresh()` |
-| Resolved features | `stellarwp_uplink_feature_catalog`    | `Feature_Repository::refresh()` |
+| Cache             | Type      | TTL             | Key / Location                        | Invalidation                    |
+| ----------------- | --------- | --------------- | ------------------------------------- | ------------------------------- |
+| Licensed products | Option    | None (persist)  | `stellarwp_uplink_licensing_products` | `License_Repository::refresh()` |
+| Product catalog   | Option    | None (persist)  | `stellarwp_uplink_catalog_state`      | `Catalog_Repository::refresh()` |
+| Resolved features | In-memory | Current request | —                                     | `Feature_Repository::refresh()` |
 
 The unified key itself is stored in a WordPress option (`stellarwp_uplink_unified_license_key`), not a transient.
 

--- a/src/Uplink/Features/Feature_Repository.php
+++ b/src/Uplink/Features/Feature_Repository.php
@@ -5,29 +5,15 @@ namespace StellarWP\Uplink\Features;
 use WP_Error;
 
 /**
- * Manages caching and delegates feature resolution to Resolve_Feature_Collection.
+ * Manages in-memory caching and delegates feature resolution to Resolve_Feature_Collection.
+ *
+ * Resolution is cheap (iterates cached catalog and licensing arrays), so this
+ * class only caches the result for the current request. Fresh requests always
+ * resolve from the upstream caches, which are the single source of truth.
  *
  * @since 3.0.0
  */
 class Feature_Repository {
-
-	/**
-	 * Transient key for the cached feature catalog.
-	 *
-	 * @since 3.0.0
-	 *
-	 * @var string
-	 */
-	public const TRANSIENT_KEY = 'stellarwp_uplink_feature_catalog';
-
-	/**
-	 * Default cache duration in seconds (12 hours).
-	 *
-	 * @since 3.0.0
-	 *
-	 * @var int
-	 */
-	private const CACHE_DURATION = HOUR_IN_SECONDS * 12;
 
 	/**
 	 * The feature collection resolver.
@@ -37,6 +23,15 @@ class Feature_Repository {
 	 * @var Resolve_Feature_Collection
 	 */
 	private Resolve_Feature_Collection $resolver;
+
+	/**
+	 * In-memory cache of the resolved result for the current request.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var Feature_Collection|WP_Error|null
+	 */
+	private $cached;
 
 	/**
 	 * Constructor.
@@ -50,7 +45,7 @@ class Feature_Repository {
 	}
 
 	/**
-	 * Gets the resolved feature collection, using the transient cache when available.
+	 * Gets the resolved feature collection, using the in-memory cache when available.
 	 *
 	 * @since 3.0.0
 	 *
@@ -60,22 +55,15 @@ class Feature_Repository {
 	 * @return Feature_Collection|WP_Error
 	 */
 	public function get( string $key, string $domain ) {
-		$cached = get_transient( self::TRANSIENT_KEY );
-
-		if ( is_wp_error( $cached ) ) {
-			return $cached;
-		}
-
-		if ( is_array( $cached ) ) {
-			/** @var array<array<string, mixed>> $cached */
-			return Feature_Collection::from_array( $cached );
+		if ( $this->cached !== null ) {
+			return $this->cached;
 		}
 
 		return $this->resolve( $key, $domain );
 	}
 
 	/**
-	 * Deletes the transient cache and re-resolves.
+	 * Clears the in-memory cache and re-resolves.
 	 *
 	 * @since 3.0.0
 	 *
@@ -85,13 +73,13 @@ class Feature_Repository {
 	 * @return Feature_Collection|WP_Error
 	 */
 	public function refresh( string $key, string $domain ) {
-		delete_transient( self::TRANSIENT_KEY );
+		$this->cached = null;
 
 		return $this->resolve( $key, $domain );
 	}
 
 	/**
-	 * Delegates resolution to the resolver and caches the result.
+	 * Delegates resolution to the resolver and caches the result in memory.
 	 *
 	 * @since 3.0.0
 	 *
@@ -101,14 +89,8 @@ class Feature_Repository {
 	 * @return Feature_Collection|WP_Error
 	 */
 	protected function resolve( string $key, string $domain ) {
-		$result = ( $this->resolver )( $domain );
+		$this->cached = ( $this->resolver )( $domain );
 
-		if ( $result instanceof Feature_Collection ) {
-			set_transient( self::TRANSIENT_KEY, $result->to_array(), self::CACHE_DURATION );
-		} elseif ( is_wp_error( $result ) ) {
-			set_transient( self::TRANSIENT_KEY, $result, self::CACHE_DURATION );
-		}
-
-		return $result;
+		return $this->cached;
 	}
 }

--- a/src/Uplink/Features/Manager.php
+++ b/src/Uplink/Features/Manager.php
@@ -489,9 +489,9 @@ class Manager {
 	/**
 	 * Stamps live enabled state onto every feature in the collection.
 	 *
-	 * The Feature_Collection may come from a transient cache where
-	 * is_enabled values are stale. This method overwrites each
-	 * feature's is_enabled with the current live state from its strategy.
+	 * The Feature_Collection from the repository does not include
+	 * is_enabled state. This method overwrites each feature's
+	 * is_enabled with the current live state from its strategy.
 	 *
 	 * @since 3.0.0
 	 *

--- a/src/Uplink/Features/Provider.php
+++ b/src/Uplink/Features/Provider.php
@@ -67,8 +67,6 @@ class Provider extends Abstract_Provider {
 			}
 		);
 
-		$this->register_hooks();
-
 		$this->container->singleton( Update\Provider::class, Update\Provider::class );
 		$this->container->get( Update\Provider::class )->register();
 	}
@@ -86,22 +84,6 @@ class Provider extends Abstract_Provider {
 		$resolver->register_type( Feature::TYPE_PLUGIN, Plugin::class );
 		$resolver->register_type( Feature::TYPE_FLAG, Flag::class );
 		$resolver->register_type( Feature::TYPE_THEME, Theme::class );
-	}
-
-	/**
-	 * Registers WordPress hooks for the Features subsystem.
-	 *
-	 * @since 3.0.0
-	 *
-	 * @return void
-	 */
-	private function register_hooks(): void {
-		add_action(
-			'stellarwp/uplink/unified_license_key_changed',
-			static function () {
-				delete_transient( Feature_Repository::TRANSIENT_KEY );
-			}
-		);
 	}
 
 }

--- a/tests/wpunit/Features/Feature_RepositoryTest.php
+++ b/tests/wpunit/Features/Feature_RepositoryTest.php
@@ -26,25 +26,23 @@ use WP_Error;
 final class Feature_RepositoryTest extends UplinkTestCase {
 
 	/**
-	 * Clears all relevant transients before each test.
+	 * Clears upstream caches before each test.
 	 *
 	 * @return void
 	 */
 	protected function setUp(): void {
 		parent::setUp();
 
-		delete_transient( Feature_Repository::TRANSIENT_KEY );
 		delete_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME );
 		delete_option( License_Repository::PRODUCTS_STATE_OPTION_NAME );
 	}
 
 	/**
-	 * Clears all relevant transients after each test.
+	 * Clears upstream caches after each test.
 	 *
 	 * @return void
 	 */
 	protected function tearDown(): void {
-		delete_transient( Feature_Repository::TRANSIENT_KEY );
 		delete_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME );
 		delete_option( License_Repository::PRODUCTS_STATE_OPTION_NAME );
 
@@ -254,85 +252,33 @@ final class Feature_RepositoryTest extends UplinkTestCase {
 	}
 
 	/**
-	 * Tests that the feature catalog is stored in a WordPress transient after fetching.
+	 * Tests that the same instance is returned on repeated calls within one request.
 	 *
 	 * @return void
 	 */
-	public function test_it_caches_in_transient(): void {
+	public function test_it_returns_cached_collection_within_request(): void {
 		$repository = $this->make_repository( 'lwsw-unified-kad-pro-2026' );
 
-		$repository->get( 'lwsw-unified-kad-pro-2026', 'example.com' );
+		$first  = $repository->get( 'lwsw-unified-kad-pro-2026', 'example.com' );
+		$second = $repository->get( 'lwsw-unified-kad-pro-2026', 'example.com' );
 
-		$cached = get_transient( Feature_Repository::TRANSIENT_KEY );
-
-		$this->assertIsArray( $cached );
-		$this->assertNotEmpty( $cached );
+		$this->assertSame( $first, $second );
 	}
 
 	/**
-	 * Tests that a cached transient is returned without calling the clients again.
-	 *
-	 * @return void
-	 */
-	public function test_it_returns_cached_collection(): void {
-		$cached = [
-			[
-				'slug'              => 'cached-feature',
-				'group'             => 'test',
-				'tier'              => 'free',
-				'name'              => 'Cached',
-				'description'       => '',
-				'type'              => 'plugin',
-				'is_available'      => true,
-				'documentation_url' => '',
-				'plugin_file'       => '',
-				'authors'           => [],
-			],
-		];
-
-		// Set the transient after make_repository() so that store_key() inside
-		// make_repository() does not fire the key-changed hook and wipe the cache.
-		$repository = $this->make_repository( 'lwsw-unified-kad-pro-2026' );
-		set_transient( Feature_Repository::TRANSIENT_KEY, $cached );
-		$result = $repository->get( 'lwsw-unified-kad-pro-2026', 'example.com' );
-
-		$this->assertCount( 1, $result );
-		$this->assertSame( 'cached-feature', $result->get( 'cached-feature' )->get_slug() );
-	}
-
-	/**
-	 * Tests that a cached WP_Error transient is returned directly.
-	 *
-	 * @return void
-	 */
-	public function test_it_returns_cached_wp_error(): void {
-		$error = new WP_Error( 'api_error', 'Cached error' );
-
-		// Set the transient after make_repository() so that store_key() inside
-		// make_repository() does not fire the key-changed hook and wipe the cache.
-		$repository = $this->make_repository( 'lwsw-unified-kad-pro-2026' );
-		set_transient( Feature_Repository::TRANSIENT_KEY, $error );
-		$result = $repository->get( 'lwsw-unified-kad-pro-2026', 'example.com' );
-
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'Cached error', $result->get_error_message() );
-	}
-
-	/**
-	 * Tests refresh clears and re-fetches the transient cache.
+	 * Tests refresh clears the in-memory cache and re-resolves.
 	 *
 	 * @return void
 	 */
 	public function test_refresh_clears_and_refetches(): void {
 		$repository = $this->make_repository( 'lwsw-unified-kad-pro-2026' );
 
-		$repository->get( 'lwsw-unified-kad-pro-2026', 'example.com' );
+		$first  = $repository->get( 'lwsw-unified-kad-pro-2026', 'example.com' );
+		$second = $repository->refresh( 'lwsw-unified-kad-pro-2026', 'example.com' );
 
-		$this->assertIsArray( get_transient( Feature_Repository::TRANSIENT_KEY ) );
-
-		$repository->refresh( 'lwsw-unified-kad-pro-2026', 'example.com' );
-
-		$this->assertIsArray( get_transient( Feature_Repository::TRANSIENT_KEY ) );
+		$this->assertInstanceOf( Feature_Collection::class, $first );
+		$this->assertInstanceOf( Feature_Collection::class, $second );
+		$this->assertNotSame( $first, $second );
 	}
 
 	/**

--- a/tests/wpunit/Features/ManagerTest.php
+++ b/tests/wpunit/Features/ManagerTest.php
@@ -55,8 +55,6 @@ final class ManagerTest extends UplinkTestCase {
 			define( 'STELLARWP_UPLINK_FEATURES_USE_FIXTURE_DATA', true );
 		}
 
-		delete_transient( 'stellarwp_uplink_feature_catalog' );
-
 		$this->collection = new Feature_Collection();
 		$this->collection->add(
 			Flag::from_array(
@@ -105,7 +103,6 @@ final class ManagerTest extends UplinkTestCase {
 	protected function tearDown(): void {
 		delete_option( 'stellarwp_uplink_feature_kad-pattern-hub_active' );
 		delete_option( License_Repository::KEY_OPTION_NAME );
-		delete_transient( Feature_Repository::TRANSIENT_KEY );
 		delete_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME );
 		delete_option( License_Repository::PRODUCTS_STATE_OPTION_NAME );
 

--- a/tests/wpunit/Licensing/Repositories/License_Key_Cache_InvalidationTest.php
+++ b/tests/wpunit/Licensing/Repositories/License_Key_Cache_InvalidationTest.php
@@ -4,10 +4,6 @@ namespace StellarWP\Uplink\Tests\Licensing\Repositories;
 
 use StellarWP\Uplink\Catalog\Catalog_Repository;
 use StellarWP\Uplink\Catalog\Clients\Fixture_Client as Catalog_Fixture;
-use StellarWP\Uplink\Features\Feature_Repository;
-use StellarWP\Uplink\Features\Resolve_Feature_Collection;
-use StellarWP\Uplink\Features\Types\Flag;
-use StellarWP\Uplink\Features\Types\Plugin;
 use StellarWP\Uplink\Licensing\Clients\Fixture_Client as Licensing_Fixture;
 use StellarWP\Uplink\Licensing\License_Manager;
 use StellarWP\Uplink\Licensing\Product_Collection;
@@ -17,7 +13,7 @@ use StellarWP\Uplink\Tests\UplinkTestCase;
 
 /**
  * Integration tests verifying that changing the unified license key
- * invalidates all repository transient caches, causing fresh data
+ * invalidates upstream repository caches, causing fresh data
  * to be fetched on the next call.
  *
  * @since 3.0.0
@@ -27,7 +23,6 @@ final class License_Key_Cache_InvalidationTest extends UplinkTestCase {
 	private License_Repository $license_repository;
 	private License_Manager $license_manager;
 	private Catalog_Repository $catalog_repository;
-	private Feature_Repository $feature_repository;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -44,16 +39,6 @@ final class License_Key_Cache_InvalidationTest extends UplinkTestCase {
 		$catalog_client           = new Catalog_Fixture( codecept_data_dir( 'catalog/default.json' ) );
 		$this->catalog_repository = new Catalog_Repository( $catalog_client );
 
-		$resolver = new Resolve_Feature_Collection(
-			$this->catalog_repository,
-			$this->license_manager
-		);
-		$resolver->register_type( 'plugin', Plugin::class );
-		$resolver->register_type( 'flag', Flag::class );
-		$resolver->register_type( 'theme', Plugin::class ); // TODO: Will be replaced with Theme type.
-
-		$this->feature_repository = new Feature_Repository( $resolver );
-
 		// Register cache invalidation hooks that providers normally wire up.
 		add_action(
 			'stellarwp/uplink/unified_license_key_changed',
@@ -65,16 +50,9 @@ final class License_Key_Cache_InvalidationTest extends UplinkTestCase {
 				delete_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME );
 			}
 		);
-		add_action(
-			'stellarwp/uplink/unified_license_key_changed',
-			static function () {
-				delete_transient( Feature_Repository::TRANSIENT_KEY );
-			}
-		);
 
 		delete_option( License_Repository::PRODUCTS_STATE_OPTION_NAME );
 		delete_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME );
-		delete_transient( Feature_Repository::TRANSIENT_KEY );
 		delete_option( License_Repository::KEY_OPTION_NAME );
 	}
 
@@ -83,7 +61,6 @@ final class License_Key_Cache_InvalidationTest extends UplinkTestCase {
 
 		delete_option( License_Repository::PRODUCTS_STATE_OPTION_NAME );
 		delete_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME );
-		delete_transient( Feature_Repository::TRANSIENT_KEY );
 		delete_option( License_Repository::KEY_OPTION_NAME );
 
 		parent::tearDown();
@@ -140,95 +117,50 @@ final class License_Key_Cache_InvalidationTest extends UplinkTestCase {
 		$this->assertNotNull( $fresh->get( 'kadence' ) );
 	}
 
-	public function test_feature_repository_returns_different_availability_after_key_change(): void {
-		// With a pro key, pro-tier features like kad-shop-kit (min: kadence-pro) are available.
-		$this->license_repository->store_key( 'LWSW-UNIFIED-KAD-PRO-2026' );
-		$pro_result = $this->feature_repository->get( 'LWSW-UNIFIED-KAD-PRO-2026', 'example.com' );
-
-		$this->assertTrue(
-			$pro_result->get( 'kad-shop-kit' )->is_available(),
-			'Pro tier (rank 2) should have access to kad-shop-kit (min: kadence-pro, rank 2).'
-		);
-		$this->assertTrue(
-			$pro_result->get( 'kad-blocks-pro' )->is_available(),
-			'Pro tier (rank 2) should have access to kad-blocks-pro (min: kadence-basic, rank 1).'
-		);
-
-		// Cached — even after changing stored key, stale pro features are returned until cache clears.
-		$stale = $this->feature_repository->get( 'LWSW-UNIFIED-BASIC-2026', 'example.com' );
-		$this->assertTrue(
-			$stale->get( 'kad-shop-kit' )->is_available(),
-			'Should still be cached pro feature data.'
-		);
-
-		// Change the license key — invalidates the feature transient.
-		$this->license_repository->store_key( 'LWSW-UNIFIED-BASIC-2026' );
-
-		// With a basic key, pro-tier features should no longer be available.
-		$basic_result = $this->feature_repository->get( 'LWSW-UNIFIED-BASIC-2026', 'example.com' );
-
-		$this->assertFalse(
-			$basic_result->get( 'kad-shop-kit' )->is_available(),
-			'Basic tier (rank 1) should NOT have access to kad-shop-kit (min: kadence-pro, rank 2).'
-		);
-		$this->assertTrue(
-			$basic_result->get( 'kad-blocks-pro' )->is_available(),
-			'Basic tier (rank 1) should still have access to kad-blocks-pro (min: kadence-basic, rank 1).'
-		);
-	}
-
 	public function test_all_caches_invalidated_on_key_change(): void {
-		// Populate all three caches.
+		// Populate upstream caches.
 		$this->license_repository->store_key( 'LWSW-UNIFIED-PRO-2026' );
 		$this->license_manager->get_products( 'example.com' );
 		$this->catalog_repository->get();
-		$this->feature_repository->get( 'LWSW-UNIFIED-KAD-PRO-2026', 'example.com' );
 
 		$this->assertInstanceOf( Product_Collection::class, $this->license_repository->get_products() );
 		$this->assertNotFalse( get_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME ) );
-		$this->assertNotFalse( get_transient( Feature_Repository::TRANSIENT_KEY ) );
 
-		// Storing a new key should clear the catalog option and feature transient.
+		// Storing a new key should clear the upstream caches.
 		$this->license_repository->store_key( 'LWSW-UNIFIED-BASIC-2026' );
 
 		$this->assertNull( $this->license_repository->get_products() );
 		$this->assertFalse( get_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME ) );
-		$this->assertFalse( get_transient( Feature_Repository::TRANSIENT_KEY ) );
 	}
 
 	public function test_all_caches_invalidated_on_key_delete(): void {
 		$this->license_repository->store_key( 'LWSW-UNIFIED-PRO-2026' );
 
-		// Populate all three caches.
+		// Populate upstream caches.
 		$this->license_manager->get_products( 'example.com' );
 		$this->catalog_repository->get();
-		$this->feature_repository->get( 'LWSW-UNIFIED-KAD-PRO-2026', 'example.com' );
 
 		$this->assertInstanceOf( Product_Collection::class, $this->license_repository->get_products() );
 		$this->assertNotFalse( get_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME ) );
-		$this->assertNotFalse( get_transient( Feature_Repository::TRANSIENT_KEY ) );
 
-		// Deleting the key should clear the catalog option and feature transient.
+		// Deleting the key should clear the upstream caches.
 		$this->license_repository->delete_key();
 
 		$this->assertNull( $this->license_repository->get_products() );
 		$this->assertFalse( get_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME ) );
-		$this->assertFalse( get_transient( Feature_Repository::TRANSIENT_KEY ) );
 	}
 
 	public function test_caches_not_invalidated_when_same_key_stored(): void {
 		$this->license_repository->store_key( 'LWSW-UNIFIED-PRO-2026' );
 
-		// Populate all three caches.
+		// Populate upstream caches.
 		$this->license_manager->get_products( 'example.com' );
 		$this->catalog_repository->get();
-		$this->feature_repository->get( 'LWSW-UNIFIED-KAD-PRO-2026', 'example.com' );
 
 		// Re-store the same key — caches should remain intact.
 		$this->license_repository->store_key( 'LWSW-UNIFIED-PRO-2026' );
 
 		$this->assertInstanceOf( Product_Collection::class, $this->license_repository->get_products() );
 		$this->assertNotFalse( get_option( Catalog_Repository::CATALOG_STATE_OPTION_NAME ) );
-		$this->assertNotFalse( get_transient( Feature_Repository::TRANSIENT_KEY ) );
 	}
 }


### PR DESCRIPTION
🎫 [SCON-349]

I just removed the transient usage here.

It requires https://github.com/stellarwp/uplink-sample-plugin/pull/7 to function because a constant got removed.

I tested and features list still works :-)

[SCON-349]: https://stellarwp.atlassian.net/browse/SCON-349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ