### PR TITLE
Fix: notice singleton available when disabled

### DIFF
--- a/src/Uplink/Uplink.php
+++ b/src/Uplink/Uplink.php
@@ -59,9 +59,11 @@ class Uplink {
 		$container->singleton( API\REST\V1\Provider::class, API\REST\V1\Provider::class );
 		$container->singleton( CLI\Provider::class, CLI\Provider::class );
 
+		$container->get( View\Provider::class )->register();
+		$container->singleton( Notice\Notice_Controller::class, Notice\Notice_Controller::class );
+
 		if ( static::is_enabled() ) {
 			$container->get( Storage\Provider::class )->register();
-			$container->get( View\Provider::class )->register();
 			$container->get( API\V3\Provider::class )->register();
 			$container->get( Notice\Provider::class )->register();
 			$container->get( Admin\Provider::class )->register();


### PR DESCRIPTION
## Description

This prevents a fatal error that will occur if a site is using `define('STELLARWP_LICENSING_DISABLED', true);` by always registering the `View` class and creating `Notice_Controller` singleton.


**This is the error when trying to activate a plugin with the constant defined:**

<img width="939" height="415" alt="Screenshot 2026-03-17 at 10 23 59 AM" src="https://github.com/user-attachments/assets/8b391ac0-9102-4b07-ae62-f28b0f06124e" />

