### PR TITLE
Improve feature constructor | SCON-428

### DIFF
--- a/src/Uplink/Features/Types/Plugin.php
+++ b/src/Uplink/Features/Types/Plugin.php
@@ -28,7 +28,23 @@ final class Plugin extends Feature implements Installable {
 	public function __construct( array $attributes ) {
 		$attributes['type'] = self::TYPE_PLUGIN;
 
+		$attributes = array_merge(
+			$attributes,
+			[
+				'plugin_file'       => $attributes['plugin_file'] ?? '',
+				'authors'           => $attributes['authors'] ?? [],
+				'is_dot_org'        => $attributes['is_dot_org'] ?? false,
+				'released_at'       => $attributes['released_at'] ?? null,
+				'installed_version' => $attributes['installed_version'] ?? null,
+				'version'           => $attributes['version'] ?? null,
+				'changelog'         => $attributes['changelog'] ?? null,
+			]
+		);
+
 		parent::__construct( $attributes );
+
+		// has_update() reads $this->attributes, so it must be set after parent::__construct().
+		$this->attributes['has_update'] = $this->has_update();
 	}
 
 	/**
@@ -41,24 +57,7 @@ final class Plugin extends Feature implements Installable {
 	 * @return static
 	 */
 	public static function from_array( array $data ) {
-		$instance = new self(
-			array_merge(
-				self::base_attributes( $data ),
-				[
-					'plugin_file'       => $data['plugin_file'] ?? '',
-					'authors'           => $data['authors'] ?? [],
-					'is_dot_org'        => $data['is_dot_org'] ?? false,
-					'released_at'       => $data['released_at'] ?? null,
-					'installed_version' => $data['installed_version'] ?? null,
-					'version'           => $data['version'] ?? null,
-					'changelog'         => $data['changelog'] ?? null,
-				]
-			)
-		);
-
-		$instance->attributes['has_update'] = $instance->has_update();
-
-		return $instance;
+		return new self( $data );
 	}
 
 	/**

--- a/src/Uplink/Features/Types/Theme.php
+++ b/src/Uplink/Features/Types/Theme.php
@@ -28,7 +28,22 @@ final class Theme extends Feature implements Installable {
 	public function __construct( array $attributes ) {
 		$attributes['type'] = self::TYPE_THEME;
 
+		$attributes = array_merge(
+			$attributes,
+			[
+				'authors'           => $attributes['authors'] ?? [],
+				'is_dot_org'        => $attributes['is_dot_org'] ?? false,
+				'released_at'       => $attributes['released_at'] ?? null,
+				'installed_version' => $attributes['installed_version'] ?? null,
+				'version'           => $attributes['version'] ?? null,
+				'changelog'         => $attributes['changelog'] ?? null,
+			]
+		);
+
 		parent::__construct( $attributes );
+
+		// has_update() reads $this->attributes, so it must be set after parent::__construct().
+		$this->attributes['has_update'] = $this->has_update();
 	}
 
 	/**
@@ -41,23 +56,7 @@ final class Theme extends Feature implements Installable {
 	 * @return static
 	 */
 	public static function from_array( array $data ) {
-		$instance = new self(
-			array_merge(
-				self::base_attributes( $data ),
-				[
-					'authors'           => $data['authors'] ?? [],
-					'is_dot_org'        => $data['is_dot_org'] ?? false,
-					'released_at'       => $data['released_at'] ?? null,
-					'installed_version' => $data['installed_version'] ?? null,
-					'version'           => $data['version'] ?? null,
-					'changelog'         => $data['changelog'] ?? null,
-				]
-			)
-		);
-
-		$instance->attributes['has_update'] = $instance->has_update();
-
-		return $instance;
+		return new self( $data );
 	}
 
 	/**

--- a/tests/wpunit/Features/Types/PluginTest.php
+++ b/tests/wpunit/Features/Types/PluginTest.php
@@ -123,6 +123,10 @@ final class PluginTest extends UplinkTestCase {
 				'released_at'       => '2025-11-15',
 				'installed_version' => '1.0.0',
 				'type'              => 'plugin',
+				'is_dot_org'        => false,
+				'version'           => null,
+				'changelog'         => null,
+				'has_update'        => false,
 			],
 			$feature->to_array()
 		);

--- a/tests/wpunit/Features/Types/ThemeTest.php
+++ b/tests/wpunit/Features/Types/ThemeTest.php
@@ -115,6 +115,10 @@ final class ThemeTest extends UplinkTestCase {
 				'released_at'       => '2025-11-15',
 				'installed_version' => '2.0.0',
 				'type'              => 'theme',
+				'is_dot_org'        => false,
+				'version'           => null,
+				'changelog'         => null,
+				'has_update'        => false,
 			],
 			$feature->to_array()
 		);


### PR DESCRIPTION
This pull request refactors how attributes are initialized for the `Plugin` and `Theme` feature types, streamlining their constructors and improving consistency. The main change is moving attribute defaulting logic from the `from_array` static method into the constructors, which simplifies object creation and ensures all attributes are properly set. Associated tests have been updated to reflect these changes.
