### PR TITLE
fix: global feature functions should return boolean

### DIFF
--- a/src/Uplink/API/Functions/Global_Function_Registry.php
+++ b/src/Uplink/API/Functions/Global_Function_Registry.php
@@ -140,6 +140,13 @@ class Global_Function_Registry {
 		}
 	}
 
+	/**
+	 * Logs a WP_Error message and trace when WP_DEBUG is enabled.
+	 *
+	 * @param WP_Error $error The WP_Error to log.
+	 * @param string $context The context of the log.
+	 * @return void
+	 */
 	private static function debug_log_wp_error( WP_Error $error, string $context ): void {
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Intentionally logging.

--- a/src/Uplink/API/Functions/Global_Function_Registry.php
+++ b/src/Uplink/API/Functions/Global_Function_Registry.php
@@ -144,7 +144,7 @@ class Global_Function_Registry {
 	 * Logs a WP_Error message and trace when WP_DEBUG is enabled.
 	 *
 	 * @param WP_Error $error The WP_Error to log.
-	 * @param string $context The context of the log.
+	 * @param string   $context The context of the log.
 	 * @return void
 	 */
 	private static function debug_log_wp_error( WP_Error $error, string $context ): void {

--- a/src/Uplink/API/Functions/Global_Function_Registry.php
+++ b/src/Uplink/API/Functions/Global_Function_Registry.php
@@ -3,7 +3,6 @@
 namespace StellarWP\Uplink\API\Functions;
 
 use StellarWP\ContainerContract\ContainerInterface;
-use StellarWP\Uplink\Features\Error_Code;
 use StellarWP\Uplink\Features\Manager;
 use StellarWP\Uplink\Licensing\Repositories\License_Repository;
 use Throwable;
@@ -83,13 +82,19 @@ class Global_Function_Registry {
 			$version,
 			static function ( string $slug ) use ( $container ) {
 				try {
-					return $container->get( Manager::class )->is_enabled( $slug );
+					$result = $container->get( Manager::class )->is_enabled( $slug );
+
+					if ( is_wp_error( $result ) ) {
+						self::debug_log_wp_error( $result, 'Error checking feature enabled state' );
+
+						return false;
+					}
+
+					return $result;
 				} catch ( Throwable $e ) {
 					self::debug_log( $e, 'Error checking feature enabled state' );
 
-					$message = $e instanceof \Exception ? $e->getMessage() : 'An unexpected error occurred.';
-
-					return new WP_Error( Error_Code::FEATURE_CHECK_FAILED, $message );
+					return false;
 				}
 			}
 		);
@@ -100,13 +105,19 @@ class Global_Function_Registry {
 			$version,
 			static function ( string $slug ) use ( $container ) {
 				try {
-					return $container->get( Manager::class )->is_available( $slug );
+					$result = $container->get( Manager::class )->is_available( $slug );
+
+					if ( is_wp_error( $result ) ) {
+						self::debug_log_wp_error( $result, 'Error checking feature availability' );
+
+						return false;
+					}
+
+					return $result;
 				} catch ( Throwable $e ) {
 					self::debug_log( $e, 'Error checking feature availability' );
 
-					$message = $e instanceof \Exception ? $e->getMessage() : 'An unexpected error occurred.';
-
-					return new WP_Error( Error_Code::FEATURE_CHECK_FAILED, $message );
+					return false;
 				}
 			}
 		);
@@ -126,6 +137,13 @@ class Global_Function_Registry {
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Intentionally logging.
 			error_log( "{$context}: {$e->getMessage()} {$e->getFile()}:{$e->getLine()} {$e->getTraceAsString()}" );
+		}
+	}
+
+	private static function debug_log_wp_error( WP_Error $error, string $context ): void {
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Intentionally logging.
+			error_log( "{$context}: [{$error->get_error_code()}] {$error->get_error_message()}" );
 		}
 	}
 }

--- a/src/Uplink/global-functions.php
+++ b/src/Uplink/global-functions.php
@@ -108,14 +108,13 @@ if ( ! function_exists( 'stellarwp_uplink_is_feature_enabled' ) ) {
 	 *
 	 * @param string $slug The feature slug.
 	 *
-	 * @return bool|WP_Error
+	 * @return bool
 	 */
-	function stellarwp_uplink_is_feature_enabled( string $slug ) {
+	function stellarwp_uplink_is_feature_enabled( string $slug ): bool {
 		// @phpstan-ignore function.internal
 		$callback = _stellarwp_uplink_global_function_registry( 'stellarwp_uplink_is_feature_enabled' );
 
-		// @phpstan-ignore return.type
-		return $callback ? $callback( $slug ) : false;
+		return $callback ? (bool) $callback( $slug ) : false;
 	}
 }
 
@@ -127,13 +126,12 @@ if ( ! function_exists( 'stellarwp_uplink_is_feature_available' ) ) {
 	 *
 	 * @param string $slug The feature slug.
 	 *
-	 * @return bool|WP_Error
+	 * @return bool
 	 */
-	function stellarwp_uplink_is_feature_available( string $slug ) {
+	function stellarwp_uplink_is_feature_available( string $slug ): bool {
 		// @phpstan-ignore function.internal
 		$callback = _stellarwp_uplink_global_function_registry( 'stellarwp_uplink_is_feature_available' );
 
-		// @phpstan-ignore return.type
-		return $callback ? $callback( $slug ) : false;
+		return $callback ? (bool) $callback( $slug ) : false;
 	}
 }

--- a/tests/wpunit/API/Functions/GlobalFunctionsTest.php
+++ b/tests/wpunit/API/Functions/GlobalFunctionsTest.php
@@ -201,18 +201,12 @@ final class GlobalFunctionsTest extends UplinkTestCase {
 	// stellarwp_uplink_is_feature_enabled() / stellarwp_uplink_is_feature_available()
 	// -------------------------------------------------------------------------
 
-	public function test_is_feature_enabled_returns_wp_error_when_no_license_key_stored(): void {
-		// Feature_Repository cannot fetch the catalog without a license key,
-		// so Manager converts the failure into a WP_Error.
-		$result = stellarwp_uplink_is_feature_enabled( 'any-feature' );
-
-		$this->assertInstanceOf( \WP_Error::class, $result );
+	public function test_is_feature_enabled_returns_false_when_no_license_key_stored(): void {
+		$this->assertFalse( stellarwp_uplink_is_feature_enabled( 'any-feature' ) );
 	}
 
-	public function test_is_feature_available_returns_wp_error_when_no_license_key_stored(): void {
-		$result = stellarwp_uplink_is_feature_available( 'any-feature' );
-
-		$this->assertInstanceOf( \WP_Error::class, $result );
+	public function test_is_feature_available_returns_false_when_no_license_key_stored(): void {
+		$this->assertFalse( stellarwp_uplink_is_feature_available( 'any-feature' ) );
 	}
 
 	// -------------------------------------------------------------------------

--- a/tests/wpunit/Features/FunctionsTest.php
+++ b/tests/wpunit/Features/FunctionsTest.php
@@ -78,14 +78,12 @@ final class FunctionsTest extends UplinkTestCase {
 	}
 
 	/**
-	 * Tests is_feature_enabled returns WP_Error for a feature not in the catalog.
+	 * Tests is_feature_enabled returns false for a feature not in the catalog.
 	 *
 	 * @return void
 	 */
-	public function test_is_feature_enabled_returns_wp_error_for_unknown_feature(): void {
-		$result = stellarwp_uplink_is_feature_enabled( 'nonexistent' );
-
-		$this->assertInstanceOf( WP_Error::class, $result );
+	public function test_is_feature_enabled_returns_false_for_unknown_feature(): void {
+		$this->assertFalse( stellarwp_uplink_is_feature_enabled( 'nonexistent' ) );
 	}
 
 	/**
@@ -151,22 +149,20 @@ final class FunctionsTest extends UplinkTestCase {
 	}
 
 	/**
-	 * Tests is_feature_available returns WP_Error for a feature not in the catalog.
+	 * Tests is_feature_available returns false for a feature not in the catalog.
 	 *
 	 * @return void
 	 */
-	public function test_is_feature_available_returns_wp_error_for_unknown_feature(): void {
-		$result = stellarwp_uplink_is_feature_available( 'nonexistent' );
-
-		$this->assertInstanceOf( WP_Error::class, $result );
+	public function test_is_feature_available_returns_false_for_unknown_feature(): void {
+		$this->assertFalse( stellarwp_uplink_is_feature_available( 'nonexistent' ) );
 	}
 
 	/**
-	 * Tests that is_feature_enabled returns WP_Error when the catalog returns a WP_Error.
+	 * Tests that is_feature_enabled returns false when the catalog returns a WP_Error.
 	 *
 	 * @return void
 	 */
-	public function test_is_feature_enabled_returns_wp_error_when_catalog_errors(): void {
+	public function test_is_feature_enabled_returns_false_when_catalog_errors(): void {
 		$error = new WP_Error( 'api_error', 'Could not fetch features.' );
 
 		$repository = $this->makeEmpty(
@@ -187,16 +183,15 @@ final class FunctionsTest extends UplinkTestCase {
 			}
 		);
 
-		$result = stellarwp_uplink_is_feature_enabled( 'test-feature' );
-		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertFalse( stellarwp_uplink_is_feature_enabled( 'test-feature' ) );
 	}
 
 	/**
-	 * Tests that is_feature_available returns a WP_Error when the catalog returns a WP_Error.
+	 * Tests that is_feature_available returns false when the catalog returns a WP_Error.
 	 *
 	 * @return void
 	 */
-	public function test_is_feature_available_returns_wp_error_when_catalog_errors(): void {
+	public function test_is_feature_available_returns_false_when_catalog_errors(): void {
 		$error = new WP_Error( 'api_error', 'Could not fetch features.' );
 
 		$repository = $this->makeEmpty(
@@ -217,8 +212,6 @@ final class FunctionsTest extends UplinkTestCase {
 			}
 		);
 
-		$result = stellarwp_uplink_is_feature_available( 'test-feature' );
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'api_error', $result->get_error_code() );
+		$this->assertFalse( stellarwp_uplink_is_feature_available( 'test-feature' ) );
 	}
 }


### PR DESCRIPTION
## Description

When implementing the global feature functions, I noticed they would optionally return a WP_Error.  However, consumers using these functions should not care about errors, they should only care about the boolean being returned.  This will ensure  `stellarwp_uplink_is_feature_enabled()` and `stellarwp_uplink_is_feature_available()` always return `true` or `false` instead of having to do `stellarwp_uplink_is_feature_enabled('give') === true`.  If there's some kind of error from uplink, then it will logged but not the job of the consumer to handle.