### PR TITLE
chore: add build directory to composer autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
             "StellarWP\\Uplink\\": "src/Uplink/",
             "StellarWP\\Uplink\\Admin_Views\\": "src/admin-views/",
             "StellarWP\\Uplink\\Assets_Dir\\": "src/assets/",
-            "StellarWP\\Uplink\\Views\\": "src/views/"
+            "StellarWP\\Uplink\\Views\\": "src/views/",
+            "StellarWP\\Uplink\\Build_Dir\\": "build/"
         }
     },
     "autoload-dev": {


### PR DESCRIPTION
## Description

This PR adds our required `build` folder directory to composer autoload.  This will ensure strauss will copy over the build folder when included in a project.  Without this, the build folder does not get included in the package through strauss.

<img width="312" height="298" alt="Screenshot 2026-03-12 at 9 52 27 AM" src="https://github.com/user-attachments/assets/3b11ec67-16a2-4eb8-a4bb-c6e096940f36" />
