### PR TITLE
Feature: add legacy admin notices

### DIFF
--- a/src/Uplink/API/REST/V1/Legacy_License_Controller.php
+++ b/src/Uplink/API/REST/V1/Legacy_License_Controller.php
@@ -32,7 +32,7 @@ final class Legacy_License_Controller extends WP_REST_Controller {
 	 *
 	 * @var string
 	 */
-	protected $rest_base = 'license/legacy';
+	protected $rest_base = 'legacy-licenses';
 
 	/**
 	 * The legacy license repository.
@@ -149,9 +149,9 @@ final class Legacy_License_Controller extends WP_REST_Controller {
 					'readonly'    => true,
 					'context'     => [ 'view' ],
 				],
-				'status'     => [
-					'description' => __( 'The license status.', '%TEXTDOMAIN%' ),
-					'type'        => 'string',
+				'is_active'  => [
+					'description' => __( 'Whether the license is currently active.', '%TEXTDOMAIN%' ),
+					'type'        => 'boolean',
 					'readonly'    => true,
 					'context'     => [ 'view' ],
 				],

--- a/src/Uplink/API/REST/V1/Provider.php
+++ b/src/Uplink/API/REST/V1/Provider.php
@@ -20,7 +20,6 @@ final class Provider extends Abstract_Provider {
 		$this->container->singleton( License_Controller::class );
 		$this->container->singleton( Catalog_Controller::class );
 		$this->container->singleton( Legacy_License_Controller::class );
-
 		add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
 	}
 

--- a/src/Uplink/CLI/Commands/License.php
+++ b/src/Uplink/CLI/Commands/License.php
@@ -57,7 +57,7 @@ class License extends WP_CLI_Command {
 	 *
 	 * @var string
 	 */
-	private const DEFAULT_LEGACY_FIELDS = 'slug,name,brand,key,status,expires_at';
+	private const DEFAULT_LEGACY_FIELDS = 'slug,name,brand,key,is_active,expires_at';
 
 	/**
 	 * The license manager instance.

--- a/src/Uplink/Legacy/Admin/License_Notice_Handler.php
+++ b/src/Uplink/Legacy/Admin/License_Notice_Handler.php
@@ -1,0 +1,104 @@
+<?php declare( strict_types=1 );
+
+namespace StellarWP\Uplink\Legacy\Admin;
+
+use StellarWP\Uplink\Legacy\License_Repository;
+use StellarWP\Uplink\Notice\Notice;
+use StellarWP\Uplink\Notice\Notice_Controller;
+use StellarWP\Uplink\Utils\Version;
+
+/**
+ * Displays consolidated admin notices for legacy licenses that are not
+ * covered by a v3 unified license.
+ *
+ * Only fires on the leader Uplink instance to prevent duplicate notices
+ * when multiple plugins bundle Uplink.
+ *
+ * @since 3.0.0
+ */
+class License_Notice_Handler {
+
+	/**
+	 * @var License_Repository
+	 */
+	private $repository;
+
+	/**
+	 * @var Notice_Controller
+	 */
+	private $controller;
+
+	public function __construct( License_Repository $repository, Notice_Controller $controller ) {
+		$this->repository = $repository;
+		$this->controller = $controller;
+	}
+
+	/**
+	 * Display notices for inactive legacy licenses that are not covered by a v3 unified license.
+	 *
+	 * @action admin_notices
+	 *
+	 * @return void
+	 */
+	public function display(): void {
+		if ( ! Version::should_handle( 'legacy_license_notices' ) ) {
+			return;
+		}
+
+		$licenses = $this->repository->all_inactive();
+
+		if ( empty( $licenses ) ) {
+			return;
+		}
+
+		// Group by brand, skipping any slug already covered by v3.
+		$by_brand = [];
+
+		foreach ( $licenses as $license ) {
+			if ( stellarwp_uplink_is_feature_available( $license->slug ) ) {
+				continue;
+			}
+
+			$brand = $license->brand;
+
+			if ( ! isset( $by_brand[ $brand ] ) ) {
+				$by_brand[ $brand ] = [
+					'page_url' => $license->page_url,
+					'count'    => 0,
+				];
+			}
+
+			$by_brand[ $brand ]['count']++;
+		}
+
+		foreach ( $by_brand as $brand => $data ) {
+			$this->render_notice( $brand, $data );
+		}
+	}
+
+	/**
+	 * Render a single brand's license notice.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string                                   $brand
+	 * @param array{page_url: string, count: int} $data
+	 *
+	 * @return void
+	 */
+	private function render_notice( string $brand, array $data ): void {
+		$message = sprintf(
+			_n(
+				'Your %1$s add-on is not receiving critical updates and new features because you have an inactive license. Please <a href="%2$s">activate your license</a> to receive updates.',
+				'Your %1$s add-ons are not receiving critical updates and new features because you have %3$d inactive license keys. Please <a href="%2$s">activate your licenses</a> to receive updates.',
+				$data['count'],
+				'%TEXTDOMAIN%'
+			),
+			ucfirst( $brand ),
+			esc_url( $data['page_url'] ),
+			$data['count']
+		);
+
+		$this->controller->render( ( new Notice( Notice::ERROR, $message ) )->toArray() );
+	}
+}

--- a/src/Uplink/Legacy/Legacy_License.php
+++ b/src/Uplink/Legacy/Legacy_License.php
@@ -42,11 +42,13 @@ class Legacy_License {
 	public string $brand;
 
 	/**
+	 * Whether the license is currently active.
+	 *
 	 * @since 3.0.0
 	 *
-	 * @var string
+	 * @var bool
 	 */
-	public string $status;
+	public bool $is_active;
 
 	/**
 	 * @since 3.0.0
@@ -65,7 +67,7 @@ class Legacy_License {
 	/**
 	 * @since 3.0.0
 	 *
-	 * @return array<string, string>
+	 * @return array<string, mixed>
 	 */
 	public function to_array(): array {
 		return [
@@ -73,7 +75,7 @@ class Legacy_License {
 			'slug'       => $this->slug,
 			'name'       => $this->name,
 			'brand'      => $this->brand,
-			'status'     => $this->status,
+			'is_active'  => $this->is_active,
 			'page_url'   => $this->page_url,
 			'expires_at' => $this->expires_at,
 		];
@@ -91,7 +93,7 @@ class Legacy_License {
 		$self->slug       = Cast::to_string( $data['slug'] ?? '' );
 		$self->name       = Cast::to_string( $data['name'] ?? '' );
 		$self->brand      = Cast::to_string( $data['brand'] ?? '' );
-		$self->status     = Cast::to_string( $data['status'] ?? 'unknown' );
+		$self->is_active  = (bool) ( $data['is_active'] ?? false );
 		$self->page_url   = Cast::to_string( $data['page_url'] ?? '' );
 		$self->expires_at = Cast::to_string( $data['expires_at'] ?? '' );
 

--- a/src/Uplink/Legacy/License_Repository.php
+++ b/src/Uplink/Legacy/License_Repository.php
@@ -53,9 +53,14 @@ class License_Repository {
 	 * @return Legacy_License[]
 	 */
 	public function all_active(): array {
-		return array_values( array_filter( $this->all(), static function ( Legacy_License $l ): bool {
-			return $l->is_active;
-		} ) );
+		return array_values(
+			array_filter(
+				$this->all(),
+				static function ( Legacy_License $l ): bool {
+					return $l->is_active;
+				} 
+			) 
+		);
 	}
 
 	/**
@@ -66,9 +71,14 @@ class License_Repository {
 	 * @return Legacy_License[]
 	 */
 	public function all_inactive(): array {
-		return array_values( array_filter( $this->all(), static function ( Legacy_License $l ): bool {
-			return ! $l->is_active;
-		} ) );
+		return array_values(
+			array_filter(
+				$this->all(),
+				static function ( Legacy_License $l ): bool {
+					return ! $l->is_active;
+				} 
+			) 
+		);
 	}
 
 	/**

--- a/src/Uplink/Legacy/License_Repository.php
+++ b/src/Uplink/Legacy/License_Repository.php
@@ -46,6 +46,32 @@ class License_Repository {
 	}
 
 	/**
+	 * Get all legacy licenses that are currently active.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return Legacy_License[]
+	 */
+	public function all_active(): array {
+		return array_values( array_filter( $this->all(), static function ( Legacy_License $l ): bool {
+			return $l->is_active;
+		} ) );
+	}
+
+	/**
+	 * Get all legacy licenses that are not currently active.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return Legacy_License[]
+	 */
+	public function all_inactive(): array {
+		return array_values( array_filter( $this->all(), static function ( Legacy_License $l ): bool {
+			return ! $l->is_active;
+		} ) );
+	}
+
+	/**
 	 * Get a legacy license by resource slug.
 	 *
 	 * @since 3.0.0

--- a/src/Uplink/Legacy/Notices/License_Notice_Handler.php
+++ b/src/Uplink/Legacy/Notices/License_Notice_Handler.php
@@ -1,10 +1,11 @@
 <?php declare( strict_types=1 );
 
-namespace StellarWP\Uplink\Legacy\Admin;
+namespace StellarWP\Uplink\Legacy\Notices;
 
 use StellarWP\Uplink\Legacy\License_Repository;
 use StellarWP\Uplink\Notice\Notice;
 use StellarWP\Uplink\Notice\Notice_Controller;
+use StellarWP\Uplink\Utils\Cast;
 use StellarWP\Uplink\Utils\Version;
 
 /**
@@ -17,6 +18,20 @@ use StellarWP\Uplink\Utils\Version;
  * @since 3.0.0
  */
 class License_Notice_Handler {
+
+	/**
+	 * User meta key that stores a map of notice ID => dismissed-until timestamp.
+	 *
+	 * @since 3.0.0
+	 */
+	public const DISMISSED_META_KEY = 'stellarwp_uplink_dismissed_notices';
+
+	/**
+	 * How long a dismissal lasts in seconds (7 days).
+	 *
+	 * @since 3.0.0
+	 */
+	public const DISMISS_TTL = 7 * DAY_IN_SECONDS;
 
 	/**
 	 * @var License_Repository
@@ -51,7 +66,7 @@ class License_Notice_Handler {
 			return;
 		}
 
-		// Group by brand, skipping any slug already covered by v3.
+		// Group by brand, skipping any slug already covered by v3 or dismissed by the user.
 		$by_brand = [];
 
 		foreach ( $licenses as $license ) {
@@ -60,9 +75,15 @@ class License_Notice_Handler {
 			}
 
 			$brand = $license->brand;
+			$id    = 'legacy-' . $brand;
+
+			if ( $this->is_dismissed( $id ) ) {
+				continue;
+			}
 
 			if ( ! isset( $by_brand[ $brand ] ) ) {
 				$by_brand[ $brand ] = [
+					'id'       => $id,
 					'page_url' => $license->page_url,
 					'count'    => 0,
 				];
@@ -71,9 +92,30 @@ class License_Notice_Handler {
 			$by_brand[ $brand ]['count']++;
 		}
 
+		if ( empty( $by_brand ) ) {
+			return;
+		}
+
 		foreach ( $by_brand as $brand => $data ) {
 			$this->render_notice( $brand, $data );
 		}
+
+		$this->enqueue_dismiss_script();
+	}
+
+	/**
+	 * Whether a notice is currently dismissed for the current user.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $id The notice ID.
+	 *
+	 * @return bool
+	 */
+	private function is_dismissed( string $id ): bool {
+		$dismissed = (array) get_user_meta( get_current_user_id(), self::DISMISSED_META_KEY, true );
+
+		return isset( $dismissed[ $id ] ) && Cast::to_int( $dismissed[ $id ] ) > time();
 	}
 
 	/**
@@ -81,8 +123,8 @@ class License_Notice_Handler {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string                                   $brand
-	 * @param array{page_url: string, count: int} $data
+	 * @param string                                           $brand
+	 * @param array{id: string, page_url: string, count: int} $data
 	 *
 	 * @return void
 	 */
@@ -99,6 +141,42 @@ class License_Notice_Handler {
 			$data['count']
 		);
 
-		$this->controller->render( ( new Notice( Notice::ERROR, $message ) )->toArray() );
+		$this->controller->render(
+			( new Notice( Notice::ERROR, $message, true, false, false, $data['id'] ) )->toArray()
+		);
+	}
+
+	/**
+	 * Register and enqueue the notice dismiss script, passing config via wp_localize_script.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return void
+	 */
+	private function enqueue_dismiss_script(): void {
+		$handle = 'stellarwp-uplink-notice-dismiss';
+
+		if ( ! wp_script_is( $handle, 'registered' ) ) {
+			$assets_url = trailingslashit( plugin_dir_url( __DIR__ . '/index.php' ) );
+
+			wp_register_script(
+				$handle,
+				$assets_url . 'assets/js/notice-dismiss.js',
+				[ 'wp-api-fetch' ],
+				null,
+				[ 'in_footer' => true ]
+			);
+
+			wp_localize_script(
+				$handle,
+				'uplinkNoticeDismiss',
+				[
+					'ttl'     => self::DISMISS_TTL,
+					'metaKey' => self::DISMISSED_META_KEY,
+				]
+			);
+		}
+
+		wp_enqueue_script( $handle );
 	}
 }

--- a/src/Uplink/Legacy/Notices/License_Notice_Handler.php
+++ b/src/Uplink/Legacy/Notices/License_Notice_Handler.php
@@ -5,6 +5,7 @@ namespace StellarWP\Uplink\Legacy\Notices;
 use StellarWP\Uplink\Legacy\License_Repository;
 use StellarWP\Uplink\Notice\Notice;
 use StellarWP\Uplink\Notice\Notice_Controller;
+use StellarWP\Uplink\Uplink;
 use StellarWP\Uplink\Utils\Cast;
 use StellarWP\Uplink\Utils\Version;
 
@@ -43,6 +44,12 @@ class License_Notice_Handler {
 	 */
 	private $controller;
 
+	/**
+	 * @since 3.0.0
+	 *
+	 * @param License_Repository $repository The license repository.
+	 * @param Notice_Controller  $controller The notice controller.
+	 */
 	public function __construct( License_Repository $repository, Notice_Controller $controller ) {
 		$this->repository = $repository;
 		$this->controller = $controller;
@@ -125,15 +132,16 @@ class License_Notice_Handler {
 	 *
 	 * TODO: Decide on messaging for all brands.
 	 *
-	 * @param string                                          $brand
-	 * @param array{id: string, page_url: string, count: int} $data
+	 * @param string                                          $brand The brand name.
+	 * @param array{id: string, page_url: string, count: int} $data The notice data.
 	 *
 	 * @return void
 	 */
 	private function render_notice( string $brand, array $data ): void {
 		$message = sprintf(
+			/* translators: %1$s is the brand name, %2$s is the page URL, %3$d is the number of inactive licenses. */
 			_n(
-				'You have an inactive %1$s license. Please <a href="%2$s">activate it</a> to receive critical updates and new features.',
+				'You have %3$d inactive %1$s license. Please <a href="%2$s">activate it</a> to receive critical updates and new features.',
 				'You have %3$d inactive %1$s licenses. Please <a href="%2$s">activate them</a> to receive critical updates and new features.',
 				$data['count'],
 				'%TEXTDOMAIN%'
@@ -144,7 +152,7 @@ class License_Notice_Handler {
 		);
 
 		$this->controller->render(
-			( new Notice( Notice::ERROR, $message, true, false, false, $data['id'] ) )->toArray()
+			( new Notice( Notice::ERROR, $message, true, false, false, $data['id'] ) )->to_array()
 		);
 	}
 
@@ -153,7 +161,7 @@ class License_Notice_Handler {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @return void
+	 * @return void Enqueues the notice dismiss script.
 	 */
 	private function enqueue_dismiss_script(): void {
 		$handle = 'stellarwp-uplink-notice-dismiss';
@@ -165,7 +173,7 @@ class License_Notice_Handler {
 				$handle,
 				$assets_url . 'assets/js/notice-dismiss.js',
 				[ 'wp-api-fetch' ],
-				null,
+				Uplink::VERSION,
 				[ 'in_footer' => true ]
 			);
 

--- a/src/Uplink/Legacy/Notices/License_Notice_Handler.php
+++ b/src/Uplink/Legacy/Notices/License_Notice_Handler.php
@@ -89,7 +89,7 @@ class License_Notice_Handler {
 				];
 			}
 
-			$by_brand[ $brand ]['count']++;
+			++$by_brand[ $brand ]['count'];
 		}
 
 		if ( empty( $by_brand ) ) {
@@ -123,7 +123,7 @@ class License_Notice_Handler {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string                                           $brand
+	 * @param string                                          $brand
 	 * @param array{id: string, page_url: string, count: int} $data
 	 *
 	 * @return void

--- a/src/Uplink/Legacy/Notices/License_Notice_Handler.php
+++ b/src/Uplink/Legacy/Notices/License_Notice_Handler.php
@@ -123,6 +123,8 @@ class License_Notice_Handler {
 	 *
 	 * @since 3.0.0
 	 *
+	 * TODO: Decide on messaging for all brands.
+	 *
 	 * @param string                                          $brand
 	 * @param array{id: string, page_url: string, count: int} $data
 	 *
@@ -131,8 +133,8 @@ class License_Notice_Handler {
 	private function render_notice( string $brand, array $data ): void {
 		$message = sprintf(
 			_n(
-				'Your %1$s add-on is not receiving critical updates and new features because you have an inactive license. Please <a href="%2$s">activate your license</a> to receive updates.',
-				'Your %1$s add-ons are not receiving critical updates and new features because you have %3$d inactive license keys. Please <a href="%2$s">activate your licenses</a> to receive updates.',
+				'You have an inactive %1$s license. Please <a href="%2$s">activate it</a> to receive critical updates and new features.',
+				'You have %3$d inactive %1$s licenses. Please <a href="%2$s">activate them</a> to receive critical updates and new features.',
 				$data['count'],
 				'%TEXTDOMAIN%'
 			),

--- a/src/Uplink/Legacy/Notices/License_Notice_Handler.php
+++ b/src/Uplink/Legacy/Notices/License_Notice_Handler.php
@@ -63,6 +63,10 @@ class License_Notice_Handler {
 	 * @return void
 	 */
 	public function display(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
 		if ( ! Version::should_handle( 'legacy_license_notices' ) ) {
 			return;
 		}

--- a/src/Uplink/Legacy/Notices/assets/js/notice-dismiss.js
+++ b/src/Uplink/Legacy/Notices/assets/js/notice-dismiss.js
@@ -15,20 +15,20 @@
 
 		var id = notice.getAttribute( 'data-uplink-notice-id' );
 
-		window.wp.apiFetch( { path: '/wp/v2/users/me' } ).then( function( user ) {
-			var dismissed = Object.assign( {}, user.meta[ META_KEY ] || {} );
-			dismissed[ id ] = Math.floor( Date.now() / 1000 ) + TTL;
-
+		( async function() {
 			try {
-				return window.wp.apiFetch( {
+				var user      = await window.wp.apiFetch( { path: '/wp/v2/users/me' } );
+				var dismissed = Object.assign( {}, user.meta[ META_KEY ] || {} );
+				dismissed[ id ] = Math.floor( Date.now() / 1000 ) + TTL;
+
+				await window.wp.apiFetch( {
 					path:   '/wp/v2/users/me',
 					method: 'PATCH',
 					data:   { meta: { [ META_KEY ]: dismissed } },
 				} );
 			} catch ( error ) {
 				console.error( error );
-				return false;
 			}
-		} );
+		} )();
 	} );
 } )();

--- a/src/Uplink/Legacy/Notices/assets/js/notice-dismiss.js
+++ b/src/Uplink/Legacy/Notices/assets/js/notice-dismiss.js
@@ -1,0 +1,34 @@
+( function() {
+	var config   = window.uplinkNoticeDismiss;
+	var TTL      = config.ttl;
+	var META_KEY = config.metaKey;
+
+	document.addEventListener( 'click', function( e ) {
+		if ( ! e.target.classList.contains( 'notice-dismiss' ) ) {
+			return;
+		}
+
+		var notice = e.target.closest( '[data-uplink-notice-id]' );
+		if ( ! notice ) {
+			return;
+		}
+
+		var id = notice.getAttribute( 'data-uplink-notice-id' );
+
+		window.wp.apiFetch( { path: '/wp/v2/users/me' } ).then( function( user ) {
+			var dismissed = Object.assign( {}, user.meta[ META_KEY ] || {} );
+			dismissed[ id ] = Math.floor( Date.now() / 1000 ) + TTL;
+
+			try {
+				return window.wp.apiFetch( {
+					path:   '/wp/v2/users/me',
+					method: 'PATCH',
+					data:   { meta: { [ META_KEY ]: dismissed } },
+				} );
+			} catch ( error ) {
+				console.error( error );
+				return false;
+			}
+		} );
+	} );
+} )();

--- a/src/Uplink/Legacy/Provider.php
+++ b/src/Uplink/Legacy/Provider.php
@@ -31,6 +31,7 @@ class Provider extends Abstract_Provider {
 		);
 
 		$this->register_dismissed_notices_meta();
+
 		add_action( 'admin_notices', [ $this->container->get( License_Notice_Handler::class ), 'display' ], 10, 0 );
 	}
 

--- a/src/Uplink/Legacy/Provider.php
+++ b/src/Uplink/Legacy/Provider.php
@@ -3,6 +3,8 @@
 namespace StellarWP\Uplink\Legacy;
 
 use StellarWP\Uplink\Contracts\Abstract_Provider;
+use StellarWP\Uplink\Legacy\Admin\License_Notice_Handler;
+use StellarWP\Uplink\Notice\Notice_Controller;
 
 /**
  * Registers services for legacy license discovery.
@@ -16,5 +18,17 @@ class Provider extends Abstract_Provider {
 	 */
 	public function register(): void {
 		$this->container->singleton( License_Repository::class, License_Repository::class );
+
+		$this->container->singleton(
+			License_Notice_Handler::class,
+			static function ( $c ): License_Notice_Handler {
+				return new License_Notice_Handler(
+					$c->get( License_Repository::class ),
+					$c->get( Notice_Controller::class )
+				);
+			}
+		);
+
+		add_action( 'admin_notices', [ $this->container->get( License_Notice_Handler::class ), 'display' ], 10, 0 );
 	}
 }

--- a/src/Uplink/Legacy/Provider.php
+++ b/src/Uplink/Legacy/Provider.php
@@ -2,8 +2,9 @@
 
 namespace StellarWP\Uplink\Legacy;
 
+use StellarWP\ContainerContract\ContainerInterface;
 use StellarWP\Uplink\Contracts\Abstract_Provider;
-use StellarWP\Uplink\Legacy\Admin\License_Notice_Handler;
+use StellarWP\Uplink\Legacy\Notices\License_Notice_Handler;
 use StellarWP\Uplink\Notice\Notice_Controller;
 
 /**
@@ -21,7 +22,7 @@ class Provider extends Abstract_Provider {
 
 		$this->container->singleton(
 			License_Notice_Handler::class,
-			static function ( $c ): License_Notice_Handler {
+			static function ( ContainerInterface $c ): License_Notice_Handler {
 				return new License_Notice_Handler(
 					$c->get( License_Repository::class ),
 					$c->get( Notice_Controller::class )
@@ -29,6 +30,38 @@ class Provider extends Abstract_Provider {
 			}
 		);
 
+		$this->register_dismissed_notices_meta();
 		add_action( 'admin_notices', [ $this->container->get( License_Notice_Handler::class ), 'display' ], 10, 0 );
+	}
+
+	/**
+	 * Register the user meta field that tracks dismissed notice IDs and their
+	 * expiry timestamps, exposed via the REST API for JS to read and update.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return void
+	 */
+	public function register_dismissed_notices_meta(): void {
+		register_meta(
+			'user',
+			License_Notice_Handler::DISMISSED_META_KEY,
+			[
+				'type'         => 'object',
+				'single'       => true,
+				'default'      => [],
+				'show_in_rest' => [
+					'schema' => [
+						'type'                 => 'object',
+						'additionalProperties' => [
+							'type' => 'integer',
+						],
+					],
+				],
+				'auth_callback' => static function (): bool {
+					return is_user_logged_in();
+				},
+			]
+		);
 	}
 }

--- a/src/Uplink/Legacy/Provider.php
+++ b/src/Uplink/Legacy/Provider.php
@@ -48,10 +48,10 @@ class Provider extends Abstract_Provider {
 			'user',
 			License_Notice_Handler::DISMISSED_META_KEY,
 			[
-				'type'         => 'object',
-				'single'       => true,
-				'default'      => [],
-				'show_in_rest' => [
+				'type'          => 'object',
+				'single'        => true,
+				'default'       => [],
+				'show_in_rest'  => [
 					'schema' => [
 						'type'                 => 'object',
 						'additionalProperties' => [

--- a/src/Uplink/Notice/Notice.php
+++ b/src/Uplink/Notice/Notice.php
@@ -59,18 +59,27 @@ final class Notice {
 	private $large;
 
 	/**
-	 * @param string $type  The notice type, one of the above constants.
-	 * @param string $message  The already translated message to display.
-	 * @param bool   $dismissible  Whether this notice is dismissible.
-	 * @param bool   $alt  Whether this is an alt-notice.
-	 * @param bool   $large  Whether this should be a large notice.
+	 * Optional unique identifier used for persistent dismissal.
+	 *
+	 * @var string
+	 */
+	private $id;
+
+	/**
+	 * @param string $type        The notice type, one of the above constants.
+	 * @param string $message     The already translated message to display.
+	 * @param bool   $dismissible Whether this notice is dismissible.
+	 * @param bool   $alt         Whether this is an alt-notice.
+	 * @param bool   $large       Whether this should be a large notice.
+	 * @param string $id          Optional unique ID for persistent dismissal.
 	 */
 	public function __construct(
 		string $type,
 		string $message,
 		bool $dismissible = false,
 		bool $alt = false,
-		bool $large = false
+		bool $large = false,
+		string $id = ''
 	) {
 		if ( ! in_array( $type, self::ALLOWED_TYPES, true ) ) {
 			throw new InvalidArgumentException(
@@ -90,12 +99,20 @@ final class Notice {
 		$this->dismissible = $dismissible;
 		$this->alt         = $alt;
 		$this->large       = $large;
+		$this->id          = $id;
 	}
 
 	/**
-	 * @return array{type: string, message: string, dismissible: bool, alt: bool, large: bool}
+	 * @return array{type: string, message: string, dismissible: bool, alt: bool, large: bool, id: string}
 	 */
 	public function toArray(): array {
-		return get_object_vars( $this );
+		return [
+			'type'        => $this->type,
+			'message'     => $this->message,
+			'dismissible' => $this->dismissible,
+			'alt'         => $this->alt,
+			'large'       => $this->large,
+			'id'          => $this->id,
+		];
 	}
 }

--- a/src/Uplink/Notice/Notice.php
+++ b/src/Uplink/Notice/Notice.php
@@ -72,6 +72,8 @@ final class Notice {
 	 * @param bool   $alt         Whether this is an alt-notice.
 	 * @param bool   $large       Whether this should be a large notice.
 	 * @param string $id          Optional unique ID for persistent dismissal.
+	 *
+	 * @throws InvalidArgumentException If the type is not one of the allowed types or the message is empty.
 	 */
 	public function __construct(
 		string $type,
@@ -84,14 +86,18 @@ final class Notice {
 		if ( ! in_array( $type, self::ALLOWED_TYPES, true ) ) {
 			throw new InvalidArgumentException(
 				sprintf(
+					/* translators: %s is the list of allowed notice types. */
 					__( 'Notice $type must be one of: %s', '%TEXTDOMAIN%' ),
-					implode( ', ', self::ALLOWED_TYPES ) 
+					implode( ', ', self::ALLOWED_TYPES )
 				)
 			);
 		}
 
 		if ( empty( $message ) ) {
-			throw new InvalidArgumentException( __( 'The $message cannot be empty', '%TEXTDOMAIN%' ) );
+			throw new InvalidArgumentException(
+				/* translators: %s is the list of allowed notice types. */
+				__( 'The $message cannot be empty', '%TEXTDOMAIN%' )
+			);
 		}
 
 		$this->type        = $type;
@@ -103,9 +109,19 @@ final class Notice {
 	}
 
 	/**
-	 * @return array{type: string, message: string, dismissible: bool, alt: bool, large: bool, id: string}
+	 * @deprecated 3.0.0 Use to_array() instead.
+	 * @return array<mixed>
 	 */
 	public function toArray(): array {
+		return get_object_vars( $this );
+	}
+
+	/**
+	 * @since 3.0.0
+	 *
+	 * @return array{type: string, message: string, dismissible: bool, alt: bool, large: bool, id: string}
+	 */
+	public function to_array(): array {
 		return [
 			'type'        => $this->type,
 			'message'     => $this->message,

--- a/src/Uplink/Notice/Notice_Controller.php
+++ b/src/Uplink/Notice/Notice_Controller.php
@@ -43,12 +43,12 @@ final class Notice_Controller extends Controller {
 			$large ? 'notice-large' : '',
 		];
 
-		echo $this->view->render(
+		$this->view->display(
 			self::VIEW,
 			[
 				'message'           => $message,
-				'id'                => $id,
-				'classes'           => $this->classes( $classes ),
+				'id'                => esc_attr( $id ),
+				'classes'           => esc_attr( $this->classes( $classes ) ),
 				'allowed_tags'      => [
 					'a'      => [
 						'href'   => [],
@@ -68,7 +68,7 @@ final class Notice_Controller extends Controller {
 					'https',
 					'mailto',
 				],
-			] 
+			]
 		);
 	}
 }

--- a/src/Uplink/Notice/Notice_Controller.php
+++ b/src/Uplink/Notice/Notice_Controller.php
@@ -21,25 +21,33 @@ final class Notice_Controller extends Controller {
 	 * @see Notice::toArray()
 	 * @see src/views/admin/notice.php
 	 *
-	 * @param array{type?: string, message?: string, dismissible?: bool, alt?: bool, large?: bool} $args The notice.
+	 * @param array{type?: string, message?: string, dismissible?: bool, alt?: bool, large?: bool, id?: string} $args The notice.
 	 *
 	 * @throws FileNotFoundException If the view is not found.
 	 *
 	 * @return void
 	 */
 	public function render( array $args = [] ): void {
+		$type        = $args['type'] ?? 'info';
+		$dismissible = $args['dismissible'] ?? false;
+		$alt         = $args['alt'] ?? false;
+		$large       = $args['large'] ?? false;
+		$message     = $args['message'] ?? '';
+		$id          = $args['id'] ?? '';
+
 		$classes = [
 			'notice',
-			sprintf( 'notice-%s', $args['type'] ),
-			$args['dismissible'] ? 'is-dismissible' : '',
-			$args['alt'] ? 'notice-alt' : '',
-			$args['large'] ? 'notice-large' : '',
+			sprintf( 'notice-%s', $type ),
+			$dismissible ? 'is-dismissible' : '',
+			$alt ? 'notice-alt' : '',
+			$large ? 'notice-large' : '',
 		];
 
 		echo $this->view->render(
 			self::VIEW,
 			[
-				'message'           => $args['message'],
+				'message'           => $message,
+				'id'                => $id,
 				'classes'           => $this->classes( $classes ),
 				'allowed_tags'      => [
 					'a'      => [

--- a/src/Uplink/Notice/Notice_Handler.php
+++ b/src/Uplink/Notice/Notice_Handler.php
@@ -64,7 +64,7 @@ final class Notice_Handler {
 		}
 
 		foreach ( $this->notices as $notice ) {
-			$this->controller->render( $notice->toArray() );
+			$this->controller->render( $notice->to_array() );
 		}
 
 		$this->clear();

--- a/src/Uplink/Uplink.php
+++ b/src/Uplink/Uplink.php
@@ -173,5 +173,4 @@ class Uplink {
 	public static function is_enabled(): bool {
 		return ! static::is_disabled();
 	}
-
 }

--- a/src/Uplink/View/Contracts/View.php
+++ b/src/Uplink/View/Contracts/View.php
@@ -21,4 +21,19 @@ interface View {
 	 * @return string
 	 */
 	public function render( string $name, array $args = [] ): string;
+
+	/**
+	 * Renders a view directly to output.
+	 *
+	 * Use this instead of echo render() to avoid PHPCS escaping warnings
+	 * when the view template handles its own escaping.
+	 *
+	 * @param string  $name  The relative path/name of the view file without extension.
+	 * @param mixed[] $args  Arguments to be extracted and passed to the view.
+	 *
+	 * @throws FileNotFoundException If the view file cannot be found.
+	 *
+	 * @return void
+	 */
+	public function display( string $name, array $args = [] ): void;
 }

--- a/src/Uplink/View/WordPress_View.php
+++ b/src/Uplink/View/WordPress_View.php
@@ -79,7 +79,6 @@ final class WordPress_View implements Contracts\View {
 	 * @param mixed[] $args  Arguments to be extracted and passed to the view.
 	 *
 	 * @return void
-	 *
 	 */
 	public function display( string $name, array $args = [] ): void {
 		$file = $this->get_path( $name );

--- a/src/Uplink/View/WordPress_View.php
+++ b/src/Uplink/View/WordPress_View.php
@@ -73,6 +73,22 @@ final class WordPress_View implements Contracts\View {
 	}
 
 	/**
+	 * Render a view directly to output.
+	 *
+	 * @param string  $name  The relative path/name of the view file without extension.
+	 * @param mixed[] $args  Arguments to be extracted and passed to the view.
+	 *
+	 * @return void
+	 *
+	 */
+	public function display( string $name, array $args = [] ): void {
+		$file = $this->get_path( $name );
+
+		extract( $args );
+		include $file;
+	}
+
+	/**
 	 * Get the absolute server path to a view file.
 	 *
 	 * @param string $name  The relative view path/name, e.g. `admin/notice`.

--- a/src/views/admin/notice.php
+++ b/src/views/admin/notice.php
@@ -6,12 +6,13 @@
  *
  * @var string               $message           The message to display.
  * @var string               $classes           The CSS classes for the notice.
+ * @var string               $id                Optional unique ID for persistent dismissal.
  * @var array<string, mixed> $allowed_tags      The allowed HTML tags for wp_kses().
  * @var string[]             $allowed_protocols The allowed protocols for wp_kses().
  */
 
 defined( 'ABSPATH' ) || exit;
 ?>
-<div class="<?php echo esc_attr( $classes ); ?>">
+<div class="<?php echo esc_attr( $classes ); ?>"<?php echo $id ? ' data-uplink-notice-id="' . esc_attr( $id ) . '"' : ''; ?>>
 	<p><?php echo wp_kses( $message, $allowed_tags, $allowed_protocols ); ?></p>
 </div>

--- a/tests/wpunit/API/REST/V1/Legacy_License_ControllerTest.php
+++ b/tests/wpunit/API/REST/V1/Legacy_License_ControllerTest.php
@@ -26,7 +26,7 @@ final class Legacy_License_ControllerTest extends UplinkTestCase {
 		'slug'       => 'my-plugin',
 		'name'       => 'My Plugin',
 		'brand'      => 'My Brand',
-		'status'     => 'active',
+		'is_active'  => true,
 		'page_url'   => 'https://example.com/account',
 		'expires_at' => '2027-01-01',
 	];
@@ -68,7 +68,7 @@ final class Legacy_License_ControllerTest extends UplinkTestCase {
 	public function test_returns_empty_array_when_no_legacy_licenses(): void {
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 
-		$request  = new WP_REST_Request( 'GET', '/stellarwp/uplink/v1/license/legacy' );
+		$request  = new WP_REST_Request( 'GET', '/stellarwp/uplink/v1/legacy-licenses' );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertSame( 200, $response->get_status() );
@@ -85,7 +85,7 @@ final class Legacy_License_ControllerTest extends UplinkTestCase {
 			}
 		);
 
-		$request  = new WP_REST_Request( 'GET', '/stellarwp/uplink/v1/license/legacy' );
+		$request  = new WP_REST_Request( 'GET', '/stellarwp/uplink/v1/legacy-licenses' );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertSame( 200, $response->get_status() );
@@ -102,7 +102,7 @@ final class Legacy_License_ControllerTest extends UplinkTestCase {
 			}
 		);
 
-		$request  = new WP_REST_Request( 'GET', '/stellarwp/uplink/v1/license/legacy' );
+		$request  = new WP_REST_Request( 'GET', '/stellarwp/uplink/v1/legacy-licenses' );
 		$response = $this->server->dispatch( $request );
 		$item     = $response->get_data()[0];
 
@@ -110,7 +110,7 @@ final class Legacy_License_ControllerTest extends UplinkTestCase {
 		$this->assertArrayHasKey( 'slug', $item );
 		$this->assertArrayHasKey( 'name', $item );
 		$this->assertArrayHasKey( 'brand', $item );
-		$this->assertArrayHasKey( 'status', $item );
+		$this->assertArrayHasKey( 'is_active', $item );
 		$this->assertArrayHasKey( 'page_url', $item );
 		$this->assertArrayHasKey( 'expires_at', $item );
 
@@ -118,7 +118,7 @@ final class Legacy_License_ControllerTest extends UplinkTestCase {
 		$this->assertSame( 'my-plugin', $item['slug'] );
 		$this->assertSame( 'My Plugin', $item['name'] );
 		$this->assertSame( 'My Brand', $item['brand'] );
-		$this->assertSame( 'active', $item['status'] );
+		$this->assertTrue( $item['is_active'] );
 		$this->assertSame( 'https://example.com/account', $item['page_url'] );
 		$this->assertSame( '2027-01-01', $item['expires_at'] );
 	}
@@ -136,13 +136,13 @@ final class Legacy_License_ControllerTest extends UplinkTestCase {
 						[
 							'slug' => 'another-plugin',
 							'name' => 'Another Plugin',
-						] 
+						]
 					),
 				];
 			}
 		);
 
-		$request  = new WP_REST_Request( 'GET', '/stellarwp/uplink/v1/license/legacy' );
+		$request  = new WP_REST_Request( 'GET', '/stellarwp/uplink/v1/legacy-licenses' );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertSame( 200, $response->get_status() );
@@ -152,7 +152,7 @@ final class Legacy_License_ControllerTest extends UplinkTestCase {
 	public function test_requires_manage_options(): void {
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );
 
-		$request  = new WP_REST_Request( 'GET', '/stellarwp/uplink/v1/license/legacy' );
+		$request  = new WP_REST_Request( 'GET', '/stellarwp/uplink/v1/legacy-licenses' );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertSame( 403, $response->get_status() );
@@ -161,7 +161,7 @@ final class Legacy_License_ControllerTest extends UplinkTestCase {
 	public function test_rejects_unauthenticated(): void {
 		wp_set_current_user( 0 );
 
-		$request  = new WP_REST_Request( 'GET', '/stellarwp/uplink/v1/license/legacy' );
+		$request  = new WP_REST_Request( 'GET', '/stellarwp/uplink/v1/legacy-licenses' );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertSame( 401, $response->get_status() );
@@ -173,7 +173,7 @@ final class Legacy_License_ControllerTest extends UplinkTestCase {
 
 		$this->assertArrayHasKey( 'properties', $schema );
 
-		$expected = [ 'key', 'slug', 'name', 'brand', 'status', 'page_url', 'expires_at' ];
+		$expected = [ 'key', 'slug', 'name', 'brand', 'is_active', 'page_url', 'expires_at' ];
 
 		foreach ( $expected as $property ) {
 			$this->assertArrayHasKey( $property, $schema['properties'], "Missing schema property: {$property}" );

--- a/tests/wpunit/CLI/Commands/LicenseTest.php
+++ b/tests/wpunit/CLI/Commands/LicenseTest.php
@@ -54,7 +54,7 @@ final class LicenseTest extends UplinkTestCase {
 			Data::class,
 			[
 				'get_domain' => 'example.com',
-			] 
+			]
 		);
 
 		$this->legacy_repository = new Legacy_License_Repository();
@@ -71,8 +71,8 @@ final class LicenseTest extends UplinkTestCase {
 						'site_limit'   => 5,
 						'active_count' => 2,
 					],
-				] 
-			) 
+				]
+			)
 		);
 		$this->products->add(
 			Product_Entry::from_array(
@@ -85,8 +85,8 @@ final class LicenseTest extends UplinkTestCase {
 						'site_limit'   => 0,
 						'active_count' => 10,
 					],
-				] 
-			) 
+				]
+			)
 		);
 	}
 
@@ -108,7 +108,7 @@ final class LicenseTest extends UplinkTestCase {
 			[
 				'get_key'      => 'LWSW-test-key-123',
 				'get_products' => $this->products,
-			] 
+			]
 		);
 
 		$command = new License_Command( $manager, $this->site_data, $this->legacy_repository );
@@ -126,7 +126,7 @@ final class LicenseTest extends UplinkTestCase {
 			License_Manager::class,
 			[
 				'get_key' => null,
-			] 
+			]
 		);
 
 		$command = new License_Command( $manager, $this->site_data, $this->legacy_repository );
@@ -141,7 +141,7 @@ final class LicenseTest extends UplinkTestCase {
 			[
 				'get_key'      => 'LWSW-test-key-123',
 				'get_products' => new WP_Error( 'api_error', 'Could not fetch products.' ),
-			] 
+			]
 		);
 
 		$command = new License_Command( $manager, $this->site_data, $this->legacy_repository );
@@ -156,7 +156,7 @@ final class LicenseTest extends UplinkTestCase {
 			[
 				'get_key'      => 'LWSW-test-key-123',
 				'get_products' => $this->products,
-			] 
+			]
 		);
 
 		$command = new License_Command( $manager, $this->site_data, $this->legacy_repository );
@@ -175,7 +175,7 @@ final class LicenseTest extends UplinkTestCase {
 			[
 				'get_key'      => 'LWSW-test-key-123',
 				'get_products' => $this->products,
-			] 
+			]
 		);
 
 		$command = new License_Command( $manager, $this->site_data, $this->legacy_repository );
@@ -196,7 +196,7 @@ final class LicenseTest extends UplinkTestCase {
 				'validate_and_store' => [],
 				'get_products'       => $this->products,
 				'get_key'            => 'LWSW-test-key-123',
-			] 
+			]
 		);
 
 		$command = new License_Command( $manager, $this->site_data, $this->legacy_repository );
@@ -219,7 +219,7 @@ final class LicenseTest extends UplinkTestCase {
 			License_Manager::class,
 			[
 				'validate_and_store' => new WP_Error( 'api_error', 'License not recognized.' ),
-			] 
+			]
 		);
 
 		$command = new License_Command( $manager, $this->site_data, $this->legacy_repository );
@@ -237,7 +237,7 @@ final class LicenseTest extends UplinkTestCase {
 			License_Manager::class,
 			[
 				'lookup_products' => $this->products,
-			] 
+			]
 		);
 
 		$command = new License_Command( $manager, $this->site_data, $this->legacy_repository );
@@ -253,7 +253,7 @@ final class LicenseTest extends UplinkTestCase {
 			License_Manager::class,
 			[
 				'lookup_products' => new WP_Error( 'invalid_key', 'Invalid key format.' ),
-			] 
+			]
 		);
 
 		$command = new License_Command( $manager, $this->site_data, $this->legacy_repository );
@@ -274,7 +274,7 @@ final class LicenseTest extends UplinkTestCase {
 					\StellarWP\Uplink\Licensing\Results\Validation_Result::class,
 					[ 'is_valid' => true ]
 				),
-			] 
+			]
 		);
 
 		$command = new License_Command( $manager, $this->site_data, $this->legacy_repository );
@@ -288,7 +288,7 @@ final class LicenseTest extends UplinkTestCase {
 			License_Manager::class,
 			[
 				'validate_product' => new WP_Error( 'validation_failed', 'Product validation failed.' ),
-			] 
+			]
 		);
 
 		$command = new License_Command( $manager, $this->site_data, $this->legacy_repository );
@@ -306,7 +306,7 @@ final class LicenseTest extends UplinkTestCase {
 			License_Manager::class,
 			[
 				'delete_key' => true,
-			] 
+			]
 		);
 
 		$command = new License_Command( $manager, $this->site_data, $this->legacy_repository );
@@ -334,8 +334,8 @@ final class LicenseTest extends UplinkTestCase {
 						'site_limit'   => 1,
 						'active_count' => 2,
 					],
-				] 
-			) 
+				]
+			)
 		);
 
 		$manager = $this->makeEmpty(
@@ -343,7 +343,7 @@ final class LicenseTest extends UplinkTestCase {
 			[
 				'get_key'      => 'LWSW-test-key-123',
 				'get_products' => $products,
-			] 
+			]
 		);
 
 		$command = new License_Command( $manager, $this->site_data, $this->legacy_repository );
@@ -368,8 +368,8 @@ final class LicenseTest extends UplinkTestCase {
 						'site_limit'   => 5,
 						'active_count' => 2,
 					],
-				] 
-			) 
+				]
+			)
 		);
 
 		$manager = $this->makeEmpty(
@@ -377,7 +377,7 @@ final class LicenseTest extends UplinkTestCase {
 			[
 				'get_key'      => 'LWSW-test-key-123',
 				'get_products' => $products,
-			] 
+			]
 		);
 
 		$command = new License_Command( $manager, $this->site_data, $this->legacy_repository );
@@ -395,7 +395,7 @@ final class LicenseTest extends UplinkTestCase {
 			[
 				'get_key'      => 'LWSW-test-key-123',
 				'get_products' => new Product_Collection(),
-			] 
+			]
 		);
 
 		$command = new License_Command( $manager, $this->site_data, $this->legacy_repository );
@@ -418,7 +418,7 @@ final class LicenseTest extends UplinkTestCase {
 						'slug'       => 'my-plugin',
 						'name'       => 'My Plugin',
 						'brand'      => 'My Brand',
-						'status'     => 'active',
+						'is_active'  => true,
 						'page_url'   => 'https://example.com/account',
 						'expires_at' => '2027-01-01',
 					],
@@ -436,7 +436,7 @@ final class LicenseTest extends UplinkTestCase {
 		$this->assertSame( 'My Plugin', $items[0]['name'] );
 		$this->assertSame( 'My Brand', $items[0]['brand'] );
 		$this->assertSame( 'ABC123', $items[0]['key'] );
-		$this->assertSame( 'active', $items[0]['status'] );
+		$this->assertTrue( $items[0]['is_active'] );
 		$this->assertSame( '2027-01-01', $items[0]['expires_at'] );
 	}
 
@@ -466,7 +466,7 @@ final class LicenseTest extends UplinkTestCase {
 			[
 				'format' => 'json',
 				'fields' => 'product_slug,tier,status,expires,site_limit,active_count,over_limit,installed_here,validation_status,is_valid,pending_tier',
-			] 
+			]
 		);
 		$output = ob_get_clean();
 
@@ -488,7 +488,7 @@ final class LicenseTest extends UplinkTestCase {
 			[],
 			[
 				'format' => 'json',
-				'fields' => 'slug,name,brand,key,status,expires_at,page_url',
+				'fields' => 'slug,name,brand,key,is_active,expires_at,page_url',
 			]
 		);
 		$output = ob_get_clean();

--- a/tests/wpunit/Legacy/Legacy_LicenseTest.php
+++ b/tests/wpunit/Legacy/Legacy_LicenseTest.php
@@ -78,21 +78,25 @@ final class Legacy_LicenseTest extends UplinkTestCase {
 	 * @since 3.0.0
 	 */
 	public function it_uses_explicit_is_active_value(): void {
-		$active = Legacy_License::from_data( [
-			'key'       => 'k',
-			'slug'      => 's',
-			'name'      => 'N',
-			'brand'     => 'B',
-			'is_active' => true,
-		] );
+		$active = Legacy_License::from_data(
+			[
+				'key'       => 'k',
+				'slug'      => 's',
+				'name'      => 'N',
+				'brand'     => 'B',
+				'is_active' => true,
+			] 
+		);
 
-		$inactive = Legacy_License::from_data( [
-			'key'       => 'k',
-			'slug'      => 's',
-			'name'      => 'N',
-			'brand'     => 'B',
-			'is_active' => false,
-		] );
+		$inactive = Legacy_License::from_data(
+			[
+				'key'       => 'k',
+				'slug'      => 's',
+				'name'      => 'N',
+				'brand'     => 'B',
+				'is_active' => false,
+			] 
+		);
 
 		$this->assertTrue( $active->is_active );
 		$this->assertFalse( $inactive->is_active );

--- a/tests/wpunit/Legacy/Legacy_LicenseTest.php
+++ b/tests/wpunit/Legacy/Legacy_LicenseTest.php
@@ -13,15 +13,15 @@ final class Legacy_LicenseTest extends UplinkTestCase {
 	/**
 	 * @since 3.0.0
 	 */
-	public function it_sets_properties_via_constructor(): void {
+	public function it_sets_properties_via_from_data(): void {
 		$license = Legacy_License::from_data(
 			[
-				'key'      => 'key-123',
-				'slug'     => 'my-plugin',
-				'name'     => 'My Plugin',
-				'brand'    => 'StellarWP',
-				'status'   => 'valid',
-				'page_url' => 'https://example.com/licenses',
+				'key'       => 'key-123',
+				'slug'      => 'my-plugin',
+				'name'      => 'My Plugin',
+				'brand'     => 'StellarWP',
+				'is_active' => true,
+				'page_url'  => 'https://example.com/licenses',
 			]
 		);
 
@@ -29,14 +29,14 @@ final class Legacy_LicenseTest extends UplinkTestCase {
 		$this->assertSame( 'my-plugin', $license->slug );
 		$this->assertSame( 'My Plugin', $license->name );
 		$this->assertSame( 'StellarWP', $license->brand );
-		$this->assertSame( 'valid', $license->status );
+		$this->assertTrue( $license->is_active );
 		$this->assertSame( 'https://example.com/licenses', $license->page_url );
 	}
 
 	/**
 	 * @since 3.0.0
 	 */
-	public function it_uses_default_status_and_page_url_when_omitted(): void {
+	public function it_defaults_is_active_to_false_and_page_url_to_empty_when_omitted(): void {
 		$license = Legacy_License::from_data(
 			[
 				'key'   => 'key-456',
@@ -46,32 +46,56 @@ final class Legacy_LicenseTest extends UplinkTestCase {
 			]
 		);
 
-		$this->assertSame( 'unknown', $license->status );
+		$this->assertFalse( $license->is_active );
 		$this->assertSame( '', $license->page_url );
 	}
 
 	/**
 	 * @since 3.0.0
 	 */
-	public function it_creates_instance_from_array_via_from_data(): void {
-		$data = [
-			'key'      => 'key-from-array',
-			'slug'     => 'give-recurring',
-			'name'     => 'Give Recurring',
-			'brand'    => 'GiveWP',
-			'status'   => 'expired',
-			'page_url' => 'https://site.com/wp-admin/licenses',
-		];
-
-		$license = Legacy_License::from_data( $data );
+	public function it_creates_inactive_instance_from_array_via_from_data(): void {
+		$license = Legacy_License::from_data(
+			[
+				'key'       => 'key-from-array',
+				'slug'      => 'give-recurring',
+				'name'      => 'Give Recurring',
+				'brand'     => 'GiveWP',
+				'is_active' => false,
+				'page_url'  => 'https://site.com/wp-admin/licenses',
+			]
+		);
 
 		$this->assertInstanceOf( Legacy_License::class, $license );
 		$this->assertSame( 'key-from-array', $license->key );
 		$this->assertSame( 'give-recurring', $license->slug );
 		$this->assertSame( 'Give Recurring', $license->name );
 		$this->assertSame( 'GiveWP', $license->brand );
-		$this->assertSame( 'expired', $license->status );
+		$this->assertFalse( $license->is_active );
 		$this->assertSame( 'https://site.com/wp-admin/licenses', $license->page_url );
+	}
+
+	/**
+	 * @since 3.0.0
+	 */
+	public function it_uses_explicit_is_active_value(): void {
+		$active = Legacy_License::from_data( [
+			'key'       => 'k',
+			'slug'      => 's',
+			'name'      => 'N',
+			'brand'     => 'B',
+			'is_active' => true,
+		] );
+
+		$inactive = Legacy_License::from_data( [
+			'key'       => 'k',
+			'slug'      => 's',
+			'name'      => 'N',
+			'brand'     => 'B',
+			'is_active' => false,
+		] );
+
+		$this->assertTrue( $active->is_active );
+		$this->assertFalse( $inactive->is_active );
 	}
 
 	/**
@@ -84,7 +108,7 @@ final class Legacy_LicenseTest extends UplinkTestCase {
 		$this->assertSame( '', $license->slug );
 		$this->assertSame( '', $license->name );
 		$this->assertSame( '', $license->brand );
-		$this->assertSame( 'unknown', $license->status );
+		$this->assertFalse( $license->is_active );
 		$this->assertSame( '', $license->page_url );
 	}
 
@@ -98,7 +122,7 @@ final class Legacy_LicenseTest extends UplinkTestCase {
 				'slug'  => 'num-slug',
 				'name'  => 'Name',
 				'brand' => 'Brand',
-			] 
+			]
 		);
 
 		$this->assertSame( '12345', $license->key );

--- a/tests/wpunit/Legacy/License_RepositoryTest.php
+++ b/tests/wpunit/Legacy/License_RepositoryTest.php
@@ -44,12 +44,12 @@ final class License_RepositoryTest extends UplinkTestCase {
 					$licenses,
 					[
 						[
-							'key'      => 'key-1',
-							'slug'     => 'plugin-one',
-							'name'     => 'Plugin One',
-							'brand'    => 'Brand',
-							'status'   => 'valid',
-							'page_url' => 'https://example.com/license',
+							'key'       => 'key-1',
+							'slug'      => 'plugin-one',
+							'name'      => 'Plugin One',
+							'brand'     => 'Brand',
+							'is_active' => true,
+							'page_url'  => 'https://example.com/license',
 						],
 					]
 				);
@@ -228,6 +228,84 @@ final class License_RepositoryTest extends UplinkTestCase {
 		$this->repository->has_any();
 
 		$this->assertSame( 1, $call_count, 'Filter should only be applied once per request cycle.' );
+	}
+
+	/**
+	 * @since 3.0.0
+	 */
+	public function it_all_active_returns_only_active_licenses(): void {
+		add_filter(
+			'stellarwp/uplink/legacy_licenses',
+			static function ( array $licenses ) {
+				return array_merge(
+					$licenses,
+					[
+						[
+							'key'       => 'k1',
+							'slug'      => 'active-plugin',
+							'name'      => 'Active',
+							'brand'     => 'B',
+							'is_active' => true,
+						],
+						[
+							'key'       => 'k2',
+							'slug'      => 'inactive-plugin',
+							'name'      => 'Inactive',
+							'brand'     => 'B',
+							'is_active' => false,
+						],
+					]
+				);
+			}
+		);
+
+		$result = $this->repository->all_active();
+
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'active-plugin', $result[0]->slug );
+	}
+
+	/**
+	 * @since 3.0.0
+	 */
+	public function it_all_inactive_returns_only_inactive_licenses(): void {
+		add_filter(
+			'stellarwp/uplink/legacy_licenses',
+			static function ( array $licenses ) {
+				return array_merge(
+					$licenses,
+					[
+						[
+							'key'       => 'k1',
+							'slug'      => 'active-plugin',
+							'name'      => 'Active',
+							'brand'     => 'B',
+							'is_active' => true,
+						],
+						[
+							'key'       => 'k2',
+							'slug'      => 'expired-plugin',
+							'name'      => 'Expired',
+							'brand'     => 'B',
+							'is_active' => false,
+						],
+						[
+							'key'       => 'k3',
+							'slug'      => 'inactive-plugin',
+							'name'      => 'Inactive',
+							'brand'     => 'B',
+							'is_active' => false,
+						],
+					]
+				);
+			}
+		);
+
+		$result = $this->repository->all_inactive();
+
+		$this->assertCount( 2, $result );
+		$this->assertSame( 'expired-plugin', $result[0]->slug );
+		$this->assertSame( 'inactive-plugin', $result[1]->slug );
 	}
 
 	/**

--- a/tests/wpunit/Legacy/Notices/License_Notice_HandlerTest.php
+++ b/tests/wpunit/Legacy/Notices/License_Notice_HandlerTest.php
@@ -61,9 +61,15 @@ final class License_Notice_HandlerTest extends UplinkTestCase {
 		$subscriber_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
 		wp_set_current_user( $subscriber_id );
 
-		$this->add_licenses( [
-			[ 'slug' => 'give-recurring', 'brand' => 'give', 'is_active' => false ],
-		] );
+		$this->add_licenses(
+			[
+				[
+					'slug'      => 'give-recurring',
+					'brand'     => 'give',
+					'is_active' => false,
+				],
+			] 
+		);
 
 		$output = $this->capture_display();
 

--- a/tests/wpunit/Legacy/Notices/License_Notice_HandlerTest.php
+++ b/tests/wpunit/Legacy/Notices/License_Notice_HandlerTest.php
@@ -57,6 +57,22 @@ final class License_Notice_HandlerTest extends UplinkTestCase {
 	/**
 	 * @test
 	 */
+	public function it_renders_nothing_for_non_admin_user(): void {
+		$subscriber_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_id );
+
+		$this->add_licenses( [
+			[ 'slug' => 'give-recurring', 'brand' => 'give', 'is_active' => false ],
+		] );
+
+		$output = $this->capture_display();
+
+		$this->assertSame( '', trim( $output ) );
+	}
+
+	/**
+	 * @test
+	 */
 	public function it_renders_nothing_when_no_inactive_licenses(): void {
 		$output = $this->capture_display();
 

--- a/tests/wpunit/Legacy/Notices/License_Notice_HandlerTest.php
+++ b/tests/wpunit/Legacy/Notices/License_Notice_HandlerTest.php
@@ -1,0 +1,261 @@
+<?php declare( strict_types=1 );
+
+namespace StellarWP\Uplink\Tests\Legacy\Notices;
+
+use StellarWP\Uplink\Config;
+use StellarWP\Uplink\Legacy\License_Repository;
+use StellarWP\Uplink\Legacy\Notices\License_Notice_Handler;
+use StellarWP\Uplink\Notice\Notice_Controller;
+use StellarWP\Uplink\Tests\Traits\With_Uopz;
+use StellarWP\Uplink\Tests\UplinkTestCase;
+use StellarWP\Uplink\Utils\Version;
+
+/**
+ * @since 3.0.0
+ */
+final class License_Notice_HandlerTest extends UplinkTestCase {
+
+	use With_Uopz;
+
+	/**
+	 * @var License_Notice_Handler
+	 */
+	private $handler;
+
+	/**
+	 * @var int
+	 */
+	private $user_id;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		// Always act as leader so Version::should_handle() doesn't block tests.
+		$this->set_class_fn_return( Version::class, 'should_handle', true );
+
+		$this->user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $this->user_id );
+
+		$this->handler = new License_Notice_Handler(
+			new License_Repository(),
+			Config::get_container()->get( Notice_Controller::class )
+		);
+	}
+
+	protected function tearDown(): void {
+		remove_all_filters( 'stellarwp/uplink/legacy_licenses' );
+		wp_set_current_user( 0 );
+		parent::tearDown();
+	}
+
+	// ------------------------------------------------------------------
+	// No output cases
+	// ------------------------------------------------------------------
+
+	/**
+	 * @test
+	 */
+	public function it_renders_nothing_when_no_inactive_licenses(): void {
+		$output = $this->capture_display();
+
+		$this->assertSame( '', trim( $output ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_renders_nothing_when_all_licenses_are_active(): void {
+		$this->add_licenses( [
+			[ 'slug' => 'give-recurring', 'brand' => 'give', 'is_active' => true ],
+		] );
+
+		$output = $this->capture_display();
+
+		$this->assertSame( '', trim( $output ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_skips_dismissed_brand(): void {
+		$this->add_licenses( [
+			[ 'slug' => 'give-recurring', 'brand' => 'give', 'is_active' => false ],
+		] );
+
+		update_user_meta(
+			$this->user_id,
+			License_Notice_Handler::DISMISSED_META_KEY,
+			[ 'legacy-give' => time() + 1000 ]
+		);
+
+		$output = $this->capture_display();
+
+		$this->assertSame( '', trim( $output ) );
+	}
+
+	// ------------------------------------------------------------------
+	// Renders notices
+	// ------------------------------------------------------------------
+
+	/**
+	 * @test
+	 */
+	public function it_renders_notice_for_inactive_brand(): void {
+		$this->add_licenses( [
+			[
+				'slug'     => 'give-recurring',
+				'brand'    => 'give',
+				'is_active' => false,
+				'page_url' => 'https://example.com/licenses',
+			],
+		] );
+
+		$output = $this->capture_display();
+
+		$this->assertStringContainsString( 'Give', $output );
+		$this->assertStringContainsString( 'https://example.com/licenses', $output );
+		$this->assertStringContainsString( 'data-uplink-notice-id="legacy-give"', $output );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_renders_singular_message_for_one_addon(): void {
+		$this->add_licenses( [
+			[ 'slug' => 'give-recurring', 'brand' => 'give', 'is_active' => false ],
+		] );
+
+		$output = $this->capture_display();
+
+		$this->assertStringContainsString( 'add-on is not receiving', $output );
+		$this->assertStringNotContainsString( 'add-ons are not receiving', $output );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_renders_plural_message_for_multiple_addons(): void {
+		$this->add_licenses( [
+			[ 'slug' => 'give-recurring', 'brand' => 'give', 'is_active' => false ],
+			[ 'slug' => 'give-stripe',    'brand' => 'give', 'is_active' => false ],
+		] );
+
+		$output = $this->capture_display();
+
+		$this->assertStringContainsString( '2', $output );
+		$this->assertStringContainsString( 'add-ons are not receiving', $output );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_groups_multiple_addons_under_same_brand(): void {
+		$this->add_licenses( [
+			[ 'slug' => 'give-recurring', 'brand' => 'give', 'is_active' => false ],
+			[ 'slug' => 'give-stripe',    'brand' => 'give', 'is_active' => false ],
+			[ 'slug' => 'give-fee',       'brand' => 'give', 'is_active' => false ],
+		] );
+
+		$output = $this->capture_display();
+
+		$this->assertSame( 1, substr_count( $output, 'data-uplink-notice-id="legacy-give"' ) );
+		$this->assertStringContainsString( '3', $output );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_renders_separate_notices_for_different_brands(): void {
+		$this->add_licenses( [
+			[ 'slug' => 'give-recurring', 'brand' => 'give',    'is_active' => false ],
+			[ 'slug' => 'kadence-blocks', 'brand' => 'kadence', 'is_active' => false ],
+		] );
+
+		$output = $this->capture_display();
+
+		$this->assertStringContainsString( 'data-uplink-notice-id="legacy-give"', $output );
+		$this->assertStringContainsString( 'data-uplink-notice-id="legacy-kadence"', $output );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_shows_notice_again_after_dismissal_expires(): void {
+		$this->add_licenses( [
+			[ 'slug' => 'give-recurring', 'brand' => 'give', 'is_active' => false ],
+		] );
+
+		// Dismissal already expired.
+		update_user_meta(
+			$this->user_id,
+			License_Notice_Handler::DISMISSED_META_KEY,
+			[ 'legacy-give' => time() - 1 ]
+		);
+
+		$output = $this->capture_display();
+
+		$this->assertStringContainsString( 'data-uplink-notice-id="legacy-give"', $output );
+	}
+
+	// ------------------------------------------------------------------
+	// Script enqueue
+	// ------------------------------------------------------------------
+
+	/**
+	 * @test
+	 */
+	public function it_enqueues_dismiss_script_when_notices_render(): void {
+		$this->add_licenses( [
+			[ 'slug' => 'give-recurring', 'brand' => 'give', 'is_active' => false ],
+		] );
+
+		$this->capture_display();
+
+		$this->assertTrue( wp_script_is( 'stellarwp-uplink-notice-dismiss', 'enqueued' ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_does_not_enqueue_script_when_no_notices_render(): void {
+		$this->capture_display();
+
+		$this->assertFalse( wp_script_is( 'stellarwp-uplink-notice-dismiss', 'enqueued' ) );
+	}
+
+	// ------------------------------------------------------------------
+	// Helpers
+	// ------------------------------------------------------------------
+
+	/**
+	 * Run display() and return captured output.
+	 */
+	private function capture_display(): string {
+		ob_start();
+		$this->handler->display();
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Add licenses to the filter.
+	 *
+	 * @param array<int, array<string, mixed>> $licenses
+	 */
+	private function add_licenses( array $licenses ): void {
+		add_filter(
+			'stellarwp/uplink/legacy_licenses',
+			static function () use ( $licenses ) {
+				return array_map( static function ( array $entry ): array {
+					return array_merge(
+						[
+							'key'      => 'key-' . $entry['slug'],
+							'name'     => $entry['slug'],
+							'page_url' => 'https://example.com/licenses',
+						],
+						$entry
+					);
+				}, $licenses );
+			}
+		);
+	}
+}

--- a/tests/wpunit/Legacy/Notices/License_Notice_HandlerTest.php
+++ b/tests/wpunit/Legacy/Notices/License_Notice_HandlerTest.php
@@ -65,9 +65,15 @@ final class License_Notice_HandlerTest extends UplinkTestCase {
 	 * @test
 	 */
 	public function it_renders_nothing_when_all_licenses_are_active(): void {
-		$this->add_licenses( [
-			[ 'slug' => 'give-recurring', 'brand' => 'give', 'is_active' => true ],
-		] );
+		$this->add_licenses(
+			[
+				[
+					'slug'      => 'give-recurring',
+					'brand'     => 'give',
+					'is_active' => true,
+				],
+			] 
+		);
 
 		$output = $this->capture_display();
 
@@ -78,9 +84,15 @@ final class License_Notice_HandlerTest extends UplinkTestCase {
 	 * @test
 	 */
 	public function it_skips_dismissed_brand(): void {
-		$this->add_licenses( [
-			[ 'slug' => 'give-recurring', 'brand' => 'give', 'is_active' => false ],
-		] );
+		$this->add_licenses(
+			[
+				[
+					'slug'      => 'give-recurring',
+					'brand'     => 'give',
+					'is_active' => false,
+				],
+			] 
+		);
 
 		update_user_meta(
 			$this->user_id,
@@ -101,14 +113,16 @@ final class License_Notice_HandlerTest extends UplinkTestCase {
 	 * @test
 	 */
 	public function it_renders_notice_for_inactive_brand(): void {
-		$this->add_licenses( [
+		$this->add_licenses(
 			[
-				'slug'     => 'give-recurring',
-				'brand'    => 'give',
-				'is_active' => false,
-				'page_url' => 'https://example.com/licenses',
-			],
-		] );
+				[
+					'slug'      => 'give-recurring',
+					'brand'     => 'give',
+					'is_active' => false,
+					'page_url'  => 'https://example.com/licenses',
+				],
+			] 
+		);
 
 		$output = $this->capture_display();
 
@@ -121,9 +135,15 @@ final class License_Notice_HandlerTest extends UplinkTestCase {
 	 * @test
 	 */
 	public function it_renders_singular_message_for_one_addon(): void {
-		$this->add_licenses( [
-			[ 'slug' => 'give-recurring', 'brand' => 'give', 'is_active' => false ],
-		] );
+		$this->add_licenses(
+			[
+				[
+					'slug'      => 'give-recurring',
+					'brand'     => 'give',
+					'is_active' => false,
+				],
+			] 
+		);
 
 		$output = $this->capture_display();
 
@@ -135,10 +155,20 @@ final class License_Notice_HandlerTest extends UplinkTestCase {
 	 * @test
 	 */
 	public function it_renders_plural_message_for_multiple_addons(): void {
-		$this->add_licenses( [
-			[ 'slug' => 'give-recurring', 'brand' => 'give', 'is_active' => false ],
-			[ 'slug' => 'give-stripe',    'brand' => 'give', 'is_active' => false ],
-		] );
+		$this->add_licenses(
+			[
+				[
+					'slug'      => 'give-recurring',
+					'brand'     => 'give',
+					'is_active' => false,
+				],
+				[
+					'slug'      => 'give-stripe',
+					'brand'     => 'give',
+					'is_active' => false,
+				],
+			] 
+		);
 
 		$output = $this->capture_display();
 
@@ -150,11 +180,25 @@ final class License_Notice_HandlerTest extends UplinkTestCase {
 	 * @test
 	 */
 	public function it_groups_multiple_addons_under_same_brand(): void {
-		$this->add_licenses( [
-			[ 'slug' => 'give-recurring', 'brand' => 'give', 'is_active' => false ],
-			[ 'slug' => 'give-stripe',    'brand' => 'give', 'is_active' => false ],
-			[ 'slug' => 'give-fee',       'brand' => 'give', 'is_active' => false ],
-		] );
+		$this->add_licenses(
+			[
+				[
+					'slug'      => 'give-recurring',
+					'brand'     => 'give',
+					'is_active' => false,
+				],
+				[
+					'slug'      => 'give-stripe',
+					'brand'     => 'give',
+					'is_active' => false,
+				],
+				[
+					'slug'      => 'give-fee',
+					'brand'     => 'give',
+					'is_active' => false,
+				],
+			] 
+		);
 
 		$output = $this->capture_display();
 
@@ -166,10 +210,20 @@ final class License_Notice_HandlerTest extends UplinkTestCase {
 	 * @test
 	 */
 	public function it_renders_separate_notices_for_different_brands(): void {
-		$this->add_licenses( [
-			[ 'slug' => 'give-recurring', 'brand' => 'give',    'is_active' => false ],
-			[ 'slug' => 'kadence-blocks', 'brand' => 'kadence', 'is_active' => false ],
-		] );
+		$this->add_licenses(
+			[
+				[
+					'slug'      => 'give-recurring',
+					'brand'     => 'give',
+					'is_active' => false,
+				],
+				[
+					'slug'      => 'kadence-blocks',
+					'brand'     => 'kadence',
+					'is_active' => false,
+				],
+			] 
+		);
 
 		$output = $this->capture_display();
 
@@ -181,9 +235,15 @@ final class License_Notice_HandlerTest extends UplinkTestCase {
 	 * @test
 	 */
 	public function it_shows_notice_again_after_dismissal_expires(): void {
-		$this->add_licenses( [
-			[ 'slug' => 'give-recurring', 'brand' => 'give', 'is_active' => false ],
-		] );
+		$this->add_licenses(
+			[
+				[
+					'slug'      => 'give-recurring',
+					'brand'     => 'give',
+					'is_active' => false,
+				],
+			] 
+		);
 
 		// Dismissal already expired.
 		update_user_meta(
@@ -205,9 +265,15 @@ final class License_Notice_HandlerTest extends UplinkTestCase {
 	 * @test
 	 */
 	public function it_enqueues_dismiss_script_when_notices_render(): void {
-		$this->add_licenses( [
-			[ 'slug' => 'give-recurring', 'brand' => 'give', 'is_active' => false ],
-		] );
+		$this->add_licenses(
+			[
+				[
+					'slug'      => 'give-recurring',
+					'brand'     => 'give',
+					'is_active' => false,
+				],
+			] 
+		);
 
 		$this->capture_display();
 
@@ -245,16 +311,19 @@ final class License_Notice_HandlerTest extends UplinkTestCase {
 		add_filter(
 			'stellarwp/uplink/legacy_licenses',
 			static function () use ( $licenses ) {
-				return array_map( static function ( array $entry ): array {
-					return array_merge(
-						[
-							'key'      => 'key-' . $entry['slug'],
-							'name'     => $entry['slug'],
-							'page_url' => 'https://example.com/licenses',
-						],
-						$entry
-					);
-				}, $licenses );
+				return array_map(
+					static function ( array $entry ): array {
+						return array_merge(
+							[
+								'key'      => 'key-' . $entry['slug'],
+								'name'     => $entry['slug'],
+								'page_url' => 'https://example.com/licenses',
+							],
+							$entry
+						);
+					},
+					$licenses 
+				);
 			}
 		);
 	}

--- a/tests/wpunit/Legacy/Notices/License_Notice_HandlerTest.php
+++ b/tests/wpunit/Legacy/Notices/License_Notice_HandlerTest.php
@@ -44,6 +44,8 @@ final class License_Notice_HandlerTest extends UplinkTestCase {
 
 	protected function tearDown(): void {
 		remove_all_filters( 'stellarwp/uplink/legacy_licenses' );
+		wp_dequeue_script( 'stellarwp-uplink-notice-dismiss' );
+		wp_deregister_script( 'stellarwp-uplink-notice-dismiss' );
 		wp_set_current_user( 0 );
 		parent::tearDown();
 	}

--- a/tests/wpunit/Legacy/Notices/License_Notice_HandlerTest.php
+++ b/tests/wpunit/Legacy/Notices/License_Notice_HandlerTest.php
@@ -149,8 +149,8 @@ final class License_Notice_HandlerTest extends UplinkTestCase {
 
 		$output = $this->capture_display();
 
-		$this->assertStringContainsString( 'add-on is not receiving', $output );
-		$this->assertStringNotContainsString( 'add-ons are not receiving', $output );
+		$this->assertStringContainsString( 'inactive Give license', $output );
+		$this->assertStringNotContainsString( 'inactive Give licenses', $output );
 	}
 
 	/**
@@ -175,7 +175,7 @@ final class License_Notice_HandlerTest extends UplinkTestCase {
 		$output = $this->capture_display();
 
 		$this->assertStringContainsString( '2', $output );
-		$this->assertStringContainsString( 'add-ons are not receiving', $output );
+		$this->assertStringContainsString( 'inactive Give licenses', $output );
 	}
 
 	/**

--- a/tests/wpunit/Legacy/Notices/License_Notice_HandlerTest.php
+++ b/tests/wpunit/Legacy/Notices/License_Notice_HandlerTest.php
@@ -149,7 +149,7 @@ final class License_Notice_HandlerTest extends UplinkTestCase {
 
 		$output = $this->capture_display();
 
-		$this->assertStringContainsString( 'inactive Give license', $output );
+		$this->assertStringContainsString( '1 inactive Give license', $output );
 		$this->assertStringNotContainsString( 'inactive Give licenses', $output );
 	}
 


### PR DESCRIPTION
Resolves [SCON-411]

## Description

This PR add support for legacy admin notices.  This will allow all products to offload their legacy license admin notices to uplink by using the `stellarwp/uplink/legacy_licenses` filter.

**Note**
The unified uplink licenses will probably have admin notices in the future too. So, this legacy notice UI & messaging may get updated in the future.

### Updates
- The legacy license REST API had a conflict with the `stellarwp/uplink/v1/license/{key}` namespace so it was updated to `stellarwp/uplink/v1/legacy-licenses`

### Screenshot

<img width="1327" height="332" alt="Screenshot 2026-03-16 at 1 35 55 PM" src="https://github.com/user-attachments/assets/e750a456-d888-4126-82d5-639a11b273bd" />

### Demo

https://www.loom.com/share/7eb2b60fe7ae4edd915dbb291e5621a2

[SCON-411]: https://stellarwp.atlassian.net/browse/SCON-411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ