### PR TITLE
Add version data to the features API | SCON-319

### DIFF
--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -45,6 +45,9 @@ Features are the individual capabilities, plugins, themes, and flags that make u
 | `plugin_file`       | string\|null   | Plugin file path relative to the plugins directory (e.g., `kadence-blocks-pro/kadence-blocks-pro.php`). Null for themes and flags. |
 | `is_dot_org`        | bool           | Whether the feature is available on WordPress.org                                                                                  |
 | `download_url`      | string\|null   | Download URL for features not on WordPress.org                                                                                     |
+| `version`           | string\|null   | Latest available version from the Commerce Portal. Null for flags.                                                                 |
+| `released_at`       | string\|null   | Release date of the latest version (ISO 8601). Null for flags.                                                                     |
+| `changelog`         | string\|null   | Changelog HTML for the latest version, consistent with `plugins_api()` sections. Null for flags.                                   |
 | `name`              | string         | Display name                                                                                                                       |
 | `description`       | string         | Short description of what the feature does                                                                                         |
 | `category`          | string         | Grouping category (e.g., `blocks`, `theme`, `security`, `woocommerce`)                                                             |
@@ -171,12 +174,13 @@ The catalog uses delivery-oriented type names (`plugin`, `theme`, `flag`). The F
 
 The catalog describes what exists. It does not know:
 
-| Question                                     | Answer comes from                                   |
-| -------------------------------------------- | --------------------------------------------------- |
-| What tier is the customer on?                | [Licensing](licensing.md)                           |
-| Is this key valid?                           | [Licensing](licensing.md)                           |
-| Is a feature available to this customer?     | [Features](features.md) (joins catalog + licensing) |
-| Is a feature currently enabled on this site? | [Features](features.md) (checks local state)        |
+| Question                                     | Answer comes from                                         |
+| -------------------------------------------- | --------------------------------------------------------- |
+| What tier is the customer on?                | [Licensing](licensing.md)                                 |
+| Is this key valid?                           | [Licensing](licensing.md)                                 |
+| Is a feature available to this customer?     | [Features](features.md) (joins catalog + licensing)       |
+| Is a feature currently enabled on this site? | [Features](features.md) (checks local state)              |
+| What version is installed on this site?      | [Features](features.md) (reads from disk via Installable) |
 
 The catalog is the menu. Licensing is the receipt. Feature resolution is the waiter who checks both before serving.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -31,7 +31,7 @@ wp uplink feature list [--group=<group>] [--tier=<tier>] [--available=<bool>] [-
 
 - All types: `slug`, `name`, `description`, `type`, `group`, `tier`, `is_available`, `is_enabled`, `documentation_url`
 - Plugin and Theme: `installed_version`, `released_at`, `authors`, `is_dot_org`
-- Plugin only: `plugin_file`, `plugin_slug`
+- Plugin only: `plugin_file`
 
 **Examples:**
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -16,22 +16,22 @@ wp uplink feature list [--group=<group>] [--tier=<tier>] [--available=<bool>] [-
 
 **Options:**
 
-| Option               | Description                                                       |
-|----------------------|-------------------------------------------------------------------|
-| `--group=<group>`    | Filter by product group (e.g. `kadence`)                          |
-| `--tier=<tier>`      | Filter by tier (e.g. `Tier 1`)                                    |
-| `--available=<bool>` | Filter by availability (`true` or `false`)                        |
-| `--type=<type>`      | Filter by type (`flag`, `plugin`, `theme`)                        |
-| `--fields=<fields>`  | Comma-separated field list                                        |
-| `--format=<format>`  | Output format: `table` (default), `json`, `csv`, `yaml`, `count`  |
+| Option               | Description                                                      |
+| -------------------- | ---------------------------------------------------------------- |
+| `--group=<group>`    | Filter by product group (e.g. `kadence`)                         |
+| `--tier=<tier>`      | Filter by tier (e.g. `Tier 1`)                                   |
+| `--available=<bool>` | Filter by availability (`true` or `false`)                       |
+| `--type=<type>`      | Filter by type (`flag`, `plugin`, `theme`)                       |
+| `--fields=<fields>`  | Comma-separated field list                                       |
+| `--format=<format>`  | Output format: `table` (default), `json`, `csv`, `yaml`, `count` |
 
 **Default fields:** `slug, name, type, group, is_available, is_enabled`
 
 **Available fields:**
 
 - All types: `slug`, `name`, `description`, `type`, `group`, `tier`, `is_available`, `is_enabled`, `documentation_url`
-- Plugin only: `plugin_file`, `plugin_slug`, `authors`, `is_dot_org`
-- Theme only: `authors`, `is_dot_org`
+- Plugin and Theme: `installed_version`, `released_at`, `authors`, `is_dot_org`
+- Plugin only: `plugin_file`, `plugin_slug`
 
 **Examples:**
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -21,7 +21,7 @@ Each feature type has a strategy that defines how enable, disable, and active-st
 
 ### Plugin
 
-An installable WordPress plugin. The catalog provides `plugin_file`, `plugin_slug`, `download_url`/`is_dot_org`.
+An installable WordPress plugin. The catalog provides `plugin_file`, `download_url`/`is_dot_org`.
 
 | Aspect              | Behavior                                                                               |
 | ------------------- | -------------------------------------------------------------------------------------- |

--- a/docs/features.md
+++ b/docs/features.md
@@ -61,6 +61,8 @@ Plugin and Theme features share a global transient lock (`stellarwp_uplink_insta
 
 `Resolve_Feature_Collection` joins catalog and licensing data to produce a `Feature_Collection`. Availability is determined by comparing integer tier ranks, not slug strings. The catalog defines ranks (e.g., `kadence-basic` = 1, `kadence-pro` = 2). A feature is available when the customer's tier rank >= the feature's minimum tier rank.
 
+For `Installable` features (Plugin, Theme), the resolver also reads `installed_version` from disk and stores it on the resolved Feature. This is the version currently on the site, distinct from the catalog's `version` which is the latest available. Flag features always have `installed_version: null`.
+
 Edge cases:
 
 - No licensing entry for a product: tier rank = `0`, all features unavailable
@@ -166,12 +168,14 @@ Each Feature object includes `is_enabled`, stamped with live state from its stra
 
 ## Data Sources
 
-| Data                                                    | Source                                                                                    |
-| ------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| Feature exists, minimum tier, delivery type, tier ranks | Catalog                                                                                   |
-| Customer's tier, key validity                           | Licensing                                                                                 |
-| **Whether available** (`is_available`)                  | **Computed: catalog min rank vs. licensing tier rank**                                    |
-| **Whether enabled** (`is_enabled`)                      | Live WordPress state (plugin activation / theme disk / flag option), stamped by Manager   |
+| Data                                                    | Source                                                                                        |
+| ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Feature exists, minimum tier, delivery type, tier ranks | Catalog                                                                                       |
+| Latest version, release date, changelog                 | Catalog (`version`, `released_at`, `changelog`)                                               |
+| Customer's tier, key validity                           | Licensing                                                                                     |
+| **Whether available** (`is_available`)                  | **Computed: catalog min rank vs. licensing tier rank**                                        |
+| **Whether enabled** (`is_enabled`)                      | Live WordPress state (plugin activation / theme disk / flag option), stamped by Manager       |
+| **Installed version** (`installed_version`)             | Read from disk during resolution via `Installable`. Null for flags and uninstalled extensions |
 
 ## What Features Does Not Do
 

--- a/src/Uplink/API/REST/V1/Catalog_Controller.php
+++ b/src/Uplink/API/REST/V1/Catalog_Controller.php
@@ -184,6 +184,12 @@ final class Catalog_Controller extends WP_REST_Controller {
 							'version'           => [
 								'type' => [ 'string', 'null' ],
 							],
+							'released_at'       => [
+								'type' => [ 'string', 'null' ],
+							],
+							'changelog'         => [
+								'type' => [ 'string', 'null' ],
+							],
 							'name'              => [
 								'type' => 'string',
 							],

--- a/src/Uplink/API/REST/V1/Feature_Controller.php
+++ b/src/Uplink/API/REST/V1/Feature_Controller.php
@@ -366,7 +366,13 @@ class Feature_Controller extends WP_REST_Controller {
 		];
 
 		$installable_properties = [
-			'authors'    => [
+			'released_at'       => [
+				'description' => __( 'Release date of the latest version (ISO 8601), or null if not applicable.', '%TEXTDOMAIN%' ),
+				'type'        => [ 'string', 'null' ],
+				'readonly'    => true,
+				'context'     => [ 'view' ],
+			],
+			'authors'           => [
 				'description' => __( 'Expected authors for ownership verification.', '%TEXTDOMAIN%' ),
 				'type'        => 'array',
 				'items'       => [
@@ -375,9 +381,15 @@ class Feature_Controller extends WP_REST_Controller {
 				'readonly'    => true,
 				'context'     => [ 'view' ],
 			],
-			'is_dot_org' => [
+			'is_dot_org'        => [
 				'description' => __( 'Whether the feature is available on WordPress.org.', '%TEXTDOMAIN%' ),
 				'type'        => 'boolean',
+				'readonly'    => true,
+				'context'     => [ 'view' ],
+			],
+			'installed_version' => [
+				'description' => __( 'The currently installed version, or null if not installed.', '%TEXTDOMAIN%' ),
+				'type'        => [ 'string', 'null' ],
 				'readonly'    => true,
 				'context'     => [ 'view' ],
 			],

--- a/src/Uplink/CLI/Commands/Feature.php
+++ b/src/Uplink/CLI/Commands/Feature.php
@@ -117,9 +117,11 @@ class Feature extends WP_CLI_Command {
 	 * * is_available
 	 * * is_enabled
 	 * * documentation_url
-	 * * plugin_file
-	 * * authors
-	 * * is_dot_org
+	 * * installed_version (plugin, theme)
+	 * * released_at (plugin, theme)
+	 * * plugin_file (plugin)
+	 * * authors (plugin, theme)
+	 * * is_dot_org (plugin, theme)
 	 *
 	 * ## EXAMPLES
 	 *

--- a/src/Uplink/Catalog/Results/Catalog_Feature.php
+++ b/src/Uplink/Catalog/Results/Catalog_Feature.php
@@ -19,6 +19,8 @@ use StellarWP\Uplink\Utils\Cast;
  *     is_dot_org: bool,
  *     download_url: ?string,
  *     version: ?string,
+ *     released_at: ?string,
+ *     changelog: ?string,
  *     name: string,
  *     description: string,
  *     category: string,
@@ -43,6 +45,8 @@ final class Catalog_Feature {
 		'is_dot_org'        => false,
 		'download_url'      => null,
 		'version'           => null,
+		'released_at'       => null,
+		'changelog'         => null,
 		'name'              => '',
 		'description'       => '',
 		'category'          => '',
@@ -84,6 +88,8 @@ final class Catalog_Feature {
 				'is_dot_org'        => Cast::to_bool( $data['is_dot_org'] ?? false ),
 				'download_url'      => isset( $data['download_url'] ) ? Cast::to_string( $data['download_url'] ) : null,
 				'version'           => isset( $data['version'] ) ? Cast::to_string( $data['version'] ) : null,
+				'released_at'       => isset( $data['released_at'] ) ? Cast::to_string( $data['released_at'] ) : null,
+				'changelog'         => isset( $data['changelog'] ) ? Cast::to_string( $data['changelog'] ) : null,
 				'name'              => Cast::to_string( $data['name'] ?? '' ),
 				'description'       => Cast::to_string( $data['description'] ?? '' ),
 				'category'          => Cast::to_string( $data['category'] ?? '' ),
@@ -183,6 +189,28 @@ final class Catalog_Feature {
 	 */
 	public function get_version(): ?string {
 		return $this->attributes['version'];
+	}
+
+	/**
+	 * Gets the release date (ISO 8601), or null if not provided.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return string|null
+	 */
+	public function get_released_at(): ?string {
+		return $this->attributes['released_at'];
+	}
+
+	/**
+	 * Gets the changelog as an HTML string, or null if not provided.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return string|null
+	 */
+	public function get_changelog(): ?string {
+		return $this->attributes['changelog'];
 	}
 
 	/**

--- a/src/Uplink/Features/Contracts/Installable.php
+++ b/src/Uplink/Features/Contracts/Installable.php
@@ -35,6 +35,24 @@ interface Installable {
 	public function is_dot_org(): bool;
 
 	/**
+	 * Whether this extension is currently installed on disk.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return bool
+	 */
+	public function is_installed(): bool;
+
+	/**
+	 * Gets the currently installed version of this extension, or null if not installed.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return string|null
+	 */
+	public function get_installed_version(): ?string;
+
+	/**
 	 * Builds the complete update data array for this feature type.
 	 *
 	 * Each type includes common fields plus type-specific fields (e.g. plugin_file,

--- a/src/Uplink/Features/Resolve_Feature_Collection.php
+++ b/src/Uplink/Features/Resolve_Feature_Collection.php
@@ -5,6 +5,7 @@ namespace StellarWP\Uplink\Features;
 use StellarWP\Uplink\Catalog\Catalog_Repository;
 use StellarWP\Uplink\Catalog\Results\Catalog_Feature;
 use StellarWP\Uplink\Catalog\Results\Product_Catalog;
+use StellarWP\Uplink\Features\Contracts\Installable;
 use StellarWP\Uplink\Features\Types\Feature;
 use StellarWP\Uplink\Licensing\License_Manager;
 use StellarWP\Uplink\Licensing\Product_Collection;
@@ -214,11 +215,19 @@ class Resolve_Feature_Collection {
 			'type'              => $catalog_type,
 			'is_available'      => $is_available,
 			'documentation_url' => $catalog_feature->get_documentation_url(),
+			'released_at'       => $catalog_feature->get_released_at(),
 			'plugin_file'       => $catalog_feature->get_plugin_file() ?? '',
 			'is_dot_org'        => $catalog_feature->is_dot_org(),
 			'authors'           => $catalog_feature->get_authors() ?? [],
 		];
 
-		return $class::from_array( $data );
+		$feature = $class::from_array( $data );
+
+		if ( $feature instanceof Installable ) {
+			$data['installed_version'] = $feature->get_installed_version();
+			$feature                   = $class::from_array( $data );
+		}
+
+		return $feature;
 	}
 }

--- a/src/Uplink/Features/Types/Plugin.php
+++ b/src/Uplink/Features/Types/Plugin.php
@@ -45,9 +45,11 @@ final class Plugin extends Feature implements Installable {
 			array_merge(
 				self::base_attributes( $data ),
 				[
-					'plugin_file' => $data['plugin_file'] ?? '',
-					'authors'     => $data['authors'] ?? [],
-					'is_dot_org'  => $data['is_dot_org'] ?? false,
+					'plugin_file'       => $data['plugin_file'] ?? '',
+					'authors'           => $data['authors'] ?? [],
+					'is_dot_org'        => $data['is_dot_org'] ?? false,
+					'released_at'       => $data['released_at'] ?? null,
+					'installed_version' => $data['installed_version'] ?? null,
 				]
 			)
 		);

--- a/src/Uplink/Features/Types/Theme.php
+++ b/src/Uplink/Features/Types/Theme.php
@@ -45,8 +45,10 @@ final class Theme extends Feature implements Installable {
 			array_merge(
 				self::base_attributes( $data ),
 				[
-					'authors'    => $data['authors'] ?? [],
-					'is_dot_org' => $data['is_dot_org'] ?? false,
+					'authors'           => $data['authors'] ?? [],
+					'is_dot_org'        => $data['is_dot_org'] ?? false,
+					'released_at'       => $data['released_at'] ?? null,
+					'installed_version' => $data['installed_version'] ?? null,
 				]
 			)
 		);

--- a/tests/_data/catalog/default.json
+++ b/tests/_data/catalog/default.json
@@ -30,8 +30,13 @@
         "name": "Kadence Theme",
         "description": "A lightweight, performant WordPress theme for site building.",
         "category": "theme",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "3.3.8",
+        "released_at": "2025-11-15",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "kad-blocks-pro",
@@ -43,8 +48,13 @@
         "name": "Blocks Pro",
         "description": "Premium Gutenberg blocks for advanced page building.",
         "category": "blocks",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "2.7.4",
+        "released_at": "2025-11-20",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "kad-theme-kit-pro",
@@ -56,8 +66,13 @@
         "name": "Theme Kit Pro",
         "description": "Advanced theme customization options and header/footer builder.",
         "category": "theme",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "1.4.2",
+        "released_at": "2025-10-30",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "kad-shop-kit",
@@ -69,8 +84,13 @@
         "name": "Shop Kit",
         "description": "WooCommerce enhancements \u2014 product galleries, swatches, quick view, and more.",
         "category": "woocommerce",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "1.8.6",
+        "released_at": "2025-11-10",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "kad-creative-kit",
@@ -82,8 +102,13 @@
         "name": "Creative Kit",
         "description": "Advanced design tools including animations and effects.",
         "category": "design",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "1.2.1",
+        "released_at": "2025-09-25",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "kad-insights",
@@ -95,8 +120,13 @@
         "name": "Insights (A/B Testing)",
         "description": "Run A/B tests on your content to optimize conversions.",
         "category": "analytics",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "1.1.0",
+        "released_at": "2025-10-05",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "kad-pattern-hub",
@@ -106,7 +136,9 @@
         "name": "Pattern Hub",
         "description": "Access to premium design patterns and starter templates.",
         "category": "design",
-        "authors": ["KadenceWP"],
+        "authors": [
+          "KadenceWP"
+        ],
         "documentation_url": "https://www.kadencewp.com/help-center/"
       },
       {
@@ -119,8 +151,13 @@
         "name": "Conversions",
         "description": "Popups, slide-ins, and banners for conversion optimization.",
         "category": "marketing",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "1.5.3",
+        "released_at": "2025-11-01",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "kad-galleries",
@@ -132,8 +169,13 @@
         "name": "Galleries",
         "description": "Advanced image and video gallery blocks.",
         "category": "blocks",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "1.3.2",
+        "released_at": "2025-10-12",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "kad-captcha",
@@ -143,7 +185,9 @@
         "name": "Captcha",
         "description": "Spam protection for forms with reCAPTCHA and hCaptcha.",
         "category": "forms",
-        "authors": ["KadenceWP"],
+        "authors": [
+          "KadenceWP"
+        ],
         "documentation_url": "https://www.kadencewp.com/help-center/"
       },
       {
@@ -154,7 +198,9 @@
         "name": "Simple Share",
         "description": "Social sharing buttons for posts and pages.",
         "category": "social",
-        "authors": ["KadenceWP"],
+        "authors": [
+          "KadenceWP"
+        ],
         "documentation_url": "https://www.kadencewp.com/help-center/"
       },
       {
@@ -165,7 +211,9 @@
         "name": "Custom Fonts",
         "description": "Upload and use custom fonts across your site.",
         "category": "design",
-        "authors": ["KadenceWP"],
+        "authors": [
+          "KadenceWP"
+        ],
         "documentation_url": "https://www.kadencewp.com/help-center/"
       },
       {
@@ -176,7 +224,9 @@
         "name": "Reading Time",
         "description": "Display estimated reading time on posts.",
         "category": "content",
-        "authors": ["KadenceWP"],
+        "authors": [
+          "KadenceWP"
+        ],
         "documentation_url": "https://www.kadencewp.com/help-center/"
       },
       {
@@ -189,8 +239,13 @@
         "name": "Solid Security Pro",
         "description": "Comprehensive WordPress security with malware scanning, 2FA, and brute force protection.",
         "category": "security",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "9.4.0",
+        "released_at": "2025-11-18",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "solid-backups",
@@ -202,8 +257,13 @@
         "name": "Solid Backups",
         "description": "Automated WordPress backups with cloud storage and one-click restore.",
         "category": "security",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "9.1.5",
+        "released_at": "2025-10-28",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "solid-central",
@@ -215,8 +275,13 @@
         "name": "Solid Central",
         "description": "Manage multiple WordPress sites from one dashboard.",
         "category": "management",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "2.1.3",
+        "released_at": "2025-09-14",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "solid-performance",
@@ -228,8 +293,13 @@
         "name": "Solid Performance",
         "description": "Caching and performance optimization for WordPress.",
         "category": "performance",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "1.3.7",
+        "released_at": "2025-11-05",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "solid-mail",
@@ -241,8 +311,13 @@
         "name": "Solid Mail",
         "description": "Reliable email delivery with SMTP and email logging.",
         "category": "email",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "1.0.4",
+        "released_at": "2025-08-22",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "iconic-flux",
@@ -254,8 +329,13 @@
         "name": "Flux Checkout",
         "description": "Streamlined, fast WooCommerce checkout experience.",
         "category": "woocommerce",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "1.7.2",
+        "released_at": "2025-11-10",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "iconic-delivery-slots",
@@ -267,8 +347,13 @@
         "name": "WooCommerce Delivery Slots",
         "description": "Let customers choose delivery dates and time slots.",
         "category": "woocommerce",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "1.9.5",
+        "released_at": "2025-10-20",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "iconic-woothumbs",
@@ -280,8 +365,13 @@
         "name": "WooThumbs",
         "description": "Advanced product image gallery with zoom and video support.",
         "category": "woocommerce",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "5.6.1",
+        "released_at": "2025-11-02",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "iconic-swatches",
@@ -293,8 +383,13 @@
         "name": "Attribute Swatches",
         "description": "Visual color and image swatches for product variations.",
         "category": "woocommerce",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "3.4.0",
+        "released_at": "2025-10-08",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "iconic-single-variations",
@@ -306,8 +401,13 @@
         "name": "Show Single Variations",
         "description": "Display product variations as individual products in shop listings.",
         "category": "woocommerce",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "1.5.3",
+        "released_at": "2025-09-30",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "iconic-sales-booster",
@@ -319,8 +419,13 @@
         "name": "Iconic Sales Booster",
         "description": "Cross-sells, upsells, and order bumps to increase average order value.",
         "category": "woocommerce",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "1.3.1",
+        "released_at": "2025-11-15",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "iconic-image-swap",
@@ -332,8 +437,13 @@
         "name": "Image Swap for WooCommerce",
         "description": "Swap product images on hover in shop listings.",
         "category": "woocommerce",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "2.2.0",
+        "released_at": "2025-10-25",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "iconic-linked-variations",
@@ -345,8 +455,13 @@
         "name": "Linked Variations",
         "description": "Link product variations across different products.",
         "category": "woocommerce",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "1.6.4",
+        "released_at": "2025-11-07",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "iconic-configurator",
@@ -358,8 +473,13 @@
         "name": "Product Configurator",
         "description": "Visual step-by-step product builder for complex products.",
         "category": "woocommerce",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "1.1.2",
+        "released_at": "2025-09-18",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "iconic-quickview",
@@ -371,8 +491,13 @@
         "name": "Quickview",
         "description": "Quick product preview popup without leaving the shop page.",
         "category": "woocommerce",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "1.8.0",
+        "released_at": "2025-11-12",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "iconic-wishlist",
@@ -384,8 +509,13 @@
         "name": "Wishlist for WooCommerce",
         "description": "Let customers save products to wishlists.",
         "category": "woocommerce",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "3.1.5",
+        "released_at": "2025-10-15",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "iconic-account-pages",
@@ -397,8 +527,13 @@
         "name": "Account Pages",
         "description": "Customize WooCommerce My Account pages.",
         "category": "woocommerce",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "2.4.1",
+        "released_at": "2025-11-03",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "iconic-custom-fields",
@@ -410,8 +545,13 @@
         "name": "Custom Fields for Variations",
         "description": "Add custom data fields to product variations.",
         "category": "woocommerce",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "1.2.3",
+        "released_at": "2025-09-22",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "iconic-bundled",
@@ -423,8 +563,13 @@
         "name": "Bundled Products",
         "description": "Create product bundles and kits with flexible pricing.",
         "category": "woocommerce",
-        "authors": ["KadenceWP"],
-        "documentation_url": "https://www.kadencewp.com/help-center/"
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "1.4.0",
+        "released_at": "2025-10-18",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       }
     ]
   },
@@ -464,7 +609,10 @@
         "authors": [
           "LearnDash"
         ],
-        "documentation_url": "https://www.learndash.com/support/"
+        "documentation_url": "https://www.learndash.com/support/",
+        "version": "4.17.0",
+        "released_at": "2025-11-19",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "ld-instructor-role",
@@ -474,7 +622,9 @@
         "name": "Instructor Role",
         "description": "Allow multiple instructors to create and manage their own courses.",
         "category": "core",
-        "authors": ["LearnDash"],
+        "authors": [
+          "LearnDash"
+        ],
         "documentation_url": "https://www.learndash.com/support/"
       },
       {
@@ -485,7 +635,9 @@
         "name": "Ratings, Reviews & Feedback",
         "description": "Enable students to rate and review courses.",
         "category": "core",
-        "authors": ["LearnDash"],
+        "authors": [
+          "LearnDash"
+        ],
         "documentation_url": "https://www.learndash.com/support/"
       },
       {
@@ -498,8 +650,13 @@
         "name": "ProPanel",
         "description": "Real-time reporting dashboard for course activity and student progress.",
         "category": "reporting",
-        "authors": ["LearnDash"],
-        "documentation_url": "https://www.learndash.com/support/"
+        "authors": [
+          "LearnDash"
+        ],
+        "documentation_url": "https://www.learndash.com/support/",
+        "version": "3.2.2",
+        "released_at": "2025-11-06",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "ld-notes",
@@ -509,7 +666,9 @@
         "name": "Notes",
         "description": "Allow students to take and save notes within lessons.",
         "category": "core",
-        "authors": ["LearnDash"],
+        "authors": [
+          "LearnDash"
+        ],
         "documentation_url": "https://www.learndash.com/support/"
       },
       {
@@ -520,7 +679,9 @@
         "name": "Gradebook",
         "description": "Comprehensive gradebook for tracking student performance across courses.",
         "category": "reporting",
-        "authors": ["LearnDash"],
+        "authors": [
+          "LearnDash"
+        ],
         "documentation_url": "https://www.learndash.com/support/"
       },
       {
@@ -531,7 +692,9 @@
         "name": "Groups Management",
         "description": "Organize learners into groups with group leaders and bulk enrollment.",
         "category": "management",
-        "authors": ["LearnDash"],
+        "authors": [
+          "LearnDash"
+        ],
         "documentation_url": "https://www.learndash.com/support/"
       },
       {
@@ -544,8 +707,13 @@
         "name": "MemberDash",
         "description": "Membership and content restriction functionality.",
         "category": "membership",
-        "authors": ["LearnDash"],
-        "documentation_url": "https://www.learndash.com/support/"
+        "authors": [
+          "LearnDash"
+        ],
+        "documentation_url": "https://www.learndash.com/support/",
+        "version": "2.1.0",
+        "released_at": "2025-11-08",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       }
     ]
   },
@@ -584,7 +752,10 @@
         "authors": [
           "GiveWP"
         ],
-        "documentation_url": "https://givewp.com/documentation/"
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "3.19.0",
+        "released_at": "2025-11-17",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-recurring",
@@ -596,8 +767,13 @@
         "name": "Recurring Donations",
         "description": "Accept recurring donations on a schedule.",
         "category": "core",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "2.10.1",
+        "released_at": "2025-11-04",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-fee-recovery",
@@ -609,8 +785,13 @@
         "name": "Fee Recovery",
         "description": "Optionally pass processing fees to donors.",
         "category": "core",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "2.4.2",
+        "released_at": "2025-10-16",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-form-field-manager",
@@ -622,8 +803,13 @@
         "name": "Form Field Manager",
         "description": "Add custom fields to donation forms.",
         "category": "core",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "3.2.0",
+        "released_at": "2025-09-27",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-annual-receipts",
@@ -635,8 +821,13 @@
         "name": "Annual Receipts",
         "description": "Generate annual tax-deductible receipts for donors.",
         "category": "core",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "1.4.0",
+        "released_at": "2025-08-15",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-funds",
@@ -648,8 +839,13 @@
         "name": "Funds & Designations",
         "description": "Allow donors to designate gifts to specific funds.",
         "category": "core",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "1.2.1",
+        "released_at": "2025-10-09",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-tributes",
@@ -661,8 +857,13 @@
         "name": "Tributes",
         "description": "Allow donors to make tribute donations in honor of someone.",
         "category": "core",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "1.5.3",
+        "released_at": "2025-11-01",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-pdf-receipts",
@@ -674,8 +875,13 @@
         "name": "PDF Receipts",
         "description": "Generate downloadable PDF donation receipts.",
         "category": "core",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "2.4.1",
+        "released_at": "2025-10-23",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-manual-donations",
@@ -687,8 +893,13 @@
         "name": "Manual Donations",
         "description": "Record offline or manual donations in the system.",
         "category": "core",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "2.7.0",
+        "released_at": "2025-09-12",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-peer-to-peer",
@@ -700,8 +911,13 @@
         "name": "Peer-to-Peer",
         "description": "Enable supporters to create their own fundraising pages.",
         "category": "campaigns",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "1.6.2",
+        "released_at": "2025-11-10",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-text-to-give",
@@ -713,8 +929,13 @@
         "name": "Text to Give",
         "description": "Accept donations via SMS text messages.",
         "category": "campaigns",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "1.3.4",
+        "released_at": "2025-09-20",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-stripe",
@@ -726,8 +947,13 @@
         "name": "Stripe Gateway",
         "description": "Accept donations through Stripe.",
         "category": "gateway",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "3.5.0",
+        "released_at": "2025-11-14",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-authorize",
@@ -739,8 +965,13 @@
         "name": "Authorize.net",
         "description": "Accept donations through Authorize.net.",
         "category": "gateway",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "2.1.0",
+        "released_at": "2025-08-08",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-square",
@@ -752,8 +983,13 @@
         "name": "Square",
         "description": "Accept donations through Square.",
         "category": "gateway",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "2.3.1",
+        "released_at": "2025-10-30",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-paypal",
@@ -765,8 +1001,13 @@
         "name": "PayPal Commerce",
         "description": "Accept donations through PayPal Commerce.",
         "category": "gateway",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "2.0.3",
+        "released_at": "2025-09-02",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-mollie",
@@ -778,8 +1019,13 @@
         "name": "Mollie",
         "description": "Accept donations through Mollie.",
         "category": "gateway",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "2.4.0",
+        "released_at": "2025-10-06",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-razorpay",
@@ -791,8 +1037,13 @@
         "name": "RazorPay",
         "description": "Accept donations through RazorPay.",
         "category": "gateway",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "1.5.2",
+        "released_at": "2025-08-20",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-gocardless",
@@ -804,8 +1055,13 @@
         "name": "GoCardless",
         "description": "Accept donations through GoCardless direct debit.",
         "category": "gateway",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "2.1.1",
+        "released_at": "2025-09-08",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-braintree",
@@ -817,8 +1073,13 @@
         "name": "Braintree",
         "description": "Accept donations through Braintree.",
         "category": "gateway",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "1.4.3",
+        "released_at": "2025-10-28",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-currency-switcher",
@@ -830,8 +1091,13 @@
         "name": "Currency Switcher",
         "description": "Allow donors to give in their local currency.",
         "category": "integration",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "2.3.0",
+        "released_at": "2025-11-11",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-salesforce",
@@ -843,8 +1109,13 @@
         "name": "Salesforce",
         "description": "Sync donation data with Salesforce CRM.",
         "category": "integration",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "1.1.2",
+        "released_at": "2025-08-28",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-gift-aid",
@@ -856,8 +1127,13 @@
         "name": "Gift Aid",
         "description": "UK Gift Aid declarations for tax-efficient giving.",
         "category": "integration",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "1.3.1",
+        "released_at": "2025-10-04",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-webhooks",
@@ -869,8 +1145,13 @@
         "name": "Webhooks",
         "description": "Send donation events to external services via webhooks.",
         "category": "integration",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "1.2.0",
+        "released_at": "2025-09-16",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-mailchimp",
@@ -882,8 +1163,13 @@
         "name": "MailChimp",
         "description": "Sync donors with MailChimp email lists.",
         "category": "integration",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "1.7.2",
+        "released_at": "2025-11-13",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-activecampaign",
@@ -895,8 +1181,13 @@
         "name": "ActiveCampaign",
         "description": "Sync donors with ActiveCampaign.",
         "category": "integration",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "2.2.1",
+        "released_at": "2025-10-11",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-zapier",
@@ -908,8 +1199,13 @@
         "name": "Zapier",
         "description": "Connect donations to 5000+ apps via Zapier.",
         "category": "integration",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "1.4.0",
+        "released_at": "2025-09-24",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-constant-contact",
@@ -921,8 +1217,13 @@
         "name": "Constant Contact",
         "description": "Sync donors with Constant Contact.",
         "category": "integration",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "1.1.3",
+        "released_at": "2025-08-12",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-convertkit",
@@ -934,8 +1235,13 @@
         "name": "ConvertKit",
         "description": "Sync donors with ConvertKit.",
         "category": "integration",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "1.2.1",
+        "released_at": "2025-10-19",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-ga-tracking",
@@ -947,8 +1253,13 @@
         "name": "Google Analytics Tracking",
         "description": "Track donation events in Google Analytics.",
         "category": "integration",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "1.8.0",
+        "released_at": "2025-11-09",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-woo-upsells",
@@ -960,8 +1271,13 @@
         "name": "WooCommerce Upsells",
         "description": "Offer products as upsells during donations.",
         "category": "integration",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "2.0.1",
+        "released_at": "2025-09-29",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "give-double-the-donations",
@@ -973,8 +1289,13 @@
         "name": "Double the Donations",
         "description": "Corporate gift matching integration.",
         "category": "integration",
-        "authors": ["GiveWP"],
-        "documentation_url": "https://givewp.com/documentation/"
+        "authors": [
+          "GiveWP"
+        ],
+        "documentation_url": "https://givewp.com/documentation/",
+        "version": "2.3.4",
+        "released_at": "2025-11-16",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       }
     ]
   },
@@ -1013,7 +1334,10 @@
         "authors": [
           "StellarWP"
         ],
-        "documentation_url": "https://theeventscalendar.com/knowledgebase/"
+        "documentation_url": "https://theeventscalendar.com/knowledgebase/",
+        "version": "6.9.0",
+        "released_at": "2025-11-21",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "tec-calendar",
@@ -1023,7 +1347,9 @@
         "name": "Calendar",
         "description": "Full-featured event calendar with multiple views.",
         "category": "core",
-        "authors": ["StellarWP"],
+        "authors": [
+          "StellarWP"
+        ],
         "documentation_url": "https://theeventscalendar.com/knowledgebase/"
       },
       {
@@ -1036,8 +1362,13 @@
         "name": "Tickets & RSVP",
         "description": "Sell tickets and collect RSVPs for events.",
         "category": "core",
-        "authors": ["StellarWP"],
-        "documentation_url": "https://theeventscalendar.com/knowledgebase/"
+        "authors": [
+          "StellarWP"
+        ],
+        "documentation_url": "https://theeventscalendar.com/knowledgebase/",
+        "version": "5.18.0",
+        "released_at": "2025-10-25",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "tec-event-aggregator",
@@ -1049,8 +1380,13 @@
         "name": "Event Aggregator",
         "description": "Import events from other calendars, Meetup, and more.",
         "category": "import",
-        "authors": ["StellarWP"],
-        "documentation_url": "https://theeventscalendar.com/knowledgebase/"
+        "authors": [
+          "StellarWP"
+        ],
+        "documentation_url": "https://theeventscalendar.com/knowledgebase/",
+        "version": "5.9.2",
+        "released_at": "2025-11-03",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "tec-community",
@@ -1062,8 +1398,13 @@
         "name": "Community",
         "description": "Allow community members to submit events from the frontend.",
         "category": "community",
-        "authors": ["StellarWP"],
-        "documentation_url": "https://theeventscalendar.com/knowledgebase/"
+        "authors": [
+          "StellarWP"
+        ],
+        "documentation_url": "https://theeventscalendar.com/knowledgebase/",
+        "version": "4.13.0",
+        "released_at": "2025-09-18",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "tec-promoter",
@@ -1075,8 +1416,13 @@
         "name": "Promoter",
         "description": "Automated email marketing for events and attendees.",
         "category": "marketing",
-        "authors": ["StellarWP"],
-        "documentation_url": "https://theeventscalendar.com/knowledgebase/"
+        "authors": [
+          "StellarWP"
+        ],
+        "documentation_url": "https://theeventscalendar.com/knowledgebase/",
+        "version": "3.4.1",
+        "released_at": "2025-10-07",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "tec-seating",
@@ -1088,8 +1434,13 @@
         "name": "Seating",
         "description": "Assigned seating charts and seat selection for events.",
         "category": "ticketing",
-        "authors": ["StellarWP"],
-        "documentation_url": "https://theeventscalendar.com/knowledgebase/"
+        "authors": [
+          "StellarWP"
+        ],
+        "documentation_url": "https://theeventscalendar.com/knowledgebase/",
+        "version": "1.3.0",
+        "released_at": "2025-11-18",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "tec-filter-bar",
@@ -1101,8 +1452,13 @@
         "name": "Filter Bar",
         "description": "Advanced filtering for event calendars by category, venue, and more.",
         "category": "core",
-        "authors": ["StellarWP"],
-        "documentation_url": "https://theeventscalendar.com/knowledgebase/"
+        "authors": [
+          "StellarWP"
+        ],
+        "documentation_url": "https://theeventscalendar.com/knowledgebase/",
+        "version": "5.5.1",
+        "released_at": "2025-10-31",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "tec-eventbrite",
@@ -1114,8 +1470,13 @@
         "name": "Eventbrite Tickets",
         "description": "Sync events and tickets with Eventbrite.",
         "category": "integration",
-        "authors": ["StellarWP"],
-        "documentation_url": "https://theeventscalendar.com/knowledgebase/"
+        "authors": [
+          "StellarWP"
+        ],
+        "documentation_url": "https://theeventscalendar.com/knowledgebase/",
+        "version": "4.14.0",
+        "released_at": "2025-09-03",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       },
       {
         "feature_slug": "tec-schedule-manager",
@@ -1127,8 +1488,13 @@
         "name": "Event Schedule Manager",
         "description": "Create multi-track schedules for conferences and multi-day events.",
         "category": "management",
-        "authors": ["StellarWP"],
-        "documentation_url": "https://theeventscalendar.com/knowledgebase/"
+        "authors": [
+          "StellarWP"
+        ],
+        "documentation_url": "https://theeventscalendar.com/knowledgebase/",
+        "version": "1.1.0",
+        "released_at": "2025-10-14",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
       }
     ]
   }

--- a/tests/wpunit/API/REST/V1/Feature_ControllerTest.php
+++ b/tests/wpunit/API/REST/V1/Feature_ControllerTest.php
@@ -992,7 +992,7 @@ final class Feature_ControllerTest extends UplinkTestCase {
 		$this->assertTrue( $plugin['additionalProperties'] );
 		$this->assertSame( [ Feature::TYPE_PLUGIN ], $plugin['properties']['type']['enum'] );
 
-		$expected = [ 'slug', 'name', 'description', 'group', 'tier', 'type', 'is_available', 'documentation_url', 'is_enabled', 'plugin_file', 'authors', 'is_dot_org' ];
+		$expected = [ 'slug', 'name', 'description', 'group', 'tier', 'type', 'is_available', 'documentation_url', 'is_enabled', 'plugin_file', 'released_at', 'authors', 'is_dot_org', 'installed_version' ];
 
 		foreach ( $expected as $property ) {
 			$this->assertArrayHasKey( $property, $plugin['properties'], "Missing plugin schema property: {$property}" );
@@ -1014,7 +1014,7 @@ final class Feature_ControllerTest extends UplinkTestCase {
 		$this->assertSame( 'theme', $theme['title'] );
 		$this->assertSame( [ Feature::TYPE_THEME ], $theme['properties']['type']['enum'] );
 
-		$expected = [ 'slug', 'name', 'description', 'group', 'tier', 'type', 'is_available', 'documentation_url', 'is_enabled', 'authors', 'is_dot_org' ];
+		$expected = [ 'slug', 'name', 'description', 'group', 'tier', 'type', 'is_available', 'documentation_url', 'is_enabled', 'released_at', 'authors', 'is_dot_org', 'installed_version' ];
 
 		foreach ( $expected as $property ) {
 			$this->assertArrayHasKey( $property, $theme['properties'], "Missing theme schema property: {$property}" );

--- a/tests/wpunit/Catalog/Results/Catalog_FeatureTest.php
+++ b/tests/wpunit/Catalog/Results/Catalog_FeatureTest.php
@@ -14,6 +14,9 @@ final class Catalog_FeatureTest extends UplinkTestCase {
 		'plugin_file'       => 'kadence-security-pro/kadence-security-pro.php',
 		'is_dot_org'        => false,
 		'download_url'      => 'https://licensing.stellarwp.com/api/plugins/kadence-security',
+		'version'           => '2.1.0',
+		'released_at'       => '2025-11-15',
+		'changelog'         => '<h4>2.1.0</h4><ul><li>Bug fixes.</li></ul>',
 		'name'              => 'Kadence Security Pro',
 		'description'       => 'WordPress security hardening and monitoring.',
 		'category'          => 'security',
@@ -35,6 +38,9 @@ final class Catalog_FeatureTest extends UplinkTestCase {
 		$this->assertSame( 'security', $feature->get_category() );
 		$this->assertSame( [ 'KadenceWP' ], $feature->get_authors() );
 		$this->assertSame( 'https://www.kadencewp.com/help-center/', $feature->get_documentation_url() );
+		$this->assertSame( '2.1.0', $feature->get_version() );
+		$this->assertSame( '2025-11-15', $feature->get_released_at() );
+		$this->assertSame( '<h4>2.1.0</h4><ul><li>Bug fixes.</li></ul>', $feature->get_changelog() );
 	}
 
 	public function test_to_array_produces_expected_shape(): void {
@@ -72,6 +78,9 @@ final class Catalog_FeatureTest extends UplinkTestCase {
 		$this->assertNull( $feature->get_plugin_file() );
 		$this->assertNull( $feature->get_download_url() );
 		$this->assertNull( $feature->get_authors() );
+		$this->assertNull( $feature->get_version() );
+		$this->assertNull( $feature->get_released_at() );
+		$this->assertNull( $feature->get_changelog() );
 	}
 
 	public function test_dot_org_theme(): void {

--- a/tests/wpunit/Features/Types/PluginTest.php
+++ b/tests/wpunit/Features/Types/PluginTest.php
@@ -104,6 +104,8 @@ final class PluginTest extends UplinkTestCase {
 				'is_available'      => true,
 				'documentation_url' => 'https://example.com/docs',
 				'authors'           => [ 'StellarWP' ],
+				'released_at'       => '2025-11-15',
+				'installed_version' => '1.0.0',
 			]
 		);
 
@@ -118,6 +120,8 @@ final class PluginTest extends UplinkTestCase {
 				'is_available'      => true,
 				'documentation_url' => 'https://example.com/docs',
 				'authors'           => [ 'StellarWP' ],
+				'released_at'       => '2025-11-15',
+				'installed_version' => '1.0.0',
 				'type'              => 'plugin',
 			],
 			$feature->to_array()
@@ -143,6 +147,8 @@ final class PluginTest extends UplinkTestCase {
 			'plugin_file'       => 'test-feature/test-feature.php',
 			'authors'           => [ 'StellarWP' ],
 			'is_dot_org'        => false,
+			'released_at'       => '2025-11-15',
+			'installed_version' => '1.2.3',
 		];
 
 		$feature = Plugin::from_array( $data );

--- a/tests/wpunit/Features/Types/ThemeTest.php
+++ b/tests/wpunit/Features/Types/ThemeTest.php
@@ -97,6 +97,8 @@ final class ThemeTest extends UplinkTestCase {
 				'is_available'      => true,
 				'documentation_url' => 'https://example.com/docs',
 				'authors'           => [ 'StellarWP' ],
+				'released_at'       => '2025-11-15',
+				'installed_version' => '2.0.0',
 			]
 		);
 
@@ -110,6 +112,8 @@ final class ThemeTest extends UplinkTestCase {
 				'is_available'      => true,
 				'documentation_url' => 'https://example.com/docs',
 				'authors'           => [ 'StellarWP' ],
+				'released_at'       => '2025-11-15',
+				'installed_version' => '2.0.0',
 				'type'              => 'theme',
 			],
 			$feature->to_array()
@@ -134,6 +138,8 @@ final class ThemeTest extends UplinkTestCase {
 			'documentation_url' => 'https://example.com/docs',
 			'authors'           => [ 'StellarWP' ],
 			'is_dot_org'        => false,
+			'released_at'       => '2025-11-15',
+			'installed_version' => '2.0.0',
 		];
 
 		$feature = Theme::from_array( $data );


### PR DESCRIPTION
This pull request enhances the feature catalog and API to provide more detailed versioning information for plugins and themes. It introduces new fields for tracking the latest available version, release date, changelog, and the currently installed version of extensions. These additions improve transparency and traceability for both users and developers, and are reflected throughout the documentation, API schemas, and tests.

I'll update the sample plugin later (during SCON-255)
