### PR TITLE
Remove key/domain pass-through from feature resolution chain | SCON-350

### DIFF
--- a/src/Uplink/Features/Feature_Repository.php
+++ b/src/Uplink/Features/Feature_Repository.php
@@ -49,17 +49,14 @@ class Feature_Repository {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string $key    License key.
-	 * @param string $domain Site domain.
-	 *
 	 * @return Feature_Collection|WP_Error
 	 */
-	public function get( string $key, string $domain ) {
+	public function get() {
 		if ( $this->cached !== null ) {
 			return $this->cached;
 		}
 
-		return $this->resolve( $key, $domain );
+		return $this->resolve();
 	}
 
 	/**
@@ -67,15 +64,12 @@ class Feature_Repository {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string $key    License key.
-	 * @param string $domain Site domain.
-	 *
 	 * @return Feature_Collection|WP_Error
 	 */
-	public function refresh( string $key, string $domain ) {
+	public function refresh() {
 		$this->cached = null;
 
-		return $this->resolve( $key, $domain );
+		return $this->resolve();
 	}
 
 	/**
@@ -83,13 +77,10 @@ class Feature_Repository {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string $key    License key.
-	 * @param string $domain Site domain.
-	 *
 	 * @return Feature_Collection|WP_Error
 	 */
-	protected function resolve( string $key, string $domain ) {
-		$this->cached = ( $this->resolver )( $domain );
+	protected function resolve() {
+		$this->cached = ( $this->resolver )();
 
 		return $this->cached;
 	}

--- a/src/Uplink/Features/Manager.php
+++ b/src/Uplink/Features/Manager.php
@@ -37,40 +37,18 @@ class Manager {
 	private Strategy_Factory $strategy_factory;
 
 	/**
-	 * The license key.
-	 *
-	 * @since 3.0.0
-	 *
-	 * @var string
-	 */
-	private string $key;
-
-	/**
-	 * The site domain.
-	 *
-	 * @since 3.0.0
-	 *
-	 * @var string
-	 */
-	private string $domain;
-
-	/**
 	 * Constructor for the central feature orchestrator.
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param Feature_Repository $repository The repository for fetching available features.
+	 * @param Feature_Repository $repository       The repository for fetching available features.
 	 * @param Strategy_Factory   $strategy_factory The strategy factory.
-	 * @param string             $key              The license key.
-	 * @param string             $domain           The site domain.
 	 *
 	 * @return void
 	 */
-	public function __construct( Feature_Repository $repository, Strategy_Factory $strategy_factory, string $key, string $domain ) {
+	public function __construct( Feature_Repository $repository, Strategy_Factory $strategy_factory ) {
 		$this->repository       = $repository;
 		$this->strategy_factory = $strategy_factory;
-		$this->key              = $key;
-		$this->domain           = $domain;
 	}
 
 	/**
@@ -86,7 +64,7 @@ class Manager {
 	 * @return Feature|WP_Error The feature with updated is_enabled state, or WP_Error on failure.
 	 */
 	public function enable( string $slug ) {
-		$features = $this->repository->get( $this->key, $this->domain );
+		$features = $this->repository->get();
 
 		if ( is_wp_error( $features ) ) {
 			return $features;
@@ -185,7 +163,7 @@ class Manager {
 	 * @return Feature|WP_Error The feature with updated is_enabled state, or WP_Error on failure.
 	 */
 	public function disable( string $slug ) {
-		$features = $this->repository->get( $this->key, $this->domain );
+		$features = $this->repository->get();
 
 		if ( is_wp_error( $features ) ) {
 			return $features;
@@ -284,7 +262,7 @@ class Manager {
 	 * @return Feature|WP_Error The feature with updated state, or WP_Error on failure.
 	 */
 	public function update( string $slug ) {
-		$features = $this->repository->get( $this->key, $this->domain );
+		$features = $this->repository->get();
 
 		if ( is_wp_error( $features ) ) {
 			return $features;
@@ -436,7 +414,7 @@ class Manager {
 	 * @return bool|WP_Error
 	 */
 	public function exists( string $slug ) {
-		$features = $this->repository->get( $this->key, $this->domain );
+		$features = $this->repository->get();
 
 		if ( is_wp_error( $features ) ) {
 			return $features;
@@ -453,7 +431,7 @@ class Manager {
 	 * @return Feature_Collection|WP_Error
 	 */
 	public function get_all() {
-		$features = $this->repository->get( $this->key, $this->domain );
+		$features = $this->repository->get();
 
 		if ( is_wp_error( $features ) ) {
 			return $features;

--- a/src/Uplink/Features/Provider.php
+++ b/src/Uplink/Features/Provider.php
@@ -35,7 +35,8 @@ class Provider extends Abstract_Provider {
 			function ( ContainerInterface $c ) {
 				$resolver = new Resolve_Feature_Collection(
 					$c->get( Catalog_Repository::class ),
-					$c->get( License_Manager::class )
+					$c->get( License_Manager::class ),
+					$c->get( Data::class )
 				);
 
 				$this->register_default_types( $resolver );
@@ -60,9 +61,7 @@ class Provider extends Abstract_Provider {
 			static function ( ContainerInterface $c ) {
 				return new Manager(
 					$c->get( Feature_Repository::class ),
-					$c->get( Strategy_Factory::class ),
-					$c->get( License_Manager::class )->get_key() ?? '',
-					$c->get( Data::class )->get_domain()
+					$c->get( Strategy_Factory::class )
 				);
 			}
 		);
@@ -85,5 +84,4 @@ class Provider extends Abstract_Provider {
 		$resolver->register_type( Feature::TYPE_FLAG, Flag::class );
 		$resolver->register_type( Feature::TYPE_THEME, Theme::class );
 	}
-
 }

--- a/src/Uplink/Features/Resolve_Feature_Collection.php
+++ b/src/Uplink/Features/Resolve_Feature_Collection.php
@@ -8,6 +8,7 @@ use StellarWP\Uplink\Catalog\Results\Product_Catalog;
 use StellarWP\Uplink\Features\Types\Feature;
 use StellarWP\Uplink\Licensing\License_Manager;
 use StellarWP\Uplink\Licensing\Product_Collection;
+use StellarWP\Uplink\Site\Data;
 use WP_Error;
 
 /**
@@ -39,6 +40,15 @@ class Resolve_Feature_Collection {
 	private License_Manager $licensing;
 
 	/**
+	 * The site data provider.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var Data
+	 */
+	private Data $site_data;
+
+	/**
 	 * Map of catalog type strings to Feature subclass names.
 	 *
 	 * @since 3.0.0
@@ -54,13 +64,16 @@ class Resolve_Feature_Collection {
 	 *
 	 * @param Catalog_Repository $catalog   The catalog repository.
 	 * @param License_Manager    $licensing The license manager.
+	 * @param Data               $site_data The site data provider.
 	 */
 	public function __construct(
 		Catalog_Repository $catalog,
-		License_Manager $licensing
+		License_Manager $licensing,
+		Data $site_data
 	) {
 		$this->catalog   = $catalog;
 		$this->licensing = $licensing;
+		$this->site_data = $site_data;
 	}
 
 	/**
@@ -85,18 +98,16 @@ class Resolve_Feature_Collection {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string $domain Site domain.
-	 *
 	 * @return Feature_Collection|WP_Error
 	 */
-	public function __invoke( string $domain ) {
+	public function __invoke() {
 		$catalog = $this->catalog->get();
 
 		if ( is_wp_error( $catalog ) ) {
 			return $catalog;
 		}
 
-		$products = $this->licensing->get_products( $domain );
+		$products = $this->licensing->get_products( $this->site_data->get_domain() );
 
 		if ( is_wp_error( $products ) ) {
 			if ( $this->licensing->get_key() === null ) {

--- a/src/Uplink/Features/Update/Plugin_Handler.php
+++ b/src/Uplink/Features/Update/Plugin_Handler.php
@@ -5,7 +5,7 @@ namespace StellarWP\Uplink\Features\Update;
 use StellarWP\Uplink\Features\Contracts\Installable;
 use StellarWP\Uplink\Features\Feature_Repository;
 use StellarWP\Uplink\Features\Types\Feature;
-use StellarWP\Uplink\Site\Data;
+use StellarWP\Uplink\Licensing\License_Manager;
 use stdClass;
 use StellarWP\Uplink\Utils\Cast;
 
@@ -39,22 +39,13 @@ class Plugin_Handler {
 	private Feature_Repository $feature_repository;
 
 	/**
-	 * The site data provider.
+	 * The license manager.
 	 *
 	 * @since 3.0.0
 	 *
-	 * @var Data
+	 * @var License_Manager
 	 */
-	private Data $site_data;
-
-	/**
-	 * The license key.
-	 *
-	 * @since 3.0.0
-	 *
-	 * @var string
-	 */
-	private string $key;
+	private License_Manager $license_manager;
 
 	/**
 	 * Constructor for the consolidated update handler.
@@ -63,21 +54,18 @@ class Plugin_Handler {
 	 *
 	 * @param Resolve_Update_Data $resolver           The update data resolver.
 	 * @param Feature_Repository  $feature_repository The feature repository.
-	 * @param Data                $site_data          The site data provider.
-	 * @param string              $key                The license key.
+	 * @param License_Manager     $license_manager    The license manager.
 	 *
 	 * @return void
 	 */
 	public function __construct(
 		Resolve_Update_Data $resolver,
 		Feature_Repository $feature_repository,
-		Data $site_data,
-		string $key
+		License_Manager $license_manager
 	) {
 		$this->resolver           = $resolver;
 		$this->feature_repository = $feature_repository;
-		$this->site_data          = $site_data;
-		$this->key                = $key;
+		$this->license_manager    = $license_manager;
 	}
 
 	/**
@@ -98,7 +86,7 @@ class Plugin_Handler {
 			return $result;
 		}
 
-		if ( empty( $this->key ) ) {
+		if ( empty( $this->license_manager->get_key() ) ) {
 			return $result;
 		}
 
@@ -106,7 +94,7 @@ class Plugin_Handler {
 		$slug = $args->slug;
 
 		// Check whether the requested slug belongs to a known Plugin feature.
-		$features = $this->feature_repository->get( $this->key, $this->site_data->get_domain() );
+		$features = $this->feature_repository->get();
 
 		if ( is_wp_error( $features ) ) {
 			return $result;
@@ -124,8 +112,7 @@ class Plugin_Handler {
 			return $result;
 		}
 
-		$domain   = $this->site_data->get_domain();
-		$response = ( $this->resolver )( $this->key, $domain, Feature::TYPE_PLUGIN );
+		$response = ( $this->resolver )( Feature::TYPE_PLUGIN );
 
 		if ( is_wp_error( $response ) || empty( $response[ $slug ] ) ) {
 			return $result;
@@ -148,12 +135,11 @@ class Plugin_Handler {
 			return $transient;
 		}
 
-		if ( empty( $this->key ) ) {
+		if ( empty( $this->license_manager->get_key() ) ) {
 			return $transient;
 		}
 
-		$domain   = $this->site_data->get_domain();
-		$response = ( $this->resolver )( $this->key, $domain, Feature::TYPE_PLUGIN );
+		$response = ( $this->resolver )( Feature::TYPE_PLUGIN );
 
 		if ( is_wp_error( $response ) || empty( $response ) ) {
 			return $transient;

--- a/src/Uplink/Features/Update/Provider.php
+++ b/src/Uplink/Features/Update/Provider.php
@@ -6,7 +6,6 @@ use StellarWP\ContainerContract\ContainerInterface;
 use StellarWP\Uplink\Contracts\Abstract_Provider;
 use StellarWP\Uplink\Features\Feature_Repository;
 use StellarWP\Uplink\Licensing\License_Manager;
-use StellarWP\Uplink\Site\Data;
 use StellarWP\Uplink\Utils\Version;
 
 /**
@@ -32,8 +31,7 @@ class Provider extends Abstract_Provider {
 				return new Plugin_Handler(
 					$c->get( Resolve_Update_Data::class ),
 					$c->get( Feature_Repository::class ),
-					$c->get( Data::class ),
-					$c->get( License_Manager::class )->get_key() ?? ''
+					$c->get( License_Manager::class )
 				);
 			}
 		);
@@ -44,8 +42,7 @@ class Provider extends Abstract_Provider {
 				return new Theme_Handler(
 					$c->get( Resolve_Update_Data::class ),
 					$c->get( Feature_Repository::class ),
-					$c->get( Data::class ),
-					$c->get( License_Manager::class )->get_key() ?? ''
+					$c->get( License_Manager::class )
 				);
 			}
 		);

--- a/src/Uplink/Features/Update/Resolve_Update_Data.php
+++ b/src/Uplink/Features/Update/Resolve_Update_Data.php
@@ -69,14 +69,12 @@ class Resolve_Update_Data {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string $key    The unified license key.
-	 * @param string $domain The site domain.
-	 * @param string $type   The feature type to resolve (a Feature::TYPE_* constant).
+	 * @param string $type The feature type to resolve (a Feature::TYPE_* constant).
 	 *
 	 * @return array<string, array<string, mixed>>|WP_Error Keyed by slug, each entry contains update fields.
 	 */
-	public function __invoke( string $key, string $domain, string $type ) {
-		$features = $this->feature_repository->get( $key, $domain );
+	public function __invoke( string $type ) {
+		$features = $this->feature_repository->get();
 
 		if ( is_wp_error( $features ) ) {
 			return $features;

--- a/src/Uplink/Features/Update/Theme_Handler.php
+++ b/src/Uplink/Features/Update/Theme_Handler.php
@@ -5,7 +5,7 @@ namespace StellarWP\Uplink\Features\Update;
 use StellarWP\Uplink\Features\Contracts\Installable;
 use StellarWP\Uplink\Features\Feature_Repository;
 use StellarWP\Uplink\Features\Types\Feature;
-use StellarWP\Uplink\Site\Data;
+use StellarWP\Uplink\Licensing\License_Manager;
 use stdClass;
 use StellarWP\Uplink\Utils\Cast;
 
@@ -39,22 +39,13 @@ class Theme_Handler {
 	private Feature_Repository $feature_repository;
 
 	/**
-	 * The site data provider.
+	 * The license manager.
 	 *
 	 * @since 3.0.0
 	 *
-	 * @var Data
+	 * @var License_Manager
 	 */
-	private Data $site_data;
-
-	/**
-	 * The license key.
-	 *
-	 * @since 3.0.0
-	 *
-	 * @var string
-	 */
-	private string $key;
+	private License_Manager $license_manager;
 
 	/**
 	 * Constructor for the consolidated theme update handler.
@@ -63,21 +54,18 @@ class Theme_Handler {
 	 *
 	 * @param Resolve_Update_Data $resolver           The update data resolver.
 	 * @param Feature_Repository  $feature_repository The feature repository.
-	 * @param Data                $site_data          The site data provider.
-	 * @param string              $key                The license key.
+	 * @param License_Manager     $license_manager    The license manager.
 	 *
 	 * @return void
 	 */
 	public function __construct(
 		Resolve_Update_Data $resolver,
 		Feature_Repository $feature_repository,
-		Data $site_data,
-		string $key
+		License_Manager $license_manager
 	) {
 		$this->resolver           = $resolver;
 		$this->feature_repository = $feature_repository;
-		$this->site_data          = $site_data;
-		$this->key                = $key;
+		$this->license_manager    = $license_manager;
 	}
 
 	/**
@@ -98,7 +86,7 @@ class Theme_Handler {
 			return $result;
 		}
 
-		if ( empty( $this->key ) ) {
+		if ( empty( $this->license_manager->get_key() ) ) {
 			return $result;
 		}
 
@@ -106,7 +94,7 @@ class Theme_Handler {
 		$slug = $args->slug;
 
 		// Check whether the requested slug belongs to a known Theme feature.
-		$features = $this->feature_repository->get( $this->key, $this->site_data->get_domain() );
+		$features = $this->feature_repository->get();
 
 		if ( is_wp_error( $features ) ) {
 			return $result;
@@ -124,8 +112,7 @@ class Theme_Handler {
 			return $result;
 		}
 
-		$domain   = $this->site_data->get_domain();
-		$response = ( $this->resolver )( $this->key, $domain, Feature::TYPE_THEME );
+		$response = ( $this->resolver )( Feature::TYPE_THEME );
 
 		if ( is_wp_error( $response ) || empty( $response[ $slug ] ) ) {
 			return $result;
@@ -148,12 +135,11 @@ class Theme_Handler {
 			return $transient;
 		}
 
-		if ( empty( $this->key ) ) {
+		if ( empty( $this->license_manager->get_key() ) ) {
 			return $transient;
 		}
 
-		$domain   = $this->site_data->get_domain();
-		$response = ( $this->resolver )( $this->key, $domain, Feature::TYPE_THEME );
+		$response = ( $this->resolver )( Feature::TYPE_THEME );
 
 		if ( is_wp_error( $response ) || empty( $response ) ) {
 			return $transient;

--- a/tests/wpunit/API/REST/V1/Feature_ControllerTest.php
+++ b/tests/wpunit/API/REST/V1/Feature_ControllerTest.php
@@ -110,7 +110,7 @@ final class Feature_ControllerTest extends UplinkTestCase {
 			]
 		);
 
-		$this->manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$this->manager = new Manager( $repository, $factory );
 
 		/** @var WP_REST_Server $wp_rest_server */
 		global $wp_rest_server;
@@ -470,7 +470,7 @@ final class Feature_ControllerTest extends UplinkTestCase {
 		);
 
 		$factory = $this->makeEmpty( Strategy_Factory::class );
-		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager = new Manager( $repository, $factory );
 
 		global $wp_rest_server;
 		$wp_rest_server = new WP_REST_Server();
@@ -762,7 +762,7 @@ final class Feature_ControllerTest extends UplinkTestCase {
 
 		$factory    = $this->makeEmpty( Strategy_Factory::class, [ 'make' => $error_strategy ] );
 		$repository = $this->makeEmpty( Feature_Repository::class, [ 'get' => $this->manager->get_all() ] );
-		$manager    = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager    = new Manager( $repository, $factory );
 
 		global $wp_rest_server;
 		$wp_rest_server = new WP_REST_Server();
@@ -838,7 +838,7 @@ final class Feature_ControllerTest extends UplinkTestCase {
 
 		$factory    = $this->makeEmpty( Strategy_Factory::class, [ 'make' => $error_strategy ] );
 		$repository = $this->makeEmpty( Feature_Repository::class, [ 'get' => $this->manager->get_all() ] );
-		$manager    = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager    = new Manager( $repository, $factory );
 
 		global $wp_rest_server;
 		$wp_rest_server = new WP_REST_Server();
@@ -872,7 +872,7 @@ final class Feature_ControllerTest extends UplinkTestCase {
 		);
 
 		$factory = $this->makeEmpty( Strategy_Factory::class );
-		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager = new Manager( $repository, $factory );
 
 		global $wp_rest_server;
 		$wp_rest_server = new WP_REST_Server();
@@ -909,7 +909,7 @@ final class Feature_ControllerTest extends UplinkTestCase {
 
 		$factory    = $this->makeEmpty( Strategy_Factory::class, [ 'make' => $error_strategy ] );
 		$repository = $this->makeEmpty( Feature_Repository::class, [ 'get' => $this->manager->get_all() ] );
-		$manager    = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager    = new Manager( $repository, $factory );
 
 		global $wp_rest_server;
 		$wp_rest_server = new WP_REST_Server();
@@ -947,7 +947,7 @@ final class Feature_ControllerTest extends UplinkTestCase {
 
 		$factory    = $this->makeEmpty( Strategy_Factory::class, [ 'make' => $error_strategy ] );
 		$repository = $this->makeEmpty( Feature_Repository::class, [ 'get' => $this->manager->get_all() ] );
-		$manager    = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager    = new Manager( $repository, $factory );
 
 		global $wp_rest_server;
 		$wp_rest_server = new WP_REST_Server();

--- a/tests/wpunit/CLI/Commands/FeatureTest.php
+++ b/tests/wpunit/CLI/Commands/FeatureTest.php
@@ -113,7 +113,7 @@ final class FeatureTest extends UplinkTestCase {
 			]
 		);
 
-		$this->manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$this->manager = new Manager( $repository, $factory );
 		$this->command = new Feature_Command( $this->manager );
 	}
 
@@ -145,7 +145,7 @@ final class FeatureTest extends UplinkTestCase {
 			]
 		);
 		$factory    = $this->makeEmpty( Strategy_Factory::class );
-		$manager    = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager    = new Manager( $repository, $factory );
 		$command    = new Feature_Command( $manager );
 
 		$command->list_( [], [] );
@@ -382,7 +382,7 @@ final class FeatureTest extends UplinkTestCase {
 		$strategy   = $this->makeEmpty( Strategy::class, [ 'is_active' => false ] );
 		$factory    = $this->makeEmpty( Strategy_Factory::class, [ 'make' => $strategy ] );
 		$repository = $this->makeEmpty( Feature_Repository::class, [ 'get' => $this->collection ] );
-		$manager    = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager    = new Manager( $repository, $factory );
 		$command    = new Feature_Command( $manager );
 
 		$feature = $manager->get( 'test-flag' );
@@ -472,7 +472,7 @@ final class FeatureTest extends UplinkTestCase {
 		$strategy   = $this->makeEmpty( Strategy::class, $strategy_returns );
 		$factory    = $this->makeEmpty( Strategy_Factory::class, [ 'make' => $strategy ] );
 		$repository = $this->makeEmpty( Feature_Repository::class, [ 'get' => $this->collection ] );
-		$manager    = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager    = new Manager( $repository, $factory );
 
 		return new Feature_Command( $manager );
 	}

--- a/tests/wpunit/Features/Feature_RepositoryTest.php
+++ b/tests/wpunit/Features/Feature_RepositoryTest.php
@@ -61,7 +61,8 @@ final class Feature_RepositoryTest extends UplinkTestCase {
 		Catalog_Repository $catalog,
 		License_Manager $licensing
 	): Resolve_Feature_Collection {
-		$resolver = new Resolve_Feature_Collection( $catalog, $licensing );
+		$site_data = $this->makeEmpty( \StellarWP\Uplink\Site\Data::class, [ 'get_domain' => 'example.com' ] );
+		$resolver  = new Resolve_Feature_Collection( $catalog, $licensing, $site_data );
 
 		$resolver->register_type( 'plugin', Plugin::class );
 		$resolver->register_type( 'flag', Flag::class );
@@ -123,7 +124,7 @@ final class Feature_RepositoryTest extends UplinkTestCase {
 	public function test_get_returns_collection(): void {
 		$repository = $this->make_repository( 'lwsw-unified-kad-pro-2026' );
 
-		$result = $repository->get( 'lwsw-unified-kad-pro-2026', 'example.com' );
+		$result = $repository->get();
 
 		$this->assertInstanceOf( Feature_Collection::class, $result );
 		$this->assertGreaterThan( 0, $result->count() );
@@ -136,7 +137,7 @@ final class Feature_RepositoryTest extends UplinkTestCase {
 	 */
 	public function test_it_maps_plugin_type_to_plugin(): void {
 		$repository = $this->make_repository( 'lwsw-unified-kad-pro-2026' );
-		$result     = $repository->get( 'lwsw-unified-kad-pro-2026', 'example.com' );
+		$result     = $repository->get();
 		$feature    = $result->get( 'kad-blocks-pro' );
 
 		$this->assertInstanceOf( Plugin::class, $feature );
@@ -150,7 +151,7 @@ final class Feature_RepositoryTest extends UplinkTestCase {
 	 */
 	public function test_it_maps_flag_type_to_flag(): void {
 		$repository = $this->make_repository( 'lwsw-unified-kad-pro-2026' );
-		$result     = $repository->get( 'lwsw-unified-kad-pro-2026', 'example.com' );
+		$result     = $repository->get();
 		$feature    = $result->get( 'kad-pattern-hub' );
 
 		$this->assertInstanceOf( Flag::class, $feature );
@@ -166,7 +167,7 @@ final class Feature_RepositoryTest extends UplinkTestCase {
 	 */
 	public function test_available_when_tier_meets_minimum(): void {
 		$repository = $this->make_repository( 'lwsw-unified-kad-pro-2026' );
-		$result     = $repository->get( 'lwsw-unified-kad-pro-2026', 'example.com' );
+		$result     = $repository->get();
 
 		$this->assertTrue(
 			$result->get( 'kad-blocks-pro' )->is_available(),
@@ -187,7 +188,7 @@ final class Feature_RepositoryTest extends UplinkTestCase {
 	 */
 	public function test_unavailable_when_tier_below_minimum(): void {
 		$repository = $this->make_repository( 'lwsw-unified-kad-pro-2026' );
-		$result     = $repository->get( 'lwsw-unified-kad-pro-2026', 'example.com' );
+		$result     = $repository->get();
 
 		$this->assertFalse(
 			$result->get( 'solid-central' )->is_available(),
@@ -203,7 +204,7 @@ final class Feature_RepositoryTest extends UplinkTestCase {
 	public function test_licensing_error_returns_wp_error(): void {
 		$repository = $this->make_error_repository();
 
-		$result = $repository->get( 'LWSW-test-error-key', 'example.com' );
+		$result = $repository->get();
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 	}
@@ -218,7 +219,7 @@ final class Feature_RepositoryTest extends UplinkTestCase {
 	public function test_it_resolves_catalog_without_license_key(): void {
 		$repository = $this->make_repository();
 
-		$result = $repository->get( '', 'example.com' );
+		$result = $repository->get();
 
 		$this->assertInstanceOf( Feature_Collection::class, $result );
 		$this->assertGreaterThan( 0, $result->count() );
@@ -246,7 +247,7 @@ final class Feature_RepositoryTest extends UplinkTestCase {
 			$this->make_resolver( $catalog, $licensing )
 		);
 
-		$result = $repository->get( 'lwsw-unified-kad-pro-2026', 'example.com' );
+		$result = $repository->get();
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 	}
@@ -259,8 +260,8 @@ final class Feature_RepositoryTest extends UplinkTestCase {
 	public function test_it_returns_cached_collection_within_request(): void {
 		$repository = $this->make_repository( 'lwsw-unified-kad-pro-2026' );
 
-		$first  = $repository->get( 'lwsw-unified-kad-pro-2026', 'example.com' );
-		$second = $repository->get( 'lwsw-unified-kad-pro-2026', 'example.com' );
+		$first  = $repository->get();
+		$second = $repository->get();
 
 		$this->assertSame( $first, $second );
 	}
@@ -273,8 +274,8 @@ final class Feature_RepositoryTest extends UplinkTestCase {
 	public function test_refresh_clears_and_refetches(): void {
 		$repository = $this->make_repository( 'lwsw-unified-kad-pro-2026' );
 
-		$first  = $repository->get( 'lwsw-unified-kad-pro-2026', 'example.com' );
-		$second = $repository->refresh( 'lwsw-unified-kad-pro-2026', 'example.com' );
+		$first  = $repository->get();
+		$second = $repository->refresh();
 
 		$this->assertInstanceOf( Feature_Collection::class, $first );
 		$this->assertInstanceOf( Feature_Collection::class, $second );
@@ -377,7 +378,7 @@ final class Feature_RepositoryTest extends UplinkTestCase {
 	 */
 	public function test_it_maps_feature_data_correctly(): void {
 		$repository = $this->make_repository( 'lwsw-unified-kad-pro-2026' );
-		$result     = $repository->get( 'lwsw-unified-kad-pro-2026', 'example.com' );
+		$result     = $repository->get();
 		$feature    = $result->get( 'kad-blocks-pro' );
 
 		$this->assertSame( 'kad-blocks-pro', $feature->get_slug() );

--- a/tests/wpunit/Features/FunctionsTest.php
+++ b/tests/wpunit/Features/FunctionsTest.php
@@ -58,7 +58,7 @@ final class FunctionsTest extends UplinkTestCase {
 			]
 		);
 
-		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager = new Manager( $repository, $factory );
 
 		$this->container->bind(
 			Manager::class,
@@ -138,7 +138,7 @@ final class FunctionsTest extends UplinkTestCase {
 			]
 		);
 
-		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager = new Manager( $repository, $factory );
 
 		$this->container->bind(
 			Manager::class,
@@ -178,7 +178,7 @@ final class FunctionsTest extends UplinkTestCase {
 
 		$factory = $this->makeEmpty( Strategy_Factory::class );
 
-		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager = new Manager( $repository, $factory );
 
 		$this->container->bind(
 			Manager::class,
@@ -208,7 +208,7 @@ final class FunctionsTest extends UplinkTestCase {
 
 		$factory = $this->makeEmpty( Strategy_Factory::class );
 
-		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager = new Manager( $repository, $factory );
 
 		$this->container->bind(
 			Manager::class,

--- a/tests/wpunit/Features/ManagerTest.php
+++ b/tests/wpunit/Features/ManagerTest.php
@@ -92,7 +92,7 @@ final class ManagerTest extends UplinkTestCase {
 			]
 		);
 
-		$this->manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$this->manager = new Manager( $repository, $factory );
 	}
 
 	/**
@@ -276,7 +276,7 @@ final class ManagerTest extends UplinkTestCase {
 			]
 		);
 
-		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager = new Manager( $repository, $factory );
 
 		$updated_fired = false;
 
@@ -310,7 +310,7 @@ final class ManagerTest extends UplinkTestCase {
 
 		$factory = $this->makeEmpty( Strategy_Factory::class );
 
-		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager = new Manager( $repository, $factory );
 
 		$result = $manager->update( 'test-feature' );
 
@@ -520,7 +520,7 @@ final class ManagerTest extends UplinkTestCase {
 			]
 		);
 
-		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager = new Manager( $repository, $factory );
 
 		$enabled_fired = false;
 
@@ -566,7 +566,7 @@ final class ManagerTest extends UplinkTestCase {
 			]
 		);
 
-		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager = new Manager( $repository, $factory );
 
 		$disabled_fired = false;
 
@@ -600,7 +600,7 @@ final class ManagerTest extends UplinkTestCase {
 
 		$factory = $this->makeEmpty( Strategy_Factory::class );
 
-		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager = new Manager( $repository, $factory );
 
 		$this->assertInstanceOf( WP_Error::class, $manager->get_all() );
 	}
@@ -622,7 +622,7 @@ final class ManagerTest extends UplinkTestCase {
 
 		$factory = $this->makeEmpty( Strategy_Factory::class );
 
-		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager = new Manager( $repository, $factory );
 
 		$result = $manager->is_enabled( 'test-feature' );
 
@@ -679,7 +679,7 @@ final class ManagerTest extends UplinkTestCase {
 			]
 		);
 
-		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager = new Manager( $repository, $factory );
 
 		$this->assertFalse( $manager->is_available( 'locked-feature' ) );
 	}
@@ -713,7 +713,7 @@ final class ManagerTest extends UplinkTestCase {
 
 		$factory = $this->makeEmpty( Strategy_Factory::class );
 
-		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager = new Manager( $repository, $factory );
 
 		$this->assertInstanceOf( WP_Error::class, $manager->is_available( 'test-feature' ) );
 	}
@@ -753,7 +753,7 @@ final class ManagerTest extends UplinkTestCase {
 
 		$factory = $this->makeEmpty( Strategy_Factory::class );
 
-		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager = new Manager( $repository, $factory );
 
 		$this->assertInstanceOf( WP_Error::class, $manager->exists( 'test-feature' ) );
 	}
@@ -775,7 +775,7 @@ final class ManagerTest extends UplinkTestCase {
 
 		$factory = $this->makeEmpty( Strategy_Factory::class );
 
-		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager = new Manager( $repository, $factory );
 
 		$this->assertNull( $manager->get( 'test-feature' ) );
 	}
@@ -820,7 +820,7 @@ final class ManagerTest extends UplinkTestCase {
 			]
 		);
 
-		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager = new Manager( $repository, $factory );
 
 		$result = $manager->disable( 'test-feature' );
 
@@ -845,7 +845,7 @@ final class ManagerTest extends UplinkTestCase {
 
 		$factory = $this->makeEmpty( Strategy_Factory::class );
 
-		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager = new Manager( $repository, $factory );
 
 		$result = $manager->enable( 'test-feature' );
 
@@ -869,7 +869,7 @@ final class ManagerTest extends UplinkTestCase {
 
 		$factory = $this->makeEmpty( Strategy_Factory::class );
 
-		$manager = new Manager( $repository, $factory, 'test-key', 'example.com' );
+		$manager = new Manager( $repository, $factory );
 
 		$result = $manager->disable( 'test-feature' );
 

--- a/tests/wpunit/Features/Update/Plugin_HandlerTest.php
+++ b/tests/wpunit/Features/Update/Plugin_HandlerTest.php
@@ -31,12 +31,11 @@ final class Plugin_HandlerTest extends UplinkTestCase {
 
 		$resolver           = $this->makeEmpty( Resolve_Update_Data::class );
 		$feature_repository = $this->makeEmpty( Feature_Repository::class, [ 'get' => new Feature_Collection() ] );
-		$license_manager    = $this->makeEmpty( License_Manager::class );
 
 		$this->handler = new Plugin_Handler(
 			$resolver,
 			$feature_repository,
-			$license_manager
+			$this->container->get( License_Manager::class )
 		);
 	}
 
@@ -66,10 +65,13 @@ final class Plugin_HandlerTest extends UplinkTestCase {
 		$resolver           = $this->makeEmpty( Resolve_Update_Data::class, [ '__invoke' => $check_updates_return ] );
 		$feature_repository = $this->makeEmpty( Feature_Repository::class, [ 'get' => $features ] );
 
+		$license_manager = $this->container->get( License_Manager::class );
+		$license_manager->store_key( 'LWSW-test-handler-key' );
+
 		return new Plugin_Handler(
 			$resolver,
 			$feature_repository,
-			$this->makeEmpty( License_Manager::class )
+			$license_manager
 		);
 	}
 

--- a/tests/wpunit/Features/Update/Plugin_HandlerTest.php
+++ b/tests/wpunit/Features/Update/Plugin_HandlerTest.php
@@ -7,7 +7,7 @@ use StellarWP\Uplink\Features\Feature_Repository;
 use StellarWP\Uplink\Features\Feature_Collection;
 use StellarWP\Uplink\Features\Types\Plugin;
 use StellarWP\Uplink\Features\Update\Plugin_Handler;
-use StellarWP\Uplink\Site\Data;
+use StellarWP\Uplink\Licensing\License_Manager;
 use StellarWP\Uplink\Tests\UplinkTestCase;
 use stdClass;
 use WP_Error;
@@ -31,13 +31,12 @@ final class Plugin_HandlerTest extends UplinkTestCase {
 
 		$resolver           = $this->makeEmpty( Resolve_Update_Data::class );
 		$feature_repository = $this->makeEmpty( Feature_Repository::class, [ 'get' => new Feature_Collection() ] );
-		$site_data          = $this->makeEmpty( Data::class, [ 'get_domain' => 'example.com' ] );
+		$license_manager    = $this->makeEmpty( License_Manager::class );
 
 		$this->handler = new Plugin_Handler(
 			$resolver,
 			$feature_repository,
-			$site_data,
-			'test-key'
+			$license_manager
 		);
 	}
 
@@ -70,8 +69,7 @@ final class Plugin_HandlerTest extends UplinkTestCase {
 		return new Plugin_Handler(
 			$resolver,
 			$feature_repository,
-			$this->makeEmpty( Data::class, [ 'get_domain' => 'example.com' ] ),
-			'test-key'
+			$this->makeEmpty( License_Manager::class )
 		);
 	}
 
@@ -175,7 +173,7 @@ final class Plugin_HandlerTest extends UplinkTestCase {
 	public function test_it_returns_wp_format_for_feature(): void {
 		$update_data = [
 			'my-plugin' => [
-				'version' => '2.0.0',
+				'version'     => '2.0.0',
 				'package'     => 'https://example.com/my-plugin.zip',
 				'name'        => 'My Plugin',
 				'plugin_file' => 'my-plugin/my-plugin.php',
@@ -245,7 +243,7 @@ final class Plugin_HandlerTest extends UplinkTestCase {
 	public function test_filter_update_check_adds_to_response_when_update_available(): void {
 		$update_data = [
 			'my-plugin' => [
-				'version' => '2.0.0',
+				'version'     => '2.0.0',
 				'package'     => 'https://example.com/my-plugin.zip',
 				'plugin_file' => 'my-plugin/my-plugin.php',
 			],
@@ -270,7 +268,7 @@ final class Plugin_HandlerTest extends UplinkTestCase {
 	public function test_filter_update_check_adds_to_no_update_when_no_newer_version(): void {
 		$update_data = [
 			'my-plugin' => [
-				'version' => '',
+				'version'     => '',
 				'package'     => 'https://example.com/my-plugin.zip',
 				'plugin_file' => 'my-plugin/my-plugin.php',
 			],
@@ -296,7 +294,7 @@ final class Plugin_HandlerTest extends UplinkTestCase {
 	public function test_filter_update_check_preserves_existing_update_from_other_system(): void {
 		$update_data = [
 			'my-plugin' => [
-				'version' => '',
+				'version'     => '',
 				'package'     => 'https://example.com/my-plugin.zip',
 				'plugin_file' => 'my-plugin/my-plugin.php',
 			],

--- a/tests/wpunit/Features/Update/Theme_HandlerTest.php
+++ b/tests/wpunit/Features/Update/Theme_HandlerTest.php
@@ -7,7 +7,7 @@ use StellarWP\Uplink\Features\Feature_Repository;
 use StellarWP\Uplink\Features\Feature_Collection;
 use StellarWP\Uplink\Features\Types\Theme;
 use StellarWP\Uplink\Features\Update\Theme_Handler;
-use StellarWP\Uplink\Site\Data;
+use StellarWP\Uplink\Licensing\License_Manager;
 use StellarWP\Uplink\Tests\UplinkTestCase;
 use stdClass;
 use WP_Error;
@@ -31,13 +31,12 @@ final class Theme_HandlerTest extends UplinkTestCase {
 
 		$resolver           = $this->makeEmpty( Resolve_Update_Data::class );
 		$feature_repository = $this->makeEmpty( Feature_Repository::class, [ 'get' => new Feature_Collection() ] );
-		$site_data          = $this->makeEmpty( Data::class, [ 'get_domain' => 'example.com' ] );
+		$license_manager    = $this->makeEmpty( License_Manager::class );
 
 		$this->handler = new Theme_Handler(
 			$resolver,
 			$feature_repository,
-			$site_data,
-			'test-key'
+			$license_manager
 		);
 	}
 
@@ -70,8 +69,7 @@ final class Theme_HandlerTest extends UplinkTestCase {
 		return new Theme_Handler(
 			$resolver,
 			$feature_repository,
-			$this->makeEmpty( Data::class, [ 'get_domain' => 'example.com' ] ),
-			'test-key'
+			$this->makeEmpty( License_Manager::class )
 		);
 	}
 
@@ -317,10 +315,10 @@ final class Theme_HandlerTest extends UplinkTestCase {
 			'package'     => 'https://legacy.example.com/my-theme.zip',
 		];
 
-		$transient                        = new stdClass();
-		$transient->response              = [];
-		$transient->response['my-theme']  = $existing_update;
-		$transient->no_update             = [];
+		$transient                       = new stdClass();
+		$transient->response             = [];
+		$transient->response['my-theme'] = $existing_update;
+		$transient->no_update            = [];
 
 		$result = $handler->filter_update_check( $transient );
 

--- a/tests/wpunit/Features/Update/Theme_HandlerTest.php
+++ b/tests/wpunit/Features/Update/Theme_HandlerTest.php
@@ -31,12 +31,11 @@ final class Theme_HandlerTest extends UplinkTestCase {
 
 		$resolver           = $this->makeEmpty( Resolve_Update_Data::class );
 		$feature_repository = $this->makeEmpty( Feature_Repository::class, [ 'get' => new Feature_Collection() ] );
-		$license_manager    = $this->makeEmpty( License_Manager::class );
 
 		$this->handler = new Theme_Handler(
 			$resolver,
 			$feature_repository,
-			$license_manager
+			$this->container->get( License_Manager::class )
 		);
 	}
 
@@ -66,10 +65,13 @@ final class Theme_HandlerTest extends UplinkTestCase {
 		$resolver           = $this->makeEmpty( Resolve_Update_Data::class, [ '__invoke' => $check_updates_return ] );
 		$feature_repository = $this->makeEmpty( Feature_Repository::class, [ 'get' => $features ] );
 
+		$license_manager = $this->container->get( License_Manager::class );
+		$license_manager->store_key( 'LWSW-test-handler-key' );
+
 		return new Theme_Handler(
 			$resolver,
 			$feature_repository,
-			$this->makeEmpty( License_Manager::class )
+			$license_manager
 		);
 	}
 


### PR DESCRIPTION
🎫 [SCON-350]

I tested the basic features operations and it works, I asked @estevao90 to test as well if I'm not aware of something.
                                                  
### Summary

  - Remove $key and $domain as constructor properties from Manager and pass-through parameters from Feature_Repository — they were never used at those layers
  - Inject Data into Resolve_Feature_Collection so it resolves the domain at call time instead of receiving it as a parameter
  - Replace the stored $key string in Plugin_Handler and Theme_Handler with an injected License_Manager that reads the key on-demand
  - Drop $key/$domain from Resolve_Update_Data::__invoke(), leaving only $type


[SCON-350]: https://stellarwp.atlassian.net/browse/SCON-350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ