### PR TITLE
feature: add legacy license api

### DIFF
--- a/src/Uplink/API/REST/V1/Legacy_License_Controller.php
+++ b/src/Uplink/API/REST/V1/Legacy_License_Controller.php
@@ -100,17 +100,7 @@ final class Legacy_License_Controller extends WP_REST_Controller {
 	 */
 	public function get_items( $request ): WP_REST_Response {
 		$licenses = array_map(
-			static function ( Legacy_License $license ): array {
-				return [
-					'key'        => $license->key,
-					'slug'       => $license->slug,
-					'name'       => $license->name,
-					'brand'      => $license->brand,
-					'status'     => $license->status,
-					'page_url'   => $license->page_url,
-					'expires_at' => $license->expires_at,
-				];
-			},
+			static fn( Legacy_License $license ): array => $license->to_array(),
 			$this->repository->all()
 		);
 

--- a/src/Uplink/API/REST/V1/Legacy_License_Controller.php
+++ b/src/Uplink/API/REST/V1/Legacy_License_Controller.php
@@ -1,0 +1,186 @@
+<?php declare( strict_types=1 );
+
+namespace StellarWP\Uplink\API\REST\V1;
+
+use StellarWP\Uplink\Legacy\Legacy_License;
+use StellarWP\Uplink\Legacy\License_Repository;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * WP REST API controller for reading legacy per-plugin license data.
+ *
+ * @since 3.0.0
+ */
+final class Legacy_License_Controller extends WP_REST_Controller {
+
+	/**
+	 * The REST API namespace.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'stellarwp/uplink/v1';
+
+	/**
+	 * The REST API route base.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'license/legacy';
+
+	/**
+	 * The legacy license repository.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var License_Repository
+	 */
+	private License_Repository $repository;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param License_Repository $repository The legacy license repository.
+	 *
+	 * @return void
+	 */
+	public function __construct( License_Repository $repository ) {
+		$this->repository = $repository;
+	}
+
+	/**
+	 * Registers the routes.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_items' ],
+					'permission_callback' => [ $this, 'check_permissions' ],
+				],
+				'schema' => [ $this, 'get_public_item_schema' ],
+			]
+		);
+	}
+
+	/**
+	 * Permission callback: require manage_options capability.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return bool
+	 */
+	public function check_permissions(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Returns all legacy licenses.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_items( $request ): WP_REST_Response {
+		$licenses = array_map(
+			static function ( Legacy_License $license ): array {
+				return [
+					'key'        => $license->key,
+					'slug'       => $license->slug,
+					'name'       => $license->name,
+					'brand'      => $license->brand,
+					'status'     => $license->status,
+					'page_url'   => $license->page_url,
+					'expires_at' => $license->expires_at,
+				];
+			},
+			$this->repository->all()
+		);
+
+		return new WP_REST_Response( $licenses );
+	}
+
+	/**
+	 * Gets the schema for a legacy license item.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_item_schema(): array {
+		if ( $this->schema ) {
+			/** @var array<string, mixed> */
+			return $this->add_additional_fields_schema( $this->schema );
+		}
+
+		$this->schema = [
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'legacy-license',
+			'type'       => 'object',
+			'properties' => [
+				'key'        => [
+					'description' => __( 'The license key.', '%TEXTDOMAIN%' ),
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => [ 'view' ],
+				],
+				'slug'       => [
+					'description' => __( 'The plugin slug.', '%TEXTDOMAIN%' ),
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => [ 'view' ],
+				],
+				'name'       => [
+					'description' => __( 'The plugin name.', '%TEXTDOMAIN%' ),
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => [ 'view' ],
+				],
+				'brand'      => [
+					'description' => __( 'The brand name.', '%TEXTDOMAIN%' ),
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => [ 'view' ],
+				],
+				'status'     => [
+					'description' => __( 'The license status.', '%TEXTDOMAIN%' ),
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => [ 'view' ],
+				],
+				'page_url'   => [
+					'description' => __( 'The license management page URL.', '%TEXTDOMAIN%' ),
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => [ 'view' ],
+				],
+				'expires_at' => [
+					'description' => __( 'The license expiration date.', '%TEXTDOMAIN%' ),
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => [ 'view' ],
+				],
+			],
+		];
+
+		/** @var array<string, mixed> */
+		return $this->add_additional_fields_schema( $this->schema );
+	}
+}

--- a/src/Uplink/API/REST/V1/Provider.php
+++ b/src/Uplink/API/REST/V1/Provider.php
@@ -19,6 +19,7 @@ final class Provider extends Abstract_Provider {
 		$this->container->singleton( Feature_Controller::class );
 		$this->container->singleton( License_Controller::class );
 		$this->container->singleton( Catalog_Controller::class );
+		$this->container->singleton( Legacy_License_Controller::class );
 
 		add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
 	}
@@ -35,6 +36,7 @@ final class Provider extends Abstract_Provider {
 			$this->container->get( Feature_Controller::class )->register_routes();
 			$this->container->get( License_Controller::class )->register_routes();
 			$this->container->get( Catalog_Controller::class )->register_routes();
+			$this->container->get( Legacy_License_Controller::class )->register_routes();
 		}
 	}
 }

--- a/src/Uplink/Legacy/Legacy_License.php
+++ b/src/Uplink/Legacy/Legacy_License.php
@@ -65,6 +65,23 @@ class Legacy_License {
 	/**
 	 * @since 3.0.0
 	 *
+	 * @return array<string, string>
+	 */
+	public function to_array(): array {
+		return [
+			'key'        => $this->key,
+			'slug'       => $this->slug,
+			'name'       => $this->name,
+			'brand'      => $this->brand,
+			'status'     => $this->status,
+			'page_url'   => $this->page_url,
+			'expires_at' => $this->expires_at,
+		];
+	}
+
+	/**
+	 * @since 3.0.0
+	 *
 	 * @param array<string, mixed> $data The legacy license data.
 	 */
 	public static function from_data( array $data ): Legacy_License {

--- a/tests/wpunit/API/REST/V1/Legacy_License_ControllerTest.php
+++ b/tests/wpunit/API/REST/V1/Legacy_License_ControllerTest.php
@@ -1,0 +1,176 @@
+<?php declare( strict_types=1 );
+
+namespace StellarWP\Uplink\Tests\API\REST\V1;
+
+use StellarWP\Uplink\API\REST\V1\Legacy_License_Controller;
+use StellarWP\Uplink\Legacy\License_Repository;
+use StellarWP\Uplink\Tests\Traits\With_Uopz;
+use StellarWP\Uplink\Tests\UplinkTestCase;
+use WP_REST_Request;
+use WP_REST_Server;
+
+final class Legacy_License_ControllerTest extends UplinkTestCase {
+
+	use With_Uopz;
+
+	private WP_REST_Server $server;
+	private License_Repository $repository;
+
+	/**
+	 * Sample legacy license data used across tests.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private array $license_data = [
+		'key'        => 'ABC123',
+		'slug'       => 'my-plugin',
+		'name'       => 'My Plugin',
+		'brand'      => 'My Brand',
+		'status'     => 'active',
+		'page_url'   => 'https://example.com/account',
+		'expires_at' => '2027-01-01',
+	];
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->repository = new License_Repository();
+
+		/** @var WP_REST_Server $wp_rest_server */
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		// Allow registering routes outside of the rest_api_init hook.
+		$this->set_fn_return(
+			'did_action',
+			function ( $hook_name ) {
+				if ( $hook_name !== 'rest_api_init' ) {
+					return \did_action( $hook_name );
+				}
+
+				return true;
+			},
+			true
+		);
+
+		$controller = new Legacy_License_Controller( $this->repository );
+		$controller->register_routes();
+	}
+
+	protected function tearDown(): void {
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		parent::tearDown();
+	}
+
+	public function test_returns_empty_array_when_no_legacy_licenses(): void {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$request  = new WP_REST_Request( 'GET', '/stellarwp/uplink/v1/license/legacy' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( [], $response->get_data() );
+	}
+
+	public function test_returns_legacy_licenses(): void {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		add_filter(
+			'stellarwp/uplink/legacy_licenses',
+			function () {
+				return [ $this->license_data ];
+			}
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/stellarwp/uplink/v1/license/legacy' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertCount( 1, $response->get_data() );
+	}
+
+	public function test_returns_expected_shape(): void {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		add_filter(
+			'stellarwp/uplink/legacy_licenses',
+			function () {
+				return [ $this->license_data ];
+			}
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/stellarwp/uplink/v1/license/legacy' );
+		$response = $this->server->dispatch( $request );
+		$item     = $response->get_data()[0];
+
+		$this->assertArrayHasKey( 'key', $item );
+		$this->assertArrayHasKey( 'slug', $item );
+		$this->assertArrayHasKey( 'name', $item );
+		$this->assertArrayHasKey( 'brand', $item );
+		$this->assertArrayHasKey( 'status', $item );
+		$this->assertArrayHasKey( 'page_url', $item );
+		$this->assertArrayHasKey( 'expires_at', $item );
+
+		$this->assertSame( 'ABC123', $item['key'] );
+		$this->assertSame( 'my-plugin', $item['slug'] );
+		$this->assertSame( 'My Plugin', $item['name'] );
+		$this->assertSame( 'My Brand', $item['brand'] );
+		$this->assertSame( 'active', $item['status'] );
+		$this->assertSame( 'https://example.com/account', $item['page_url'] );
+		$this->assertSame( '2027-01-01', $item['expires_at'] );
+	}
+
+	public function test_returns_multiple_licenses(): void {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		add_filter(
+			'stellarwp/uplink/legacy_licenses',
+			function () {
+				return [
+					$this->license_data,
+					array_merge( $this->license_data, [ 'slug' => 'another-plugin', 'name' => 'Another Plugin' ] ),
+				];
+			}
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/stellarwp/uplink/v1/license/legacy' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertCount( 2, $response->get_data() );
+	}
+
+	public function test_requires_manage_options(): void {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );
+
+		$request  = new WP_REST_Request( 'GET', '/stellarwp/uplink/v1/license/legacy' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	public function test_rejects_unauthenticated(): void {
+		wp_set_current_user( 0 );
+
+		$request  = new WP_REST_Request( 'GET', '/stellarwp/uplink/v1/license/legacy' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 401, $response->get_status() );
+	}
+
+	public function test_schema_has_expected_properties(): void {
+		$controller = new Legacy_License_Controller( $this->repository );
+		$schema     = $controller->get_item_schema();
+
+		$this->assertArrayHasKey( 'properties', $schema );
+
+		$expected = [ 'key', 'slug', 'name', 'brand', 'status', 'page_url', 'expires_at' ];
+
+		foreach ( $expected as $property ) {
+			$this->assertArrayHasKey( $property, $schema['properties'], "Missing schema property: {$property}" );
+		}
+	}
+}

--- a/tests/wpunit/API/REST/V1/Legacy_License_ControllerTest.php
+++ b/tests/wpunit/API/REST/V1/Legacy_License_ControllerTest.php
@@ -131,7 +131,13 @@ final class Legacy_License_ControllerTest extends UplinkTestCase {
 			function () {
 				return [
 					$this->license_data,
-					array_merge( $this->license_data, [ 'slug' => 'another-plugin', 'name' => 'Another Plugin' ] ),
+					array_merge(
+						$this->license_data,
+						[
+							'slug' => 'another-plugin',
+							'name' => 'Another Plugin',
+						] 
+					),
 				];
 			}
 		);


### PR DESCRIPTION
Resolves: [SCON-344]

## Description

This PR adds a new REST API for legacy licenses at `stellarwp/uplink/v1/license/legacy`.  This will ensure the UI can consume legacy legacy information.

[SCON-344]: https://stellarwp.atlassian.net/browse/SCON-344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ