### PR TITLE
Enhance debugging capabilities across Uplink | SCON-423

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,10 @@ Fixture data lives in `tests/_data/`. The catalog and licensing fixture files ar
 
 The minimum PHP version is 7.4 (see `composer.json`). Do not use language features from PHP 8.0+ (named arguments, union types, match expressions, constructor promotion, etc.).
 
+## Debugging
+
+All debug logging goes through the `With_Debugging` trait (`src/Uplink/Traits/With_Debugging.php`). Never call `error_log()` directly — use `debug_log()`, `debug_log_throwable()`, or `debug_log_wp_error()` instead. Since it's a trait, standalone global functions that aren't inside a class can't use it — route those through a class that uses the trait (see `Global_Function_Registry` for the pattern).
+
 ## Key principles
 
 - One unified `LWSW-` license key per site, shared by all products

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -22,6 +22,20 @@ To run tests for the first time, there are a couple of things you need to do:
 
 You can simply run `slic run` or `slic run SUITE_YOU_WANT_TO_RUN` to quickly run automated tests for this library. If you want to use xdebug with your tests, you'll need to open a `slic ssh` session and turn xdebugging on (there's help text to show you how).
 
+## Debug logging
+
+Uplink uses the `With_Debugging` trait (`src/Uplink/Traits/With_Debugging.php`) for all debug output. When `WP_DEBUG` is enabled, log messages are written via `error_log()` with an `Uplink:` prefix so they're easy to filter.
+
+The trait provides three methods:
+
+| Method                  | Use for                                      |
+| ----------------------- | -------------------------------------------- |
+| `debug_log()`           | Plain string messages                        |
+| `debug_log_throwable()` | Exceptions — logs message, file, line, trace |
+| `debug_log_wp_error()`  | `WP_Error` objects — logs code and message   |
+
+To see Uplink debug output during test runs, make sure `WP_DEBUG` is `true` in the test environment (slic sets this by default). Grep for `Uplink:` in the PHP error log to isolate Uplink messages from other output.
+
 ## Local development with fixtures
 
 During development the [sample plugin](https://github.com/stellarwp/uplink-sample-plugin) replaces the real API clients with fixture clients that read local JSON files. The admin settings page (under **Uplink Sample Plugin**) exposes three controls:

--- a/src/Uplink/API/Functions/Global_Function_Registry.php
+++ b/src/Uplink/API/Functions/Global_Function_Registry.php
@@ -5,8 +5,8 @@ namespace StellarWP\Uplink\API\Functions;
 use StellarWP\Uplink\Config;
 use StellarWP\Uplink\Features\Manager;
 use StellarWP\Uplink\Licensing\Repositories\License_Repository;
+use StellarWP\Uplink\Traits\With_Debugging;
 use Throwable;
-use WP_Error;
 
 /**
  * Registers this Uplink instance's callbacks into the global function registry.
@@ -19,6 +19,8 @@ use WP_Error;
  * @since 3.0.0
  */
 class Global_Function_Registry {
+
+	use With_Debugging;
 
 	/**
 	 * Registers this instance's callbacks into the global function registry.
@@ -37,7 +39,7 @@ class Global_Function_Registry {
 				try {
 					return Config::get_container()->get( License_Repository::class )->key_exists();
 				} catch ( Throwable $e ) {
-					self::debug_log( $e, 'Error checking unified license key existence' );
+					self::debug_log_throwable( $e, 'Error checking unified license key existence' );
 
 					return false;
 				}
@@ -51,7 +53,7 @@ class Global_Function_Registry {
 				try {
 					return Config::get_container()->get( License_Repository::class )->get_key();
 				} catch ( Throwable $e ) {
-					self::debug_log( $e, 'Error getting unified license key' );
+					self::debug_log_throwable( $e, 'Error getting unified license key' );
 
 					return null;
 				}
@@ -65,7 +67,7 @@ class Global_Function_Registry {
 				try {
 					return Config::get_container()->get( License_Repository::class )->is_product_valid( $product );
 				} catch ( Throwable $e ) {
-					self::debug_log( $e, 'Error checking product license' );
+					self::debug_log_throwable( $e, 'Error checking product license' );
 
 					return false;
 				}
@@ -87,7 +89,7 @@ class Global_Function_Registry {
 
 					return $result;
 				} catch ( Throwable $e ) {
-					self::debug_log( $e, 'Error checking feature enabled state' );
+					self::debug_log_throwable( $e, 'Error checking feature enabled state' );
 
 					return false;
 				}
@@ -109,42 +111,11 @@ class Global_Function_Registry {
 
 					return $result;
 				} catch ( Throwable $e ) {
-					self::debug_log( $e, 'Error checking feature availability' );
+					self::debug_log_throwable( $e, 'Error checking feature availability' );
 
 					return false;
 				}
 			}
 		);
-	}
-
-	/**
-	 * Logs a Throwable message and trace when WP_DEBUG is enabled.
-	 *
-	 * @since 3.0.0
-	 *
-	 * @param Throwable $e The Throwable to log.
-	 * @param string    $context The context of the log.
-	 *
-	 * @return void
-	 */
-	private static function debug_log( Throwable $e, string $context ): void {
-		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Intentionally logging.
-			error_log( "{$context}: {$e->getMessage()} {$e->getFile()}:{$e->getLine()} {$e->getTraceAsString()}" );
-		}
-	}
-
-	/**
-	 * Logs a WP_Error message and trace when WP_DEBUG is enabled.
-	 *
-	 * @param WP_Error $error The WP_Error to log.
-	 * @param string   $context The context of the log.
-	 * @return void
-	 */
-	private static function debug_log_wp_error( WP_Error $error, string $context ): void {
-		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Intentionally logging.
-			error_log( "{$context}: [{$error->get_error_code()}] {$error->get_error_message()}" );
-		}
 	}
 }

--- a/src/Uplink/API/V3/Auth/Auth_Url.php
+++ b/src/Uplink/API/V3/Auth/Auth_Url.php
@@ -42,15 +42,13 @@ final class Auth_Url implements Contracts\Auth_Url {
 		);
 
 		if ( $response instanceof WP_Error ) {
-			if ( $this->is_wp_debug() ) {
-				error_log(
-					sprintf(
-						'Token auth failed for slug: "%s". Errors: %s',
-						$slug,
-						implode( ', ', $response->get_error_messages() )
-					) 
-				);
-			}
+			self::debug_log(
+				sprintf(
+					'Token auth failed for slug: "%s". Errors: %s',
+					$slug,
+					implode( ', ', $response->get_error_messages() )
+				)
+			);
 
 			return '';
 		}

--- a/src/Uplink/API/V3/Auth/Token_Authorizer.php
+++ b/src/Uplink/API/V3/Auth/Token_Authorizer.php
@@ -20,6 +20,11 @@ class Token_Authorizer implements Contracts\Token_Authorizer {
 	 */
 	private $client;
 
+	/**
+	 * Constructor.
+	 *
+	 * @param Client_V3 $client The API client.
+	 */
 	public function __construct( Client_V3 $client ) {
 		$this->client = $client;
 	}
@@ -51,17 +56,15 @@ class Token_Authorizer implements Contracts\Token_Authorizer {
 		);
 
 		if ( $response instanceof WP_Error ) {
-			if ( $this->is_wp_debug() ) {
-				error_log(
-					sprintf(
-						__( 'Authorization error occurred: License: "%1$s", Token: "%2$s", Domain: "%3$s". Errors: %4$s', '%TEXTDOMAIN%' ),
-						$license,
-						$token,
-						$domain,
-						implode( ', ', $response->get_error_messages() )
-					) 
-				);
-			}
+			static::debug_log(
+				sprintf(
+					'Authorization error occurred: License: "%s", Token: "%s", Domain: "%s". Errors: %s',
+					$license,
+					$token,
+					$domain,
+					implode( ', ', $response->get_error_messages() )
+				)
+			);
 
 			return false;
 		}

--- a/src/Uplink/Catalog/Catalog_Repository.php
+++ b/src/Uplink/Catalog/Catalog_Repository.php
@@ -3,6 +3,7 @@
 namespace StellarWP\Uplink\Catalog;
 
 use StellarWP\Uplink\Catalog\Clients\Catalog_Client;
+use StellarWP\Uplink\Traits\With_Debugging;
 use WP_Error;
 
 /**
@@ -19,6 +20,8 @@ use WP_Error;
  * @since 3.0.0
  */
 class Catalog_Repository {
+
+	use With_Debugging;
 
 	/**
 	 * How long (in seconds) to suppress outbound API calls after a failure.
@@ -128,6 +131,13 @@ class Catalog_Repository {
 		$throttled = $this->get_throttled_error();
 
 		if ( $throttled !== null ) {
+			static::debug_log(
+				sprintf(
+					'Catalog fetch throttled: %s',
+					$throttled->get_error_message()
+				)
+			);
+
 			return $throttled;
 		}
 
@@ -154,6 +164,17 @@ class Catalog_Repository {
 	 */
 	protected function fetch() {
 		$result = $this->client->get_catalog();
+
+		if ( is_wp_error( $result ) ) {
+			static::debug_log(
+				sprintf(
+					'Catalog fetch failed: [%s] %s',
+					$result->get_error_code(),
+					$result->get_error_message()
+				)
+			);
+		}
+
 		$this->set_catalog( $result );
 
 		return $result;

--- a/src/Uplink/Catalog/Clients/Http_Client.php
+++ b/src/Uplink/Catalog/Clients/Http_Client.php
@@ -8,6 +8,7 @@ use Psr\Http\Message\RequestFactoryInterface;
 use StellarWP\Uplink\Catalog\Catalog_Collection;
 use StellarWP\Uplink\Catalog\Error_Code;
 use StellarWP\Uplink\Catalog\Results\Product_Catalog;
+use StellarWP\Uplink\Traits\With_Debugging;
 use WP_Error;
 
 /**
@@ -16,6 +17,8 @@ use WP_Error;
  * @since 3.0.0
  */
 final class Http_Client implements Catalog_Client {
+
+	use With_Debugging;
 
 	/**
 	 * The PSR-18 HTTP client.
@@ -67,14 +70,21 @@ final class Http_Client implements Catalog_Client {
 	 * @inheritDoc
 	 */
 	public function get_catalog() {
-		$request = $this->request_factory->createRequest(
-			'GET',
-			$this->base_url . '/stellarwp/v4/catalog'
+		$url = $this->base_url . '/stellarwp/v4/catalog';
+
+		self::debug_log(
+			sprintf( 'Catalog HTTP request: GET %s', $url )
 		);
+
+		$request = $this->request_factory->createRequest( 'GET', $url );
 
 		try {
 			$response = $this->client->sendRequest( $request );
 		} catch ( ClientExceptionInterface $e ) {
+			self::debug_log(
+				sprintf( 'Catalog HTTP exception: %s', $e->getMessage() )
+			);
+
 			return new WP_Error(
 				Error_Code::INVALID_RESPONSE,
 				$e->getMessage()
@@ -82,6 +92,10 @@ final class Http_Client implements Catalog_Client {
 		}
 
 		$status_code = $response->getStatusCode();
+
+		self::debug_log(
+			sprintf( 'Catalog HTTP response: %d', $status_code )
+		);
 
 		if ( $status_code < 200 || $status_code >= 300 ) {
 			return new WP_Error(
@@ -94,6 +108,8 @@ final class Http_Client implements Catalog_Client {
 		$data = json_decode( (string) $response->getBody(), true );
 
 		if ( ! is_array( $data ) ) {
+			self::debug_log( 'Catalog response body could not be decoded as JSON.' );
+
 			return new WP_Error(
 				Error_Code::INVALID_RESPONSE,
 				'Catalog response could not be decoded.'

--- a/src/Uplink/Features/Feature_Repository.php
+++ b/src/Uplink/Features/Feature_Repository.php
@@ -2,6 +2,7 @@
 
 namespace StellarWP\Uplink\Features;
 
+use StellarWP\Uplink\Traits\With_Debugging;
 use WP_Error;
 
 /**
@@ -14,6 +15,8 @@ use WP_Error;
  * @since 3.0.0
  */
 class Feature_Repository {
+
+	use With_Debugging;
 
 	/**
 	 * The feature collection resolver.
@@ -80,8 +83,19 @@ class Feature_Repository {
 	 * @return Feature_Collection|WP_Error
 	 */
 	protected function resolve() {
-		$this->cached = ( $this->resolver )();
+		$result       = ( $this->resolver )();
+		$this->cached = $result;
 
-		return $this->cached;
+		if ( is_wp_error( $result ) ) {
+			static::debug_log(
+				sprintf(
+					'Feature resolution failed: [%s] %s',
+					$result->get_error_code(),
+					$result->get_error_message()
+				)
+			);
+		}
+
+		return $result;
 	}
 }

--- a/src/Uplink/Features/Manager.php
+++ b/src/Uplink/Features/Manager.php
@@ -5,6 +5,7 @@ namespace StellarWP\Uplink\Features;
 use StellarWP\Uplink\Features\Strategy\Strategy_Factory;
 use StellarWP\Uplink\Features\Types\Feature;
 use StellarWP\Uplink\Features\Error_Code;
+use StellarWP\Uplink\Traits\With_Debugging;
 use Throwable;
 use WP_Error;
 
@@ -17,6 +18,8 @@ use WP_Error;
  * @since 3.0.0
  */
 class Manager {
+
+	use With_Debugging;
 
 	/**
 	 * The repository for fetching available features.
@@ -64,15 +67,34 @@ class Manager {
 	 * @return Feature|WP_Error The feature with updated is_enabled state, or WP_Error on failure.
 	 */
 	public function enable( string $slug ) {
+		static::debug_log(
+			sprintf(
+				'Enabling feature "%s".',
+				$slug
+			)
+		);
+
 		$features = $this->repository->get();
 
 		if ( is_wp_error( $features ) ) {
+			static::debug_log_wp_error(
+				$features,
+				sprintf( 'Cannot enable "%s": feature resolution failed', $slug )
+			);
+
 			return $features;
 		}
 
 		$feature = $features->get( $slug );
 
 		if ( ! $feature ) {
+			static::debug_log(
+				sprintf(
+					'Cannot enable "%s": not found in catalog.',
+					$slug
+				)
+			);
+
 			return new WP_Error(
 				Error_Code::FEATURE_NOT_FOUND,
 				sprintf( 'Feature "%s" not found in the catalog.', $slug )
@@ -106,6 +128,11 @@ class Manager {
 
 			$result = $strategy->enable();
 		} catch ( Throwable $e ) {
+			static::debug_log_throwable(
+				$e,
+				sprintf( 'Exception enabling feature "%s"', $slug )
+			);
+
 			return new WP_Error(
 				Error_Code::FEATURE_ENABLE_FAILED,
 				$e->getMessage()
@@ -113,6 +140,11 @@ class Manager {
 		}
 
 		if ( is_wp_error( $result ) ) {
+			static::debug_log_wp_error(
+				$result,
+				sprintf( 'Strategy failed enabling "%s"', $slug )
+			);
+
 			return $result;
 		}
 
@@ -121,11 +153,25 @@ class Manager {
 		$feature = $this->get( $slug );
 
 		if ( ! $feature ) {
+			static::debug_log(
+				sprintf(
+					'Feature "%s" not found after enabling.',
+					$slug
+				)
+			);
+
 			return new WP_Error(
 				Error_Code::FEATURE_NOT_FOUND,
 				sprintf( 'Feature "%s" not found after enabling.', $slug )
 			);
 		}
+
+		static::debug_log(
+			sprintf(
+				'Feature "%s" enabled successfully.',
+				$slug
+			)
+		);
 
 		/**
 		 * Fires after a feature has been successfully enabled.
@@ -165,15 +211,34 @@ class Manager {
 	 * @return Feature|WP_Error The feature with updated is_enabled state, or WP_Error on failure.
 	 */
 	public function disable( string $slug ) {
+		static::debug_log(
+			sprintf(
+				'Disabling feature "%s".',
+				$slug
+			)
+		);
+
 		$features = $this->repository->get();
 
 		if ( is_wp_error( $features ) ) {
+			static::debug_log_wp_error(
+				$features,
+				sprintf( 'Cannot disable "%s": feature resolution failed', $slug )
+			);
+
 			return $features;
 		}
 
 		$feature = $features->get( $slug );
 
 		if ( ! $feature ) {
+			static::debug_log(
+				sprintf(
+					'Cannot disable "%s": not found in catalog.',
+					$slug
+				)
+			);
+
 			return new WP_Error(
 				Error_Code::FEATURE_NOT_FOUND,
 				sprintf( 'Feature "%s" not found in the catalog.', $slug )
@@ -207,6 +272,11 @@ class Manager {
 
 			$result = $strategy->disable();
 		} catch ( Throwable $e ) {
+			static::debug_log_throwable(
+				$e,
+				sprintf( 'Exception disabling feature "%s"', $slug )
+			);
+
 			return new WP_Error(
 				Error_Code::FEATURE_DISABLE_FAILED,
 				$e->getMessage()
@@ -214,6 +284,11 @@ class Manager {
 		}
 
 		if ( is_wp_error( $result ) ) {
+			static::debug_log_wp_error(
+				$result,
+				sprintf( 'Strategy failed disabling "%s"', $slug )
+			);
+
 			return $result;
 		}
 
@@ -222,11 +297,25 @@ class Manager {
 		$feature = $this->get( $slug );
 
 		if ( ! $feature ) {
+			static::debug_log(
+				sprintf(
+					'Feature "%s" not found after disabling.',
+					$slug
+				)
+			);
+
 			return new WP_Error(
 				Error_Code::FEATURE_NOT_FOUND,
 				sprintf( 'Feature "%s" not found after disabling.', $slug )
 			);
 		}
+
+		static::debug_log(
+			sprintf(
+				'Feature "%s" disabled successfully.',
+				$slug
+			)
+		);
 
 		/**
 		 * Fires after a feature has been successfully disabled.
@@ -266,15 +355,34 @@ class Manager {
 	 * @return Feature|WP_Error The feature with updated state, or WP_Error on failure.
 	 */
 	public function update( string $slug ) {
+		static::debug_log(
+			sprintf(
+				'Updating feature "%s".',
+				$slug
+			)
+		);
+
 		$features = $this->repository->get();
 
 		if ( is_wp_error( $features ) ) {
+			static::debug_log_wp_error(
+				$features,
+				sprintf( 'Cannot update "%s": feature resolution failed', $slug )
+			);
+
 			return $features;
 		}
 
 		$feature = $features->get( $slug );
 
 		if ( ! $feature ) {
+			static::debug_log(
+				sprintf(
+					'Cannot update "%s": not found in catalog.',
+					$slug
+				)
+			);
+
 			return new WP_Error(
 				Error_Code::FEATURE_NOT_FOUND,
 				sprintf( 'Feature "%s" not found in the catalog.', $slug )
@@ -308,6 +416,11 @@ class Manager {
 
 			$result = $strategy->update();
 		} catch ( Throwable $e ) {
+			static::debug_log_throwable(
+				$e,
+				sprintf( 'Exception updating feature "%s"', $slug )
+			);
+
 			return new WP_Error(
 				Error_Code::UPDATE_FAILED,
 				$e->getMessage()
@@ -315,6 +428,11 @@ class Manager {
 		}
 
 		if ( is_wp_error( $result ) ) {
+			static::debug_log_wp_error(
+				$result,
+				sprintf( 'Strategy failed updating "%s"', $slug )
+			);
+
 			return $result;
 		}
 
@@ -323,11 +441,25 @@ class Manager {
 		$feature = $this->get( $slug );
 
 		if ( ! $feature ) {
+			static::debug_log(
+				sprintf(
+					'Feature "%s" not found after updating.',
+					$slug
+				)
+			);
+
 			return new WP_Error(
 				Error_Code::FEATURE_NOT_FOUND,
 				sprintf( 'Feature "%s" not found after updating.', $slug )
 			);
 		}
+
+		static::debug_log(
+			sprintf(
+				'Feature "%s" updated successfully.',
+				$slug
+			)
+		);
 
 		/**
 		 * Fires after a feature has been successfully updated.
@@ -485,12 +617,19 @@ class Manager {
 	 */
 	private function stamp_enabled_state( Feature_Collection $features ): void {
 		foreach ( $features as $feature ) {
-			$strategy           = $this->strategy_factory->make( $feature );
-			$class              = get_class( $feature );
-			$data               = $feature->to_array();
-			$data['is_enabled'] = $strategy->is_active();
+			try {
+				$strategy           = $this->strategy_factory->make( $feature );
+				$class              = get_class( $feature );
+				$data               = $feature->to_array();
+				$data['is_enabled'] = $strategy->is_active();
 
-			$features->offsetSet( $feature->get_slug(), $class::from_array( $data ) );
+				$features->offsetSet( $feature->get_slug(), $class::from_array( $data ) );
+			} catch ( Throwable $e ) {
+				static::debug_log_throwable(
+					$e,
+					sprintf( 'Failed to stamp enabled state for "%s"', $feature->get_slug() )
+				);
+			}
 		}
 	}
 }

--- a/src/Uplink/Features/Resolve_Feature_Collection.php
+++ b/src/Uplink/Features/Resolve_Feature_Collection.php
@@ -10,6 +10,7 @@ use StellarWP\Uplink\Features\Types\Feature;
 use StellarWP\Uplink\Licensing\License_Manager;
 use StellarWP\Uplink\Licensing\Product_Collection;
 use StellarWP\Uplink\Site\Data;
+use StellarWP\Uplink\Traits\With_Debugging;
 use WP_Error;
 
 /**
@@ -21,6 +22,8 @@ use WP_Error;
  * @since 3.0.0
  */
 class Resolve_Feature_Collection {
+
+	use With_Debugging;
 
 	/**
 	 * The catalog repository.
@@ -105,6 +108,11 @@ class Resolve_Feature_Collection {
 		$catalog = $this->catalog->get();
 
 		if ( is_wp_error( $catalog ) ) {
+			static::debug_log_wp_error(
+				$catalog,
+				'Catalog fetch failed during feature resolution'
+			);
+
 			return $catalog;
 		}
 
@@ -114,6 +122,11 @@ class Resolve_Feature_Collection {
 			if ( $this->licensing->get_key() === null ) {
 				$products = new Product_Collection();
 			} else {
+				static::debug_log_wp_error(
+					$products,
+					'Licensing fetch failed during feature resolution'
+				);
+
 				return $products;
 			}
 		}
@@ -131,8 +144,7 @@ class Resolve_Feature_Collection {
 				$feature = $this->hydrate_feature( $catalog_feature, $product, $license_tier_rank );
 
 				if ( is_wp_error( $feature ) ) {
-					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Intentionally logging.
-					error_log( sprintf( 'Uplink: %s', $feature->get_error_message() ) );
+					static::debug_log( $feature->get_error_message() );
 					continue;
 				}
 
@@ -158,15 +170,29 @@ class Resolve_Feature_Collection {
 	 * @return int The tier rank, or 0 if the product has no license.
 	 */
 	private function resolve_license_tier_rank( Product_Catalog $product, Product_Collection $products ): int {
-		$license = $products->get( $product->get_product_slug() );
+		$product_slug = $product->get_product_slug();
+		$license      = $products->get( $product_slug );
 
-		if ( $license === null ) {
+		if ( null === $license ) {
 			return 0;
 		}
 
-		$tier = $product->get_tier_by_slug( $license->get_tier() );
+		$tier_slug = $license->get_tier();
+		$tier      = $product->get_tier_by_slug( $tier_slug );
 
-		return $tier !== null ? $tier->get_rank() : 0;
+		if ( null === $tier ) {
+			static::debug_log(
+				sprintf(
+					'Licensed tier slug "%s" not found in catalog for product "%s", tier rank = 0.',
+					$tier_slug,
+					$product_slug
+				)
+			);
+
+			return 0;
+		}
+
+		return $tier->get_rank();
 	}
 
 	/**

--- a/src/Uplink/Features/Strategy/Abstract_Strategy.php
+++ b/src/Uplink/Features/Strategy/Abstract_Strategy.php
@@ -4,6 +4,7 @@ namespace StellarWP\Uplink\Features\Strategy;
 
 use StellarWP\Uplink\Features\Contracts\Strategy;
 use StellarWP\Uplink\Features\Types\Feature;
+use StellarWP\Uplink\Traits\With_Debugging;
 
 /**
  * Base class for feature-gating strategies.
@@ -13,6 +14,8 @@ use StellarWP\Uplink\Features\Types\Feature;
  * @since 3.0.0
  */
 abstract class Abstract_Strategy implements Strategy {
+
+	use With_Debugging;
 
 	/**
 	 * The feature this strategy operates on.

--- a/src/Uplink/Features/Strategy/Flag_Strategy.php
+++ b/src/Uplink/Features/Strategy/Flag_Strategy.php
@@ -39,6 +39,10 @@ class Flag_Strategy extends Abstract_Strategy {
 	 * @return true
 	 */
 	public function enable() {
+		static::debug_log(
+			sprintf( 'Setting flag option "%s" to active.', $this->get_option_key() )
+		);
+
 		update_option( $this->get_option_key(), '1', true );
 
 		return true;
@@ -72,6 +76,10 @@ class Flag_Strategy extends Abstract_Strategy {
 	 * @return true
 	 */
 	public function disable() {
+		static::debug_log(
+			sprintf( 'Setting flag option "%s" to inactive.', $this->get_option_key() )
+		);
+
 		update_option( $this->get_option_key(), '0', true );
 
 		return true;

--- a/src/Uplink/Features/Strategy/Installable_Strategy.php
+++ b/src/Uplink/Features/Strategy/Installable_Strategy.php
@@ -164,9 +164,21 @@ abstract class Installable_Strategy extends Abstract_Strategy {
 
 		// Idempotent: if the extension is already active, verify ownership and bail.
 		if ( $this->check_active() ) {
+			static::debug_log(
+				sprintf(
+					'Feature "%s" already active, verifying ownership.',
+					$this->feature->get_slug()
+				)
+			);
+
 			$ownership = $this->verify_ownership();
 
 			if ( is_wp_error( $ownership ) ) {
+				static::debug_log_wp_error(
+					$ownership,
+					sprintf( 'Ownership check failed for active "%s"', $this->feature->get_slug() )
+				);
+
 				return $ownership;
 			}
 
@@ -180,6 +192,11 @@ abstract class Installable_Strategy extends Abstract_Strategy {
 		$ownership = $this->verify_ownership();
 
 		if ( is_wp_error( $ownership ) ) {
+			static::debug_log_wp_error(
+				$ownership,
+				sprintf( 'Pre-install ownership check failed for "%s"', $this->feature->get_slug() )
+			);
+
 			return $ownership;
 		}
 
@@ -187,6 +204,11 @@ abstract class Installable_Strategy extends Abstract_Strategy {
 		$ensure_result = $this->ensure_installed();
 
 		if ( is_wp_error( $ensure_result ) ) {
+			static::debug_log_wp_error(
+				$ensure_result,
+				sprintf( 'Installation failed for "%s"', $this->feature->get_slug() )
+			);
+
 			return $ensure_result;
 		}
 
@@ -195,6 +217,11 @@ abstract class Installable_Strategy extends Abstract_Strategy {
 		$ownership = $this->verify_ownership();
 
 		if ( is_wp_error( $ownership ) ) {
+			static::debug_log_wp_error(
+				$ownership,
+				sprintf( 'Post-install ownership check failed for "%s"', $this->feature->get_slug() )
+			);
+
 			return $ownership;
 		}
 
@@ -220,6 +247,11 @@ abstract class Installable_Strategy extends Abstract_Strategy {
 		$ownership = $this->verify_ownership();
 
 		if ( is_wp_error( $ownership ) ) {
+			static::debug_log_wp_error(
+				$ownership,
+				sprintf( 'Ownership check failed when disabling "%s"', $this->feature->get_slug() )
+			);
+
 			return $ownership;
 		}
 
@@ -242,6 +274,13 @@ abstract class Installable_Strategy extends Abstract_Strategy {
 
 		// Can't update what's not installed or active.
 		if ( ! $this->check_active() ) {
+			static::debug_log(
+				sprintf(
+					'Cannot update "%s": not active.',
+					$this->feature->get_slug()
+				)
+			);
+
 			return new WP_Error(
 				Error_Code::FEATURE_NOT_ACTIVE,
 				sprintf(
@@ -255,10 +294,22 @@ abstract class Installable_Strategy extends Abstract_Strategy {
 		$ownership = $this->verify_ownership();
 
 		if ( is_wp_error( $ownership ) ) {
+			static::debug_log_wp_error(
+				$ownership,
+				sprintf( 'Ownership check failed when updating "%s"', $this->feature->get_slug() )
+			);
+
 			return $ownership;
 		}
 
 		if ( ! $this->check_update_available() ) {
+			static::debug_log(
+				sprintf(
+					'No update available for "%s".',
+					$this->feature->get_slug()
+				)
+			);
+
 			return new WP_Error(
 				Error_Code::NO_UPDATE_AVAILABLE,
 				sprintf(
@@ -270,6 +321,13 @@ abstract class Installable_Strategy extends Abstract_Strategy {
 		}
 
 		if ( ! $this->acquire_lock( self::LOCK_KEY ) ) {
+			static::debug_log(
+				sprintf(
+					'Install lock held, cannot update "%s".',
+					$this->feature->get_slug()
+				)
+			);
+
 			return new WP_Error(
 				Error_Code::INSTALL_LOCKED,
 				sprintf(
@@ -327,6 +385,13 @@ abstract class Installable_Strategy extends Abstract_Strategy {
 		// Already on disk — ready for activation. Ownership is verified
 		// by the caller (enable()) after this method returns.
 		if ( $this->check_installed() ) {
+			static::debug_log(
+				sprintf(
+					'Feature "%s" already installed on disk.',
+					$this->feature->get_slug()
+				)
+			);
+
 			return true;
 		}
 
@@ -334,6 +399,13 @@ abstract class Installable_Strategy extends Abstract_Strategy {
 		// Only one feature can be installed at a time — two simultaneous
 		// requests could race the installer, causing file conflicts or corruption.
 		if ( ! $this->acquire_lock( self::LOCK_KEY ) ) {
+			static::debug_log(
+				sprintf(
+					'Install lock held, cannot install "%s".',
+					$this->feature->get_slug()
+				)
+			);
+
 			return new WP_Error(
 				Error_Code::INSTALL_LOCKED,
 				sprintf(
@@ -348,6 +420,11 @@ abstract class Installable_Strategy extends Abstract_Strategy {
 			$install_result = $this->do_install();
 
 			if ( is_wp_error( $install_result ) ) {
+				static::debug_log_wp_error(
+					$install_result,
+					sprintf( 'do_install() failed for "%s"', $this->feature->get_slug() )
+				);
+
 				return $install_result;
 			}
 
@@ -356,6 +433,13 @@ abstract class Installable_Strategy extends Abstract_Strategy {
 			// a confusing "not found" during activation.
 			// @phpstan-ignore-next-line booleanNot.alwaysTrue -- (do_install() creates files on disk; side effects invisible to static analysis).
 			if ( ! $this->check_installed() ) {
+				static::debug_log(
+					sprintf(
+						'Feature "%s" not found on disk after install — unexpected directory structure.',
+						$this->feature->get_slug()
+					)
+				);
+
 				return new WP_Error(
 					$this->get_not_found_after_install_error_code(),
 					sprintf(
@@ -397,19 +481,16 @@ abstract class Installable_Strategy extends Abstract_Strategy {
 		try {
 			$result = $operation();
 		} catch ( \Throwable $e ) {
-			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Intentionally logging.
-				error_log(
-					sprintf(
-						'Uplink: fatal error %s "%s": %s %s:%s',
-						$is_update ? 'updating' : 'installing',
-						$this->feature->get_slug(),
-						$e->getMessage(),
-						$e->getFile(),
-						$e->getLine()
-					)
-				);
-			}
+			static::debug_log(
+				sprintf(
+					'Fatal error %s "%s": %s %s:%s',
+					$is_update ? 'updating' : 'installing',
+					$this->feature->get_slug(),
+					$e->getMessage(),
+					$e->getFile(),
+					$e->getLine()
+				)
+			);
 
 			return new WP_Error(
 				$error_code,

--- a/src/Uplink/Features/Strategy/Plugin_Strategy.php
+++ b/src/Uplink/Features/Strategy/Plugin_Strategy.php
@@ -103,6 +103,13 @@ class Plugin_Strategy extends Installable_Strategy {
 	 * @return true|WP_Error
 	 */
 	protected function do_install() {
+		static::debug_log(
+			sprintf(
+				'Fetching plugin info for "%s" via plugins_api().',
+				$this->feature->get_slug()
+			)
+		);
+
 		$plugin_info = plugins_api(
 			'plugin_information',
 			[
@@ -138,6 +145,14 @@ class Plugin_Strategy extends Installable_Strategy {
 		$upgrader      = new Plugin_Upgrader( $skin );
 		$download_link = Cast::to_string( $plugin_info->download_link );
 
+		static::debug_log(
+			sprintf(
+				'Installing plugin "%s" from %s.',
+				$this->feature->get_slug(),
+				$download_link
+			)
+		);
+
 		return $this->run_upgrader(
 			static function () use ( $upgrader, $download_link ) {
 				return $upgrader->install( $download_link );
@@ -160,6 +175,14 @@ class Plugin_Strategy extends Installable_Strategy {
 	 * @return true|WP_Error
 	 */
 	protected function do_activate() {
+		static::debug_log(
+			sprintf(
+				'Activating plugin "%s" (%s).',
+				$this->feature->get_slug(),
+				$this->feature->get_plugin_file()
+			)
+		);
+
 		$plugin_file = $this->feature->get_plugin_file();
 		$completed   = false;
 		$die_output  = '';
@@ -237,10 +260,15 @@ class Plugin_Strategy extends Installable_Strategy {
 				ob_end_clean();
 			}
 
-			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Intentionally logging.
-				error_log( "Uplink: fatal error activating plugin \"{$this->feature->get_slug()}\": {$e->getMessage()} {$e->getFile()}:{$e->getLine()}" );
-			}
+			static::debug_log(
+				sprintf(
+					'Fatal error activating plugin "%s": %s %s:%s',
+					$this->feature->get_slug(),
+					$e->getMessage(),
+					$e->getFile(),
+					$e->getLine()
+				)
+			);
 
 			return new WP_Error(
 				Error_Code::ACTIVATION_FATAL,
@@ -304,8 +332,20 @@ class Plugin_Strategy extends Installable_Strategy {
 
 		// Idempotent: if already inactive, bail.
 		if ( ! $this->check_active() ) {
+			static::debug_log(
+				sprintf( 'Plugin "%s" already inactive.', $this->feature->get_slug() )
+			);
+
 			return true;
 		}
+
+		static::debug_log(
+			sprintf(
+				'Deactivating plugin "%s" (%s).',
+				$this->feature->get_slug(),
+				$plugin_file
+			)
+		);
 
 		// deactivate_plugins() returns void — it never errors. We verify the
 		// actual state afterward to confirm deactivation succeeded.
@@ -337,6 +377,10 @@ class Plugin_Strategy extends Installable_Strategy {
 	 * @return true|WP_Error
 	 */
 	protected function do_update() {
+		static::debug_log(
+			sprintf( 'Running plugin upgrade for "%s".', $this->feature->get_slug() )
+		);
+
 		$skin        = new WP_Ajax_Upgrader_Skin();
 		$upgrader    = new Plugin_Upgrader( $skin );
 		$plugin_file = $this->feature->get_plugin_file();

--- a/src/Uplink/Features/Strategy/Theme_Strategy.php
+++ b/src/Uplink/Features/Strategy/Theme_Strategy.php
@@ -79,6 +79,13 @@ class Theme_Strategy extends Installable_Strategy {
 	 * @return true|WP_Error
 	 */
 	protected function do_install() {
+		static::debug_log(
+			sprintf(
+				'Fetching theme info for "%s" via themes_api().',
+				$this->feature->get_slug()
+			)
+		);
+
 		$theme_info = themes_api(
 			'theme_information',
 			[
@@ -113,6 +120,14 @@ class Theme_Strategy extends Installable_Strategy {
 		$skin          = new WP_Ajax_Upgrader_Skin();
 		$upgrader      = new Theme_Upgrader( $skin );
 		$download_link = Cast::to_string( $theme_info->download_link );
+
+		static::debug_log(
+			sprintf(
+				'Installing theme "%s" from %s.',
+				$this->feature->get_slug(),
+				$download_link
+			)
+		);
 
 		return $this->run_upgrader(
 			static function () use ( $upgrader, $download_link ) {
@@ -152,8 +167,19 @@ class Theme_Strategy extends Installable_Strategy {
 	 */
 	protected function do_deactivate() {
 		if ( ! $this->check_installed() ) {
+			static::debug_log(
+				sprintf( 'Theme "%s" not installed, already disabled.', $this->feature->get_slug() )
+			);
+
 			return true;
 		}
+
+		static::debug_log(
+			sprintf(
+				'Theme "%s" is on disk, cannot deactivate programmatically.',
+				$this->feature->get_slug()
+			)
+		);
 
 		return new WP_Error(
 			Error_Code::THEME_DELETE_REQUIRED,
@@ -173,6 +199,10 @@ class Theme_Strategy extends Installable_Strategy {
 	 * @return true|WP_Error
 	 */
 	protected function do_update() {
+		static::debug_log(
+			sprintf( 'Running theme upgrade for "%s".', $this->feature->get_slug() )
+		);
+
 		$skin     = new WP_Ajax_Upgrader_Skin();
 		$upgrader = new Theme_Upgrader( $skin );
 		$slug     = $this->feature->get_slug();

--- a/src/Uplink/Features/Update/Plugin_Handler.php
+++ b/src/Uplink/Features/Update/Plugin_Handler.php
@@ -6,6 +6,7 @@ use StellarWP\Uplink\Features\Contracts\Installable;
 use StellarWP\Uplink\Features\Feature_Repository;
 use StellarWP\Uplink\Features\Types\Feature;
 use StellarWP\Uplink\Licensing\License_Manager;
+use StellarWP\Uplink\Traits\With_Debugging;
 use stdClass;
 use StellarWP\Uplink\Utils\Cast;
 
@@ -19,6 +20,8 @@ use StellarWP\Uplink\Utils\Cast;
  * @since 3.0.0
  */
 class Plugin_Handler {
+
+	use With_Debugging;
 
 	/**
 	 * The update data resolver.
@@ -97,24 +100,42 @@ class Plugin_Handler {
 		$features = $this->feature_repository->get();
 
 		if ( is_wp_error( $features ) ) {
+			static::debug_log_wp_error(
+				$features,
+				'Plugin_Handler::filter_plugins_api: feature repository failed'
+			);
+
 			return $result;
 		}
 
 		$feature = $features->get( $slug );
 
+		if ( $feature === null ) {
+			return $result;
+		}
+
 		if (
-			$feature === null
-			|| (
-				$feature instanceof Installable
-				&& $feature->is_dot_org() // Dot-org features are served by WordPress.org.
-			)
+			$feature instanceof Installable
+			&& $feature->is_dot_org()
 		) {
 			return $result;
 		}
 
 		$response = ( $this->resolver )( Feature::TYPE_PLUGIN );
 
-		if ( is_wp_error( $response ) || empty( $response[ $slug ] ) ) {
+		if ( is_wp_error( $response ) ) {
+			static::debug_log_wp_error(
+				$response,
+				sprintf(
+					'Plugin_Handler::filter_plugins_api: resolver failed for "%s"',
+					$slug
+				)
+			);
+
+			return $result;
+		}
+
+		if ( empty( $response[ $slug ] ) ) {
 			return $result;
 		}
 
@@ -141,7 +162,16 @@ class Plugin_Handler {
 
 		$response = ( $this->resolver )( Feature::TYPE_PLUGIN );
 
-		if ( is_wp_error( $response ) || empty( $response ) ) {
+		if ( is_wp_error( $response ) ) {
+			static::debug_log_wp_error(
+				$response,
+				'Plugin_Handler::filter_update_check: resolver failed'
+			);
+
+			return $transient;
+		}
+
+		if ( empty( $response ) ) {
 			return $transient;
 		}
 

--- a/src/Uplink/Features/Update/Resolve_Update_Data.php
+++ b/src/Uplink/Features/Update/Resolve_Update_Data.php
@@ -7,6 +7,7 @@ use StellarWP\Uplink\Catalog\Catalog_Repository;
 use StellarWP\Uplink\Catalog\Results\Catalog_Feature;
 use StellarWP\Uplink\Features\Contracts\Installable;
 use StellarWP\Uplink\Features\Feature_Repository;
+use StellarWP\Uplink\Traits\With_Debugging;
 use WP_Error;
 
 /**
@@ -26,6 +27,8 @@ use WP_Error;
  * @since 3.0.0
  */
 class Resolve_Update_Data {
+
+	use With_Debugging;
 
 	/**
 	 * The feature repository.
@@ -77,20 +80,28 @@ class Resolve_Update_Data {
 		$features = $this->feature_repository->get();
 
 		if ( is_wp_error( $features ) ) {
+			static::debug_log_wp_error(
+				$features,
+				'Resolve_Update_Data: feature repository failed'
+			);
+
 			return $features;
 		}
 
 		$catalog = $this->catalog_repository->get();
 
 		if ( is_wp_error( $catalog ) ) {
+			static::debug_log_wp_error(
+				$catalog,
+				'Resolve_Update_Data: catalog repository failed'
+			);
+
 			return $catalog;
 		}
 
 		$catalog_features = $this->build_catalog_feature_map( $catalog );
-
-		$available = $features->filter( null, null, true, $type );
-
-		$updates = [];
+		$available        = $features->filter( null, null, true, $type );
+		$updates          = [];
 
 		foreach ( $available as $feature ) {
 			if ( ! $feature instanceof Installable ) {

--- a/src/Uplink/Features/Update/Theme_Handler.php
+++ b/src/Uplink/Features/Update/Theme_Handler.php
@@ -6,6 +6,7 @@ use StellarWP\Uplink\Features\Contracts\Installable;
 use StellarWP\Uplink\Features\Feature_Repository;
 use StellarWP\Uplink\Features\Types\Feature;
 use StellarWP\Uplink\Licensing\License_Manager;
+use StellarWP\Uplink\Traits\With_Debugging;
 use stdClass;
 use StellarWP\Uplink\Utils\Cast;
 
@@ -19,6 +20,8 @@ use StellarWP\Uplink\Utils\Cast;
  * @since 3.0.0
  */
 class Theme_Handler {
+
+	use With_Debugging;
 
 	/**
 	 * The update data resolver.
@@ -97,24 +100,42 @@ class Theme_Handler {
 		$features = $this->feature_repository->get();
 
 		if ( is_wp_error( $features ) ) {
+			static::debug_log_wp_error(
+				$features,
+				'Theme_Handler::filter_themes_api: feature repository failed'
+			);
+
 			return $result;
 		}
 
 		$feature = $features->get( $slug );
 
+		if ( $feature === null ) {
+			return $result;
+		}
+
 		if (
-			$feature === null
-			|| (
-				$feature instanceof Installable
-				&& $feature->is_dot_org() // Dot-org features are served by WordPress.org.
-			)
+			$feature instanceof Installable
+			&& $feature->is_dot_org()
 		) {
 			return $result;
 		}
 
 		$response = ( $this->resolver )( Feature::TYPE_THEME );
 
-		if ( is_wp_error( $response ) || empty( $response[ $slug ] ) ) {
+		if ( is_wp_error( $response ) ) {
+			static::debug_log_wp_error(
+				$response,
+				sprintf(
+					'Theme_Handler::filter_themes_api: resolver failed for "%s"',
+					$slug
+				)
+			);
+
+			return $result;
+		}
+
+		if ( empty( $response[ $slug ] ) ) {
 			return $result;
 		}
 
@@ -141,7 +162,16 @@ class Theme_Handler {
 
 		$response = ( $this->resolver )( Feature::TYPE_THEME );
 
-		if ( is_wp_error( $response ) || empty( $response ) ) {
+		if ( is_wp_error( $response ) ) {
+			static::debug_log_wp_error(
+				$response,
+				'Theme_Handler::filter_update_check: resolver failed'
+			);
+
+			return $transient;
+		}
+
+		if ( empty( $response ) ) {
 			return $transient;
 		}
 

--- a/src/Uplink/Licensing/Clients/Http_Client.php
+++ b/src/Uplink/Licensing/Clients/Http_Client.php
@@ -9,6 +9,7 @@ use Psr\Http\Message\StreamFactoryInterface;
 use StellarWP\Uplink\Licensing\Error_Code;
 use StellarWP\Uplink\Licensing\Results\Product_Entry;
 use StellarWP\Uplink\Licensing\Results\Validation_Result;
+use StellarWP\Uplink\Traits\With_Debugging;
 use WP_Error;
 
 /**
@@ -17,6 +18,8 @@ use WP_Error;
  * @since 3.0.0
  */
 final class Http_Client implements Licensing_Client {
+
+	use With_Debugging;
 
 	/**
 	 * The PSR-18 HTTP client.
@@ -87,6 +90,13 @@ final class Http_Client implements Licensing_Client {
 	 * @return Product_Entry[]|WP_Error
 	 */
 	public function get_products( string $key, string $domain ) {
+		self::debug_log(
+			sprintf(
+				'Licensing HTTP request: GET products for domain "%s".',
+				$domain
+			)
+		);
+
 		$query = http_build_query(
 			[
 				'key'    => $key,
@@ -102,6 +112,13 @@ final class Http_Client implements Licensing_Client {
 		try {
 			$response = $this->client->sendRequest( $request );
 		} catch ( ClientExceptionInterface $e ) {
+			self::debug_log(
+				sprintf(
+					'Licensing HTTP exception (get_products): %s',
+					$e->getMessage()
+				)
+			);
+
 			return new WP_Error(
 				Error_Code::INVALID_RESPONSE,
 				$e->getMessage(),
@@ -110,6 +127,10 @@ final class Http_Client implements Licensing_Client {
 		}
 
 		$status_code = $response->getStatusCode();
+
+		self::debug_log(
+			sprintf( 'Licensing HTTP response (get_products): %d', $status_code )
+		);
 
 		if ( $status_code < 200 || $status_code >= 300 ) {
 			return $this->error_from_response(
@@ -121,6 +142,8 @@ final class Http_Client implements Licensing_Client {
 		$data = json_decode( (string) $response->getBody(), true );
 
 		if ( ! is_array( $data ) || ! isset( $data['products'] ) || ! is_array( $data['products'] ) ) {
+			self::debug_log( 'Licensing response body could not be decoded as JSON.' );
+
 			return new WP_Error(
 				Error_Code::INVALID_RESPONSE,
 				'License response could not be decoded.',
@@ -151,6 +174,14 @@ final class Http_Client implements Licensing_Client {
 	 * @return Validation_Result|WP_Error
 	 */
 	public function validate( string $key, string $domain, string $product_slug ) {
+		self::debug_log(
+			sprintf(
+				'Licensing HTTP request: POST validate for product "%s" on domain "%s".',
+				$product_slug,
+				$domain
+			)
+		);
+
 		$request = $this->request_factory->createRequest(
 			'POST',
 			$this->base_url . '/stellarwp/v4/licenses/validate'
@@ -173,6 +204,13 @@ final class Http_Client implements Licensing_Client {
 		try {
 			$response = $this->client->sendRequest( $request );
 		} catch ( ClientExceptionInterface $e ) {
+			self::debug_log(
+				sprintf(
+					'Licensing HTTP exception (validate): %s',
+					$e->getMessage()
+				)
+			);
+
 			return new WP_Error(
 				Error_Code::INVALID_RESPONSE,
 				$e->getMessage(),
@@ -181,6 +219,10 @@ final class Http_Client implements Licensing_Client {
 		}
 
 		$status_code = $response->getStatusCode();
+
+		self::debug_log(
+			sprintf( 'Licensing HTTP response (validate): %d', $status_code )
+		);
 
 		if ( $status_code < 200 || $status_code >= 300 ) {
 			return $this->error_from_response(
@@ -192,6 +234,8 @@ final class Http_Client implements Licensing_Client {
 		$data = json_decode( (string) $response->getBody(), true );
 
 		if ( ! is_array( $data ) || ! isset( $data['status'] ) ) {
+			self::debug_log( 'Validation response body could not be decoded as JSON.' );
+
 			return new WP_Error(
 				Error_Code::INVALID_RESPONSE,
 				'Validation response could not be decoded.',

--- a/src/Uplink/Licensing/License_Manager.php
+++ b/src/Uplink/Licensing/License_Manager.php
@@ -8,6 +8,7 @@ use StellarWP\Uplink\Licensing\Registry\Product_Registry;
 use StellarWP\Uplink\Licensing\Repositories\License_Repository;
 use StellarWP\Uplink\Licensing\Results\Product_Entry;
 use StellarWP\Uplink\Licensing\Results\Validation_Result;
+use StellarWP\Uplink\Traits\With_Debugging;
 use WP_Error;
 
 /**
@@ -31,6 +32,8 @@ use WP_Error;
  * @since 3.0.0
  */
 class License_Manager {
+
+	use With_Debugging;
 
 	/**
 	 * How long (in seconds) to suppress outbound API calls after a failure.
@@ -125,8 +128,17 @@ class License_Manager {
 	 */
 	public function store_key( string $key, bool $network = false ): bool {
 		if ( ! License_Key::is_valid_format( $key ) ) {
+			static::debug_log( 'Rejected license key: invalid format.' );
+
 			return false;
 		}
+
+		static::debug_log(
+			sprintf(
+				'Storing license key (network: %s).',
+				$network ? 'yes' : 'no'
+			)
+		);
 
 		return $this->repository->store_key( $key, $network );
 	}
@@ -146,7 +158,16 @@ class License_Manager {
 	 * @return Product_Entry[]|WP_Error The product list on success, WP_Error on failure.
 	 */
 	public function validate_and_store( string $key, string $domain, bool $network = false ) {
+		static::debug_log(
+			sprintf(
+				'Validating and storing license key for domain "%s".',
+				$domain
+			)
+		);
+
 		if ( ! License_Key::is_valid_format( $key ) ) {
+			static::debug_log( 'Validate-and-store rejected: invalid key format.' );
+
 			return new WP_Error(
 				Error_Code::INVALID_KEY,
 				__( 'The license key format is invalid.', '%TEXTDOMAIN%' ),
@@ -157,6 +178,13 @@ class License_Manager {
 		$throttled = $this->get_throttled_error();
 
 		if ( $throttled !== null ) {
+			static::debug_log(
+				sprintf(
+					'Validate-and-store throttled: %s',
+					$throttled->get_error_message()
+				)
+			);
+
 			return $throttled;
 		}
 
@@ -164,6 +192,14 @@ class License_Manager {
 		$result = $this->client->get_products( $key, $domain );
 
 		if ( is_wp_error( $result ) ) {
+			static::debug_log(
+				sprintf(
+					'Validate-and-store API failed: [%s] %s',
+					$result->get_error_code(),
+					$result->get_error_message()
+				)
+			);
+
 			$data = $result->get_error_data();
 
 			if ( ! is_array( $data ) || empty( $data['status'] ) ) {
@@ -175,15 +211,26 @@ class License_Manager {
 			return $result;
 		}
 
+		static::debug_log(
+			sprintf(
+				'License validated, %d product(s) returned.',
+				count( $result )
+			)
+		);
+
 		$this->repository->set_products( Product_Collection::from_array( $result ) );
 
 		if ( ! $this->repository->store_key( $key, $network ) ) {
+			static::debug_log( 'Failed to persist license key to repository.' );
+
 			return new WP_Error(
 				Error_Code::STORE_FAILED,
 				__( 'The license key could not be stored.', '%TEXTDOMAIN%' ),
 				[ 'status' => 500 ]
 			);
 		}
+
+		static::debug_log( 'License key validated and stored successfully.' );
 
 		return $result;
 	}
@@ -203,9 +250,19 @@ class License_Manager {
 	 * @return Validation_Result|WP_Error
 	 */
 	public function validate_product( string $domain, string $product_slug ) {
+		static::debug_log(
+			sprintf(
+				'Validating product "%s" on domain "%s".',
+				$product_slug,
+				$domain
+			)
+		);
+
 		$key = $this->get_key();
 
 		if ( $key === null ) {
+			static::debug_log( 'Cannot validate product: no license key stored.' );
+
 			return new WP_Error(
 				Error_Code::INVALID_KEY,
 				__( 'No license key is stored.', '%TEXTDOMAIN%' ),
@@ -216,12 +273,27 @@ class License_Manager {
 		$throttled = $this->get_throttled_error();
 
 		if ( $throttled !== null ) {
+			static::debug_log(
+				sprintf(
+					'Product validation throttled: %s',
+					$throttled->get_error_message()
+				)
+			);
+
 			return $throttled;
 		}
 
 		$result = $this->client->validate( $key, $domain, $product_slug );
 
 		if ( is_wp_error( $result ) ) {
+			static::debug_log(
+				sprintf(
+					'Product validation API failed: [%s] %s',
+					$result->get_error_code(),
+					$result->get_error_message()
+				)
+			);
+
 			$data = $result->get_error_data();
 
 			if ( ! is_array( $data ) || empty( $data['status'] ) ) {
@@ -234,8 +306,23 @@ class License_Manager {
 		}
 
 		if ( ! $result->is_valid() ) {
+			static::debug_log(
+				sprintf(
+					'Product validation failed for "%s": %s',
+					$product_slug,
+					$result->get_status()
+				)
+			);
+
 			return $result->to_wp_error();
 		}
+
+		static::debug_log(
+			sprintf(
+				'Product "%s" validated successfully, refreshing product cache.',
+				$product_slug
+			)
+		);
 
 		$this->fetch_and_cache( $key, $domain );
 
@@ -252,6 +339,13 @@ class License_Manager {
 	 * @return bool Whether the key was successfully deleted.
 	 */
 	public function delete_key( bool $network = false ): bool {
+		static::debug_log(
+			sprintf(
+				'Deleting license key (network: %s).',
+				$network ? 'yes' : 'no'
+			)
+		);
+
 		return $this->repository->delete_key( $network );
 	}
 
@@ -298,6 +392,13 @@ class License_Manager {
 		$throttled = $this->get_throttled_error();
 
 		if ( $throttled !== null ) {
+			static::debug_log(
+				sprintf(
+					'Products fetch throttled: %s',
+					$throttled->get_error_message()
+				)
+			);
+
 			return $throttled;
 		}
 
@@ -431,6 +532,14 @@ class License_Manager {
 		$result = $this->client->get_products( $key, $domain );
 
 		if ( is_wp_error( $result ) ) {
+			static::debug_log(
+				sprintf(
+					'Products fetch failed: [%s] %s',
+					$result->get_error_code(),
+					$result->get_error_message()
+				)
+			);
+
 			$this->repository->set_products( $result );
 
 			return $result;

--- a/src/Uplink/Traits/With_Debugging.php
+++ b/src/Uplink/Traits/With_Debugging.php
@@ -2,6 +2,9 @@
 
 namespace StellarWP\Uplink\Traits;
 
+use Throwable;
+use WP_Error;
+
 trait With_Debugging {
 
 	/**
@@ -11,5 +14,61 @@ trait With_Debugging {
 	 */
 	protected function is_wp_debug(): bool {
 		return defined( 'WP_DEBUG' ) && WP_DEBUG;
+	}
+
+	/**
+	 * Log a debug message when WP_DEBUG is enabled.
+	 *
+	 * All messages are prefixed with "Uplink:" for easy filtering in the debug log.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $message The message to log.
+	 *
+	 * @return void
+	 */
+	protected static function debug_log( string $message ): void {
+		// Inline check for WP_DEBUG instead of using the `is_wp_debug()` method here because `is_wp_debug()` is not static and we don't want to change it because of the backwards compatibility.
+		if (
+			! defined( 'WP_DEBUG' )
+			|| ! WP_DEBUG
+		) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Intentionally logging debug info.
+		error_log( 'Uplink: ' . $message );
+	}
+
+	/**
+	 * Log a Throwable with context when WP_DEBUG is enabled.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param Throwable $e       The Throwable to log.
+	 * @param string    $context A short description of where the error occurred.
+	 *
+	 * @return void
+	 */
+	protected static function debug_log_throwable( Throwable $e, string $context ): void {
+		static::debug_log(
+			"{$context}: {$e->getMessage()} {$e->getFile()}:{$e->getLine()} {$e->getTraceAsString()}"
+		);
+	}
+
+	/**
+	 * Log a WP_Error with context when WP_DEBUG is enabled.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param WP_Error $error   The WP_Error to log.
+	 * @param string   $context A short description of where the error occurred.
+	 *
+	 * @return void
+	 */
+	protected static function debug_log_wp_error( WP_Error $error, string $context ): void {
+		static::debug_log(
+			"{$context}: [{$error->get_error_code()}] {$error->get_error_message()}"
+		);
 	}
 }

--- a/tests/wpunit/Traits/With_DebuggingTest.php
+++ b/tests/wpunit/Traits/With_DebuggingTest.php
@@ -1,0 +1,204 @@
+<?php declare( strict_types=1 );
+
+namespace StellarWP\Uplink\Tests\Traits;
+
+use RuntimeException;
+use StellarWP\Uplink\Tests\UplinkTestCase;
+use StellarWP\Uplink\Traits\With_Debugging;
+use WP_Error;
+
+/**
+ * Tests for the With_Debugging trait.
+ *
+ * Uses uopz to toggle WP_DEBUG and capture error_log() calls so we can
+ * assert both the gating logic and the message format without side effects.
+ */
+final class With_DebuggingTest extends UplinkTestCase {
+
+	use With_Uopz;
+
+	/**
+	 * Concrete class exposing the trait's protected methods for testing.
+	 *
+	 * @var object
+	 */
+	private $subject;
+
+	/**
+	 * Messages captured from error_log() via uopz.
+	 *
+	 * @var string[]
+	 */
+	private array $logged = [];
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->subject = new class() {
+			use With_Debugging;
+
+			/**
+			 * Expose is_wp_debug() for assertions.
+			 */
+			public function call_is_wp_debug(): bool {
+				return $this->is_wp_debug();
+			}
+
+			/**
+			 * Expose debug_log() for assertions.
+			 */
+			public function call_debug_log( string $message ): void {
+				self::debug_log( $message );
+			}
+
+			/**
+			 * Expose debug_log_throwable() for assertions.
+			 */
+			public function call_debug_log_throwable( \Throwable $e, string $context ): void {
+				self::debug_log_throwable( $e, $context );
+			}
+
+			/**
+			 * Expose debug_log_wp_error() for assertions.
+			 */
+			public function call_debug_log_wp_error( \WP_Error $error, string $context ): void {
+				self::debug_log_wp_error( $error, $context );
+			}
+		};
+
+		$this->logged = [];
+
+		// Capture error_log calls instead of writing to the log file.
+		$logged = &$this->logged;
+		$this->set_fn_return(
+			'error_log',
+			static function ( string $message ) use ( &$logged ): bool {
+				$logged[] = $message;
+
+				return true;
+			},
+			true
+		);
+	}
+
+	// ─── is_wp_debug() ─────────────────────────────────────────────────
+
+	public function test_is_wp_debug_returns_true_when_wp_debug_is_true(): void {
+		$this->set_const_value( 'WP_DEBUG', true );
+
+		$this->assertTrue( $this->subject->call_is_wp_debug() ); // @phpstan-ignore method.notFound
+	}
+
+	public function test_is_wp_debug_returns_false_when_wp_debug_is_false(): void {
+		$this->set_const_value( 'WP_DEBUG', false );
+
+		$this->assertFalse( $this->subject->call_is_wp_debug() ); // @phpstan-ignore method.notFound
+	}
+
+	// ─── debug_log() ───────────────────────────────────────────────────
+
+	public function test_debug_log_writes_to_error_log_when_wp_debug_is_true(): void {
+		$this->set_const_value( 'WP_DEBUG', true );
+
+		$this->subject->call_debug_log( 'Something happened.' ); // @phpstan-ignore method.notFound
+
+		$this->assertCount( 1, $this->logged );
+		$this->assertSame( 'Uplink: Something happened.', $this->logged[0] );
+	}
+
+	public function test_debug_log_does_not_write_when_wp_debug_is_false(): void {
+		$this->set_const_value( 'WP_DEBUG', false );
+
+		$this->subject->call_debug_log( 'Should not appear.' ); // @phpstan-ignore method.notFound
+
+		$this->assertCount( 0, $this->logged );
+	}
+
+	public function test_debug_log_prefixes_message_with_uplink(): void {
+		$this->set_const_value( 'WP_DEBUG', true );
+
+		$this->subject->call_debug_log( 'test message' ); // @phpstan-ignore method.notFound
+
+		$this->assertStringStartsWith( 'Uplink: ', $this->logged[0] );
+	}
+
+	public function test_debug_log_preserves_full_message_after_prefix(): void {
+		$this->set_const_value( 'WP_DEBUG', true );
+
+		$message = 'Fatal error installing "kadence-blocks": file not found';
+		$this->subject->call_debug_log( $message ); // @phpstan-ignore method.notFound
+
+		$this->assertSame( 'Uplink: ' . $message, $this->logged[0] );
+	}
+
+	public function test_debug_log_handles_empty_message(): void {
+		$this->set_const_value( 'WP_DEBUG', true );
+
+		$this->subject->call_debug_log( '' ); // @phpstan-ignore method.notFound
+
+		$this->assertCount( 1, $this->logged );
+		$this->assertSame( 'Uplink: ', $this->logged[0] );
+	}
+
+	public function test_debug_log_multiple_calls_log_multiple_entries(): void {
+		$this->set_const_value( 'WP_DEBUG', true );
+
+		$this->subject->call_debug_log( 'first' ); // @phpstan-ignore method.notFound
+		$this->subject->call_debug_log( 'second' ); // @phpstan-ignore method.notFound
+		$this->subject->call_debug_log( 'third' ); // @phpstan-ignore method.notFound
+
+		$this->assertCount( 3, $this->logged );
+		$this->assertSame( 'Uplink: first', $this->logged[0] );
+		$this->assertSame( 'Uplink: second', $this->logged[1] );
+		$this->assertSame( 'Uplink: third', $this->logged[2] );
+	}
+
+	// ─── debug_log_throwable() ─────────────────────────────────────────
+
+	public function test_debug_log_throwable_logs_message_file_line_and_trace(): void {
+		$this->set_const_value( 'WP_DEBUG', true );
+
+		$exception = new RuntimeException( 'Something broke' );
+
+		$this->subject->call_debug_log_throwable( $exception, 'Catalog sync' ); // @phpstan-ignore method.notFound
+
+		$this->assertCount( 1, $this->logged );
+		$this->assertStringStartsWith( 'Uplink: Catalog sync: Something broke', $this->logged[0] );
+		$this->assertStringContainsString( $exception->getFile() . ':' . $exception->getLine(), $this->logged[0] );
+		$this->assertStringContainsString( $exception->getTraceAsString(), $this->logged[0] );
+	}
+
+	public function test_debug_log_throwable_does_not_log_when_wp_debug_is_false(): void {
+		$this->set_const_value( 'WP_DEBUG', false );
+
+		$this->subject->call_debug_log_throwable( new RuntimeException( 'hidden' ), 'ctx' ); // @phpstan-ignore method.notFound
+
+		$this->assertCount( 0, $this->logged );
+	}
+
+	// ─── debug_log_wp_error() ──────────────────────────────────────────
+
+	public function test_debug_log_wp_error_logs_code_and_message(): void {
+		$this->set_const_value( 'WP_DEBUG', true );
+
+		$error = new WP_Error( 'http_request_failed', 'Connection timed out' );
+
+		$this->subject->call_debug_log_wp_error( $error, 'License check' ); // @phpstan-ignore method.notFound
+
+		$this->assertCount( 1, $this->logged );
+		$this->assertSame(
+			'Uplink: License check: [http_request_failed] Connection timed out',
+			$this->logged[0]
+		);
+	}
+
+	public function test_debug_log_wp_error_does_not_log_when_wp_debug_is_false(): void {
+		$this->set_const_value( 'WP_DEBUG', false );
+
+		$error = new WP_Error( 'fail', 'nope' );
+
+		$this->subject->call_debug_log_wp_error( $error, 'ctx' ); // @phpstan-ignore method.notFound
+
+		$this->assertCount( 0, $this->logged );
+	}
+}


### PR DESCRIPTION
🎫 [SCON-423]

- Updated error logging methods to utilize `debug_log()`, `debug_log_throwable()`, and `debug_log_wp_error()` for consistent logging practices.
- This change improves error tracking and debugging during feature management, licensing, and API interactions.
- I tried to avoid a noisy log, and we can keep adding important logs everywhere, I added what I knew/noticed for now
- There is a weird compatibility thing with the debugger trait, let me know what you think (maybe we want to forget about the trait and use a static class so legacy global functions can use it? I decided to just use it even though it's not perfect)

### Example (enabling and disabling Give)

```
[16-Mar-2026 13:02:20 UTC] WordPress database error Deadlock found when trying to get lock; try restarting transaction for query DELETE FROM `wp_options` WHERE `option_name` = 'stellarwp_uplink_catalog_state' made by require('index.php'), require('wp-blog-header.php'), require_once('wp-load.php'), require_once('wp-config.php'), require_once('wp-settings.php'), do_action('plugins_loaded'), WP_Hook->do_action, WP_Hook->apply_filters, {closure}, UplinkSamplePlugin\Uplink\Fixture_Binder::bind, UplinkSamplePlugin\Uplink\Fixture_Binder::flush_cache, delete_option, QM_DB->query
[16-Mar-2026 13:02:24 UTC] Uplink: Enabling feature "give".
[16-Mar-2026 13:02:24 UTC] Uplink: Fetching plugin info for "give" via plugins_api().
[16-Mar-2026 13:02:25 UTC] Uplink: Installing plugin "give" from https://downloads.wordpress.org/plugin/give.4.14.3.zip.
[16-Mar-2026 13:02:57 UTC] Uplink: Activating plugin "give" (give/give.php).
[16-Mar-2026 13:02:57 UTC] Uplink: Feature "give" enabled successfully.

[16-Mar-2026 13:03:08 UTC] Uplink: Disabling feature "give".
[16-Mar-2026 13:03:08 UTC] Uplink: Deactivating plugin "give" (give/give.php).
[16-Mar-2026 13:03:08 UTC] Uplink: Feature "give" disabled successfully.

```

[SCON-423]: https://stellarwp.atlassian.net/browse/SCON-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

