### PR TITLE
feature: add free tier to catalog

### DIFF
--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -31,6 +31,8 @@ Each product defines an ordered set of tiers that represent subscription levels.
 
 Tiers are always sorted by rank. This ordering drives feature availability. A feature that requires `kadence-pro` (rank 2) is available to anyone on `kadence-pro` or `kadence-agency` (rank 3), but not to someone on `kadence-basic` (rank 1).
 
+Products that have free offerings include a free tier at rank 0 (e.g., `kadence-free`). The free tier is the entry point to the tier hierarchy. Features gated at the free tier are available without a license key — an unlicensed user resolves to rank 0, and `0 >= 0` satisfies the availability check. The `purchase_url` on the free tier points to the first paid tier, providing the upgrade path.
+
 A product's tiers are its own. Tier slugs are namespaced to the product (`kadence-basic`, `give-basic`) so there's no collision across product families.
 
 ### Features
@@ -125,11 +127,13 @@ The fixture data illustrates the structure. Each product in the current catalog 
 ```
 Product: kadence
 ├─ Tiers
+│  ├─ kadence-free   (rank 0, "Free", purchase_url → kadence-basic upgrade)
 │  ├─ kadence-basic  (rank 1, "Basic")
 │  ├─ kadence-pro    (rank 2, "Pro")
 │  └─ kadence-agency (rank 3, "Agency")
-└─ Features (31)
-   ├─ kadence           (theme, minimum: kadence-basic, the product itself, dot-org)
+└─ Features (33)
+   ├─ kad-blocks        (plugin, minimum: kadence-free,  the free blocks library, dot-org)
+   ├─ kadence           (theme,  minimum: kadence-free,  the product itself, dot-org)
    ├─ kad-blocks-pro    (plugin, minimum: kadence-basic, exclusive)
    ├─ kad-shop-kit      (plugin, minimum: kadence-pro,   exclusive)
    ├─ kad-pattern-hub   (flag,   minimum: kadence-basic)
@@ -140,12 +144,12 @@ Note that `kadence` appears as both the product and as a feature within it. This
 
 The current fixture covers four product families:
 
-| Product               | Tiers                  | Features | Categories                                                                                    |
-| --------------------- | ---------------------- | -------- | --------------------------------------------------------------------------------------------- |
-| `kadence`             | 3 (Basic, Pro, Agency) | 31       | theme, blocks, design, woocommerce, forms, social, content, security, management, performance |
-| `learndash`           | 3 (Basic, Pro, Agency) | 8        | core, membership, reporting, import, community                                                |
-| `give`                | 3 (Basic, Pro, Agency) | 28       | core, forms, gateway, email, reporting, marketing, integration                                |
-| `the-events-calendar` | 3 (Basic, Pro, Agency) | 9        | core, ticketing, community, integration                                                       |
+| Product               | Tiers                         | Features | Categories                                                                                    |
+| --------------------- | ----------------------------- | -------- | --------------------------------------------------------------------------------------------- |
+| `kadence`             | 4 (Free, Basic, Pro, Agency)  | 33       | theme, blocks, design, woocommerce, forms, social, content, security, management, performance |
+| `learndash`           | 3 (Basic, Pro, Agency)        | 8        | core, membership, reporting, import, community                                                |
+| `give`                | 4 (Free, Basic, Pro, Agency)  | 28       | core, forms, gateway, email, reporting, marketing, integration                                |
+| `the-events-calendar` | 4 (Free, Basic, Pro, Agency)  | 9        | core, ticketing, community, integration                                                       |
 
 ## Relationship to Licensing and Features
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -65,7 +65,7 @@ For `Installable` features (Plugin, Theme), the resolver also reads `installed_v
 
 Edge cases:
 
-- No licensing entry for a product: tier rank = `0`, all features unavailable
+- No licensing entry for a product: tier rank = `0`. Free-tier features (`minimum_tier` at rank 0) satisfy `0 >= 0` and are available. All paid-tier features are unavailable.
 - Feature's `minimum_tier` slug not in tier collection: rank = `PHP_INT_MAX`, feature unavailable
 
 ## The Manager

--- a/tests/_data/catalog/default.json
+++ b/tests/_data/catalog/default.json
@@ -3,6 +3,12 @@
     "product_slug": "kadence",
     "tiers": [
       {
+        "slug": "kadence-free",
+        "name": "Free",
+        "rank": 0,
+        "purchase_url": "https://software.liquidweb.com/kadence?tier=basic"
+      },
+      {
         "slug": "kadence-basic",
         "name": "Basic",
         "rank": 1,
@@ -23,9 +29,26 @@
     ],
     "features": [
       {
+        "feature_slug": "kad-blocks",
+        "type": "plugin",
+        "minimum_tier": "kadence-free",
+        "plugin_file": "kadence-blocks/kadence-blocks.php",
+        "is_dot_org": true,
+        "name": "Kadence Blocks",
+        "description": "A free Gutenberg block library for building pages with Kadence.",
+        "category": "blocks",
+        "authors": [
+          "KadenceWP"
+        ],
+        "documentation_url": "https://www.kadencewp.com/help-center/",
+        "version": "3.4.6",
+        "released_at": "2025-11-20",
+        "changelog": "<h4>Latest release</h4><ul><li>Bug fixes and performance improvements.</li></ul>"
+      },
+      {
         "feature_slug": "kadence",
         "type": "theme",
-        "minimum_tier": "kadence-basic",
+        "minimum_tier": "kadence-free",
         "is_dot_org": true,
         "name": "Kadence Theme",
         "description": "A lightweight, performant WordPress theme for site building.",
@@ -665,6 +688,12 @@
     "product_slug": "give",
     "tiers": [
       {
+        "slug": "give-free",
+        "name": "Free",
+        "rank": 0,
+        "purchase_url": "https://software.liquidweb.com/give?tier=basic"
+      },
+      {
         "slug": "give-basic",
         "name": "Basic",
         "rank": 1,
@@ -687,7 +716,7 @@
       {
         "feature_slug": "give",
         "type": "plugin",
-        "minimum_tier": "give-basic",
+        "minimum_tier": "give-free",
         "plugin_file": "give/give.php",
         "is_dot_org": true,
         "name": "GiveWP",
@@ -1247,6 +1276,12 @@
     "product_slug": "the-events-calendar",
     "tiers": [
       {
+        "slug": "the-events-calendar-free",
+        "name": "Free",
+        "rank": 0,
+        "purchase_url": "https://software.liquidweb.com/the-events-calendar?tier=basic"
+      },
+      {
         "slug": "the-events-calendar-basic",
         "name": "Basic",
         "rank": 1,
@@ -1269,7 +1304,7 @@
       {
         "feature_slug": "the-events-calendar",
         "type": "plugin",
-        "minimum_tier": "the-events-calendar-basic",
+        "minimum_tier": "the-events-calendar-free",
         "plugin_file": "the-events-calendar/the-events-calendar.php",
         "is_dot_org": true,
         "name": "The Events Calendar",

--- a/tests/wpunit/Catalog/Fixture_ClientTest.php
+++ b/tests/wpunit/Catalog/Fixture_ClientTest.php
@@ -49,7 +49,7 @@ final class Fixture_ClientTest extends UplinkTestCase {
 			foreach ( $tiers as $tier ) {
 				$this->assertInstanceOf( Catalog_Tier::class, $tier );
 				$this->assertNotEmpty( $tier->get_slug() );
-				$this->assertGreaterThan( 0, $tier->get_rank() );
+				$this->assertGreaterThanOrEqual( 0, $tier->get_rank() );
 			}
 		}
 	}

--- a/tests/wpunit/Features/Feature_RepositoryTest.php
+++ b/tests/wpunit/Features/Feature_RepositoryTest.php
@@ -260,7 +260,7 @@ final class Feature_RepositoryTest extends UplinkTestCase {
 
 		$this->assertInstanceOf( Feature_Collection::class, $result );
 
-		$free_features = $result->filter( tier: 'kadence-free' );
+		$free_features = $result->filter( null, 'kadence-free' );
 
 		$this->assertGreaterThan( 0, $free_features->count() );
 

--- a/tests/wpunit/Features/Feature_RepositoryTest.php
+++ b/tests/wpunit/Features/Feature_RepositoryTest.php
@@ -212,7 +212,7 @@ final class Feature_RepositoryTest extends UplinkTestCase {
 	/**
 	 * Tests that feature resolution succeeds and returns a Feature_Collection when no license key is stored.
 	 *
-	 * All features should be unavailable since there is no licensed tier.
+	 * Free-tier features (rank 0) are available without a license. Paid-tier features are not.
 	 *
 	 * @return void
 	 */
@@ -224,8 +224,51 @@ final class Feature_RepositoryTest extends UplinkTestCase {
 		$this->assertInstanceOf( Feature_Collection::class, $result );
 		$this->assertGreaterThan( 0, $result->count() );
 
-		foreach ( $result as $feature ) {
-			$this->assertFalse( $feature->is_available(), 'All features should be unavailable without a license.' );
+		// Free-tier features are available without a license (rank 0 >= rank 0).
+		$this->assertTrue(
+			$result->get( 'kad-blocks' )->is_available(),
+			'Free-tier plugin should be available without a license.'
+		);
+		$this->assertTrue(
+			$result->get( 'kadence' )->is_available(),
+			'Free-tier theme should be available without a license.'
+		);
+
+		// Paid-tier features are not available without a license.
+		$this->assertFalse(
+			$result->get( 'kad-blocks-pro' )->is_available(),
+			'Basic-tier feature should not be available without a license.'
+		);
+		$this->assertFalse(
+			$result->get( 'solid-central' )->is_available(),
+			'Agency-tier feature should not be available without a license.'
+		);
+	}
+
+	/**
+	 * Tests that free-tier features resolve as available for unlicensed users.
+	 *
+	 * An unlicensed user resolves to tier rank 0. Features with minimum_tier at the
+	 * free tier (rank 0) satisfy 0 >= 0 and are available without a license key.
+	 *
+	 * @return void
+	 */
+	public function test_free_tier_features_available_without_license(): void {
+		$repository = $this->make_repository();
+
+		$result = $repository->get();
+
+		$this->assertInstanceOf( Feature_Collection::class, $result );
+
+		$free_features = $result->filter( tier: 'kadence-free' );
+
+		$this->assertGreaterThan( 0, $free_features->count() );
+
+		foreach ( $free_features as $feature ) {
+			$this->assertTrue(
+				$feature->is_available(),
+				sprintf( 'Free-tier feature "%s" should be available without a license.', $feature->get_slug() )
+			);
 		}
 	}
 


### PR DESCRIPTION
Resolves: [SCON-341]

## Description

This adds the concept of free tier / 0 rank to the catalog data.  This will ensure we have a way to recognize products that are free within our system.

[SCON-341]: https://stellarwp.atlassian.net/browse/SCON-341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ