### PR TITLE
feature: prevent notice display when on legacy license page url

### DIFF
--- a/src/Uplink/Admin/Feature_Manager_Page.php
+++ b/src/Uplink/Admin/Feature_Manager_Page.php
@@ -14,6 +14,13 @@ use StellarWP\Uplink\Utils\Version;
 class Feature_Manager_Page {
 
 	/**
+	 * The admin page slug.
+	 *
+	 * @since 3.0.0
+	 */
+	public const PAGE_SLUG = 'lws-feature-manager';
+
+	/**
 	 * Hook suffix returned by add_menu_page().
 	 * Empty string until the page is registered.
 	 *
@@ -39,7 +46,7 @@ class Feature_Manager_Page {
 			__( 'Liquid Web Software', '%TEXTDOMAIN%' ),
 			__( 'LW Software', '%TEXTDOMAIN%' ),
 			'manage_options',
-			'lws-feature-manager',
+			self::PAGE_SLUG,
 			[ $this, 'render' ],
 			'dashicons-cloud',
 			3

--- a/src/Uplink/Legacy/Notices/License_Notice_Handler.php
+++ b/src/Uplink/Legacy/Notices/License_Notice_Handler.php
@@ -148,7 +148,8 @@ class License_Notice_Handler {
 	 * @return bool
 	 */
 	private function is_on_notice_page( string $page_url ): bool {
-		$current_page = Cast::to_string( isset( $_GET['page'] ) ? $_GET['page'] : '' );
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- reading current page slug, not processing a form.
+		$current_page = sanitize_key( Cast::to_string( $_GET['page'] ?? '' ) );
 
 		if ( $current_page === '' ) {
 			return false;

--- a/src/Uplink/Legacy/Notices/License_Notice_Handler.php
+++ b/src/Uplink/Legacy/Notices/License_Notice_Handler.php
@@ -2,6 +2,7 @@
 
 namespace StellarWP\Uplink\Legacy\Notices;
 
+use StellarWP\Uplink\Admin\Feature_Manager_Page;
 use StellarWP\Uplink\Legacy\License_Repository;
 use StellarWP\Uplink\Notice\Notice;
 use StellarWP\Uplink\Notice\Notice_Controller;
@@ -108,6 +109,10 @@ class License_Notice_Handler {
 		}
 
 		foreach ( $by_brand as $brand => $data ) {
+			if ( $this->is_on_notice_page( $data['page_url'] ) ) {
+				continue;
+			}
+
 			$this->render_notice( $brand, $data );
 		}
 
@@ -127,6 +132,42 @@ class License_Notice_Handler {
 		$dismissed = (array) get_user_meta( get_current_user_id(), self::DISMISSED_META_KEY, true );
 
 		return isset( $dismissed[ $id ] ) && Cast::to_int( $dismissed[ $id ] ) > time();
+	}
+
+	/**
+	 * Whether the current admin request is already on the given page URL.
+	 *
+	 * Compares the `page` query parameter from the notice URL against the
+	 * current request so the notice is suppressed when the user is already
+	 * on the page they would be directed to.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $page_url The brand's license page URL.
+	 *
+	 * @return bool
+	 */
+	private function is_on_notice_page( string $page_url ): bool {
+		$current_page = Cast::to_string( isset( $_GET['page'] ) ? $_GET['page'] : '' );
+
+		if ( $current_page === '' ) {
+			return false;
+		}
+
+		if ( $current_page === Feature_Manager_Page::PAGE_SLUG ) {
+			return true;
+		}
+
+		$parsed = wp_parse_url( $page_url );
+
+		if ( empty( $parsed['query'] ) ) {
+			return false;
+		}
+
+		$params = [];
+		wp_parse_str( $parsed['query'], $params );
+
+		return ! empty( $params['page'] ) && $current_page === $params['page'];
 	}
 
 	/**


### PR DESCRIPTION
## Description

This is an enhancement to the legacy admin notices that prevents them from being displayed when on the legacy page url itself or the new software manager page url.

https://www.loom.com/share/31c913340cfd4d20b689ac5b5ead25e6