### PR TITLE
chore: Fix Shop Kit's plugin file

### DIFF
--- a/tests/_data/catalog/default.json
+++ b/tests/_data/catalog/default.json
@@ -78,7 +78,7 @@
         "feature_slug": "kad-shop-kit",
         "type": "plugin",
         "minimum_tier": "kadence-pro",
-        "plugin_file": "kadence-shop-kit/kadence-shop-kit.php",
+        "plugin_file": "kadence-woo-extras/kadence-woo-extras.php",
         "is_dot_org": false,
         "download_url": "https://licensing.stellarwp.com/api/plugins/kad-shop-kit",
         "name": "Shop Kit",


### PR DESCRIPTION
It is `kadence-woo-extras`. This will ensure it gets recognized properly in the UI when we're testing stuff for this in [SCON-5].

[SCON-5]: https://stellarwp.atlassian.net/browse/SCON-5?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ