### PR TITLE
Add the has_update flag into installable features | SCON-428

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -63,6 +63,8 @@ Plugin and Theme features share a global transient lock (`stellarwp_uplink_insta
 
 For `Installable` features (Plugin, Theme), the resolver also reads `installed_version` from disk and stores it on the resolved Feature. This is the version currently on the site, distinct from the catalog's `version` which is the latest available. Flag features always have `installed_version: null`.
 
+`has_update()` is a computed method on the `Installable` interface that centralizes the update-available check. It returns `true` when the feature is installed on disk and `version_compare( catalog_version, installed_version, '>' )`. Both Plugin and Theme implement this method. The update handlers (`Plugin_Handler`, `Theme_Handler`) delegate to this result (via the `has_update` field in the update data array) rather than performing their own inline comparison.
+
 Edge cases:
 
 - No licensing entry for a product: tier rank = `0`. Free-tier features (`minimum_tier` at rank 0) satisfy `0 >= 0` and are available. All paid-tier features are unavailable.
@@ -130,7 +132,7 @@ Five endpoints under `stellarwp/uplink/v1`. All require `manage_options`.
 | `/features/{slug}/disable` | POST   | Disable a feature                                             |
 | `/features/{slug}/update`  | POST   | Update a feature to the latest available version              |
 
-Each Feature object includes `is_enabled`, stamped with live state from its strategy by the Manager before any consumer receives it.
+Each Feature object includes `is_enabled`, stamped with live state from its strategy by the Manager before any consumer receives it. Installable features (Plugin, Theme) additionally include `has_update` — a pre-computed boolean the frontend can read directly without doing any version parsing.
 
 ## Error Codes
 
@@ -168,14 +170,15 @@ Each Feature object includes `is_enabled`, stamped with live state from its stra
 
 ## Data Sources
 
-| Data                                                    | Source                                                                                        |
-| ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| Feature exists, minimum tier, delivery type, tier ranks | Catalog                                                                                       |
-| Latest version, release date, changelog                 | Catalog (`version`, `released_at`, `changelog`)                                               |
-| Customer's tier, key validity                           | Licensing                                                                                     |
-| **Whether available** (`is_available`)                  | **Computed: catalog min rank vs. licensing tier rank**                                        |
-| **Whether enabled** (`is_enabled`)                      | Live WordPress state (plugin activation / theme disk / flag option), stamped by Manager       |
-| **Installed version** (`installed_version`)             | Read from disk during resolution via `Installable`. Null for flags and uninstalled extensions |
+| Data                                                    | Source                                                                                                                                                                              |
+| ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Feature exists, minimum tier, delivery type, tier ranks | Catalog                                                                                                                                                                             |
+| Latest version, release date, changelog                 | Catalog (`version`, `released_at`, `changelog`)                                                                                                                                     |
+| Customer's tier, key validity                           | Licensing                                                                                                                                                                           |
+| **Whether available** (`is_available`)                  | **Computed: catalog min rank vs. licensing tier rank**                                                                                                                              |
+| **Whether enabled** (`is_enabled`)                      | Live WordPress state (plugin activation / theme disk / flag option), stamped by Manager                                                                                             |
+| **Installed version** (`installed_version`)             | Read from disk during resolution via `Installable`. Null for flags and uninstalled extensions                                                                                       |
+| **Update available** (`has_update`)                     | Computed by `Installable::has_update()`: `version_compare( catalog_version, installed_version, '>' )`. False when not installed or catalog version is absent. Plugin and Theme only |
 
 ## What Features Does Not Do
 

--- a/src/Uplink/API/REST/V1/Feature_Controller.php
+++ b/src/Uplink/API/REST/V1/Feature_Controller.php
@@ -405,6 +405,12 @@ class Feature_Controller extends WP_REST_Controller {
 				'readonly'    => true,
 				'context'     => [ 'view' ],
 			],
+			'has_update'        => [
+				'description' => __( 'Whether a newer version is available and the feature is currently installed.', '%TEXTDOMAIN%' ),
+				'type'        => 'boolean',
+				'readonly'    => true,
+				'context'     => [ 'view' ],
+			],
 		];
 
 		$plugin_properties = [

--- a/src/Uplink/API/Validation_Response.php
+++ b/src/Uplink/API/Validation_Response.php
@@ -7,6 +7,7 @@ use StellarWP\ContainerContract\ContainerInterface;
 use StellarWP\Uplink\Config;
 use StellarWP\Uplink\Messages;
 use StellarWP\Uplink\Resources\Resource;
+use StellarWP\Uplink\Utils\Cast;
 
 class Validation_Response {
 	/**
@@ -461,7 +462,7 @@ class Validation_Response {
 			}
 
 			if ( isset( $this->response->daily_limit ) ) {
-				$this->daily_limit = intval( $this->response->daily_limit );
+				$this->daily_limit = Cast::to_int( $this->response->daily_limit );
 			}
 
 			// If the license key is new or not the same as the one we have, mark it as a new key.

--- a/src/Uplink/CLI/Commands/Catalog.php
+++ b/src/Uplink/CLI/Commands/Catalog.php
@@ -6,6 +6,7 @@ use StellarWP\Uplink\Catalog\Catalog_Repository;
 use StellarWP\Uplink\Catalog\Results\Catalog_Tier;
 use StellarWP\Uplink\CLI\Display;
 use StellarWP\Uplink\Catalog\Results\Product_Catalog;
+use StellarWP\Uplink\Utils\Cast;
 use WP_CLI;
 use WP_CLI\Formatter;
 use WP_CLI_Command;
@@ -247,7 +248,7 @@ class Catalog extends WP_CLI_Command {
 			$item['is_dot_org'] = Display::bool( ! empty( $item['is_dot_org'] ) );
 
 			if ( is_array( $item['authors'] ) ) {
-				$item['authors'] = implode( ', ', $item['authors'] );
+				$item['authors'] = implode( ', ', array_map( [ Cast::class, 'to_string' ], $item['authors'] ) );
 			} else {
 				$item['authors'] = '';
 			}

--- a/src/Uplink/CLI/Commands/Feature.php
+++ b/src/Uplink/CLI/Commands/Feature.php
@@ -400,7 +400,7 @@ class Feature extends WP_CLI_Command {
 
 		foreach ( $item as $key => $value ) {
 			if ( is_array( $value ) ) {
-				$item[ $key ] = implode( ', ', $value );
+				$item[ $key ] = implode( ', ', array_map( [ Cast::class, 'to_string' ], $value ) );
 			}
 		}
 

--- a/src/Uplink/Features/Contracts/Installable.php
+++ b/src/Uplink/Features/Contracts/Installable.php
@@ -53,6 +53,18 @@ interface Installable {
 	public function get_installed_version(): ?string;
 
 	/**
+	 * Whether a newer version is available and the feature is currently installed.
+	 *
+	 * Returns true only when the feature is installed on disk and the catalog version
+	 * is strictly greater than the installed version.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return bool
+	 */
+	public function has_update(): bool;
+
+	/**
 	 * Builds the complete update data array for this feature type.
 	 *
 	 * Each type includes common fields plus type-specific fields (e.g. plugin_file,

--- a/src/Uplink/Features/Strategy/Installable_Strategy.php
+++ b/src/Uplink/Features/Strategy/Installable_Strategy.php
@@ -3,6 +3,7 @@
 namespace StellarWP\Uplink\Features\Strategy;
 
 use StellarWP\Uplink\Features\Error_Code;
+use StellarWP\Uplink\Utils\Cast;
 use WP_Ajax_Upgrader_Skin;
 use WP_Error;
 
@@ -532,7 +533,11 @@ abstract class Installable_Strategy extends Abstract_Strategy {
 			$actual_code  = $error_code;
 			$requirements = $this->get_requirements_error_codes();
 
-			if ( $requirements !== [] && $skin_errors->has_errors() && array_intersect( $skin_errors->get_error_codes(), $requirements ) ) {
+			if (
+				$requirements !== []
+				&& $skin_errors->has_errors()
+				&& array_intersect( array_map( [ Cast::class, 'to_string' ], $skin_errors->get_error_codes() ), $requirements )
+			) {
 				$actual_code = Error_Code::REQUIREMENTS_NOT_MET;
 			}
 

--- a/src/Uplink/Features/Types/Plugin.php
+++ b/src/Uplink/Features/Types/Plugin.php
@@ -41,7 +41,7 @@ final class Plugin extends Feature implements Installable {
 	 * @return static
 	 */
 	public static function from_array( array $data ) {
-		return new self(
+		$instance = new self(
 			array_merge(
 				self::base_attributes( $data ),
 				[
@@ -55,6 +55,10 @@ final class Plugin extends Feature implements Installable {
 				]
 			)
 		);
+
+		$instance->attributes['has_update'] = $instance->has_update();
+
+		return $instance;
 	}
 
 	/**
@@ -98,6 +102,29 @@ final class Plugin extends Feature implements Installable {
 	}
 
 	/**
+	 * Whether a newer version is available and this plugin is currently installed.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return bool
+	 */
+	public function has_update(): bool {
+		$installed_version = $this->get_installed_version();
+
+		if ( $installed_version === null ) {
+			return false;
+		}
+
+		$catalog_version = Cast::to_string( $this->attributes['version'] ?? '' );
+
+		if ( $catalog_version === '' ) {
+			return false;
+		}
+
+		return version_compare( $catalog_version, $installed_version, '>' );
+	}
+
+	/**
 	 * Builds the complete update data array for this Plugin feature.
 	 *
 	 * @since 3.0.0
@@ -119,6 +146,7 @@ final class Plugin extends Feature implements Installable {
 			],
 			'plugin_file'       => $this->get_plugin_file(),
 			'installed_version' => $this->get_installed_version() ?? '',
+			'has_update'        => $this->has_update(),
 		];
 	}
 

--- a/src/Uplink/Features/Types/Theme.php
+++ b/src/Uplink/Features/Types/Theme.php
@@ -41,7 +41,7 @@ final class Theme extends Feature implements Installable {
 	 * @return static
 	 */
 	public static function from_array( array $data ) {
-		return new self(
+		$instance = new self(
 			array_merge(
 				self::base_attributes( $data ),
 				[
@@ -54,6 +54,10 @@ final class Theme extends Feature implements Installable {
 				]
 			)
 		);
+
+		$instance->attributes['has_update'] = $instance->has_update();
+
+		return $instance;
 	}
 
 	/**
@@ -85,6 +89,29 @@ final class Theme extends Feature implements Installable {
 	}
 
 	/**
+	 * Whether a newer version is available and this theme is currently installed.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return bool
+	 */
+	public function has_update(): bool {
+		$installed_version = $this->get_installed_version();
+
+		if ( $installed_version === null ) {
+			return false;
+		}
+
+		$catalog_version = Cast::to_string( $this->attributes['version'] ?? '' );
+
+		if ( $catalog_version === '' ) {
+			return false;
+		}
+
+		return version_compare( $catalog_version, $installed_version, '>' );
+	}
+
+	/**
 	 * Builds the complete update data array for this Theme feature.
 	 *
 	 * @since 3.0.0
@@ -105,6 +132,7 @@ final class Theme extends Feature implements Installable {
 				'description' => $this->get_description(),
 			],
 			'installed_version' => $this->get_installed_version() ?? '',
+			'has_update'        => $this->has_update(),
 		];
 	}
 

--- a/src/Uplink/Features/Update/Plugin_Handler.php
+++ b/src/Uplink/Features/Update/Plugin_Handler.php
@@ -8,7 +8,6 @@ use StellarWP\Uplink\Features\Types\Feature;
 use StellarWP\Uplink\Licensing\License_Manager;
 use StellarWP\Uplink\Traits\With_Debugging;
 use stdClass;
-use StellarWP\Uplink\Utils\Cast;
 
 /**
  * Consolidated update handler for Plugin features.
@@ -211,10 +210,6 @@ class Plugin_Handler {
 				continue;
 			}
 
-			/** @var string $new_version */
-			$new_version       = Cast::to_string( $update_data['version'] ?? '' );
-			$installed_version = Cast::to_string( $update_data['installed_version'] ?? '' );
-
 			$update_object = $this->to_update_object( $slug, $plugin_file, $update_data );
 
 			/**
@@ -225,7 +220,7 @@ class Plugin_Handler {
 			 * already in `response` from another system (e.g. legacy licensing) to avoid
 			 * clearing updates we didn't provide.
 			 */
-			if ( version_compare( $new_version, $installed_version, '>' ) ) {
+			if ( $update_data['has_update'] ?? false ) {
 				$wp_response[ $plugin_file ] = $update_object;
 				unset( $wp_no_update[ $plugin_file ] );
 			} elseif ( ! isset( $wp_response[ $plugin_file ] ) ) {

--- a/src/Uplink/Features/Update/Theme_Handler.php
+++ b/src/Uplink/Features/Update/Theme_Handler.php
@@ -204,10 +204,6 @@ class Theme_Handler {
 				continue;
 			}
 
-			/** @var string $new_version */
-			$new_version       = Cast::to_string( $update_data['version'] ?? '' );
-			$installed_version = Cast::to_string( $update_data['installed_version'] ?? '' );
-
 			$update_array = $this->to_update_array( $slug, $update_data );
 
 			/**
@@ -218,7 +214,7 @@ class Theme_Handler {
 			 * already in `response` from another system (e.g. legacy licensing) to avoid
 			 * clearing updates we didn't provide.
 			 */
-			if ( version_compare( $new_version, $installed_version, '>' ) ) {
+			if ( $update_data['has_update'] ?? false ) {
 				$wp_response[ $slug ] = $update_array;
 				unset( $wp_no_update[ $slug ] );
 			} elseif ( ! isset( $wp_response[ $slug ] ) ) {

--- a/tests/wpunit/API/REST/V1/Feature_ControllerTest.php
+++ b/tests/wpunit/API/REST/V1/Feature_ControllerTest.php
@@ -992,7 +992,7 @@ final class Feature_ControllerTest extends UplinkTestCase {
 		$this->assertTrue( $plugin['additionalProperties'] );
 		$this->assertSame( [ Feature::TYPE_PLUGIN ], $plugin['properties']['type']['enum'] );
 
-		$expected = [ 'slug', 'name', 'description', 'group', 'tier', 'type', 'is_available', 'documentation_url', 'is_enabled', 'plugin_file', 'released_at', 'version', 'changelog', 'authors', 'is_dot_org', 'installed_version' ];
+		$expected = [ 'slug', 'name', 'description', 'group', 'tier', 'type', 'is_available', 'documentation_url', 'is_enabled', 'plugin_file', 'released_at', 'version', 'changelog', 'authors', 'is_dot_org', 'installed_version', 'has_update' ];
 
 		foreach ( $expected as $property ) {
 			$this->assertArrayHasKey( $property, $plugin['properties'], "Missing plugin schema property: {$property}" );
@@ -1014,7 +1014,7 @@ final class Feature_ControllerTest extends UplinkTestCase {
 		$this->assertSame( 'theme', $theme['title'] );
 		$this->assertSame( [ Feature::TYPE_THEME ], $theme['properties']['type']['enum'] );
 
-		$expected = [ 'slug', 'name', 'description', 'group', 'tier', 'type', 'is_available', 'documentation_url', 'is_enabled', 'released_at', 'version', 'changelog', 'authors', 'is_dot_org', 'installed_version' ];
+		$expected = [ 'slug', 'name', 'description', 'group', 'tier', 'type', 'is_available', 'documentation_url', 'is_enabled', 'released_at', 'version', 'changelog', 'authors', 'is_dot_org', 'installed_version', 'has_update' ];
 
 		foreach ( $expected as $property ) {
 			$this->assertArrayHasKey( $property, $theme['properties'], "Missing theme schema property: {$property}" );

--- a/tests/wpunit/Features/Types/PluginTest.php
+++ b/tests/wpunit/Features/Types/PluginTest.php
@@ -151,6 +151,7 @@ final class PluginTest extends UplinkTestCase {
 			'installed_version' => '1.2.3',
 			'version'           => null,
 			'changelog'         => null,
+			'has_update'        => false,
 		];
 
 		$feature = Plugin::from_array( $data );

--- a/tests/wpunit/Features/Types/ThemeTest.php
+++ b/tests/wpunit/Features/Types/ThemeTest.php
@@ -142,6 +142,7 @@ final class ThemeTest extends UplinkTestCase {
 			'installed_version' => '2.0.0',
 			'version'           => null,
 			'changelog'         => null,
+			'has_update'        => false,
 		];
 
 		$feature = Theme::from_array( $data );

--- a/tests/wpunit/Features/Update/Plugin_HandlerTest.php
+++ b/tests/wpunit/Features/Update/Plugin_HandlerTest.php
@@ -296,6 +296,7 @@ final class Plugin_HandlerTest extends UplinkTestCase {
 				'version'     => '2.0.0',
 				'package'     => 'https://example.com/my-plugin.zip',
 				'plugin_file' => 'my-plugin/my-plugin.php',
+				'has_update'  => true,
 			],
 		];
 

--- a/tests/wpunit/Features/Update/Theme_HandlerTest.php
+++ b/tests/wpunit/Features/Update/Theme_HandlerTest.php
@@ -328,8 +328,9 @@ final class Theme_HandlerTest extends UplinkTestCase {
 	public function test_filter_update_check_adds_to_response_when_update_available(): void {
 		$update_data = [
 			'my-theme' => [
-				'version' => '2.0.0',
-				'package' => 'https://example.com/my-theme.zip',
+				'version'    => '2.0.0',
+				'package'    => 'https://example.com/my-theme.zip',
+				'has_update' => true,
 			],
 		];
 


### PR DESCRIPTION
This pull request introduces a unified and explicit mechanism for determining if a plugin or theme has an update available. The core change is the addition of a `has_update` computed property on installable features (plugins and themes), which centralizes the version comparison logic and exposes this information directly to consumers (including the REST API and frontend). Update handlers now rely on this property rather than duplicating version checks. Documentation and tests have been updated to reflect and validate this new behavior.

<img width="1284" height="1132" alt="image" src="https://github.com/user-attachments/assets/c982a9ba-f8c6-4a3c-9264-174df6c91973" />

Demo: https://www.loom.com/share/79abe4270d39448aaa36462a55edb087
