### PR TITLE
Make installation lock atomic | SCON-450

### DIFF
--- a/src/Uplink/Features/Strategy/Installable_Strategy.php
+++ b/src/Uplink/Features/Strategy/Installable_Strategy.php
@@ -6,10 +6,7 @@ use StellarWP\Uplink\Features\Error_Code;
 use StellarWP\Uplink\Utils\Cast;
 use WP_Ajax_Upgrader_Skin;
 use WP_Error;
-
-use function delete_transient;
-use function get_transient;
-use function set_transient;
+use WP_Upgrader;
 
 /**
  * Abstract base for strategies that install extensions (plugins, themes) from ZIP files.
@@ -584,37 +581,39 @@ abstract class Installable_Strategy extends Abstract_Strategy {
 	}
 
 	/**
-	 * Attempt to acquire a transient-based lock.
+	 * Attempt to acquire an atomic install lock.
 	 *
-	 * Uses a simple set-if-absent pattern. The transient TTL ensures the lock
-	 * auto-expires even if the process crashes without releasing it.
+	 * Delegates to WP_Upgrader::create_lock() which uses INSERT IGNORE
+	 * on wp_options for atomicity. The lock auto-expires after LOCK_TTL
+	 * seconds even if the process crashes without releasing it.
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string $lock_key Transient key for the lock.
+	 * @param string $lock_key Lock name.
 	 *
 	 * @return bool True if lock acquired, false if already held.
 	 */
 	protected function acquire_lock( string $lock_key ): bool {
-		if ( get_transient( $lock_key ) !== false ) {
-			return false;
+		if ( ! class_exists( 'WP_Upgrader' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 		}
 
-		set_transient( $lock_key, '1', self::LOCK_TTL );
-
-		return true;
+		return WP_Upgrader::create_lock(
+			$lock_key,
+			self::LOCK_TTL
+		);
 	}
 
 	/**
-	 * Release a transient-based install lock.
+	 * Release the install lock.
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string $lock_key Transient key for the lock.
+	 * @param string $lock_key Lock name.
 	 *
 	 * @return void
 	 */
 	protected function release_lock( string $lock_key ): void {
-		delete_transient( $lock_key );
+		WP_Upgrader::release_lock( $lock_key );
 	}
 }

--- a/src/Uplink/Features/Strategy/Installable_Strategy.php
+++ b/src/Uplink/Features/Strategy/Installable_Strategy.php
@@ -30,7 +30,7 @@ abstract class Installable_Strategy extends Abstract_Strategy {
 	protected const LOCK_TTL = MINUTE_IN_SECONDS * 2;
 
 	/**
-	 * Transient key for the global install lock.
+	 * Key for the global install lock.
 	 *
 	 * Only one installable feature can be installed at a time, regardless of
 	 * type (plugin or theme). This prevents filesystem conflicts when multiple
@@ -149,7 +149,7 @@ abstract class Installable_Strategy extends Abstract_Strategy {
 	 * Enable the feature: install (if needed) and activate the extension.
 	 *
 	 * Idempotent: returns true if the extension is already active. Uses a
-	 * global transient lock to prevent concurrent installs of any extension.
+	 * global lock to prevent concurrent installs of any extension.
 	 *
 	 * @since 3.0.0
 	 *
@@ -369,7 +369,7 @@ abstract class Installable_Strategy extends Abstract_Strategy {
 	/**
 	 * Ensure the extension is installed on disk, downloading if needed.
 	 *
-	 * Acquires a global transient lock to prevent concurrent installs of any
+	 * Acquires a global lock to prevent concurrent installs of any
 	 * feature, delegates to do_install() for the actual download, and verifies
 	 * the expected file exists on disk afterward.
 	 *
@@ -393,7 +393,7 @@ abstract class Installable_Strategy extends Abstract_Strategy {
 			return true;
 		}
 
-		// Acquire a global transient lock to prevent concurrent installs.
+		// Acquire a global lock to prevent concurrent installs.
 		// Only one feature can be installed at a time — two simultaneous
 		// requests could race the installer, causing file conflicts or corruption.
 		if ( ! $this->acquire_lock( self::LOCK_KEY ) ) {

--- a/tests/wpunit/Features/Strategy/PluginStrategyTest.php
+++ b/tests/wpunit/Features/Strategy/PluginStrategyTest.php
@@ -7,12 +7,13 @@ use StellarWP\Uplink\Features\Strategy\Plugin_Strategy;
 use StellarWP\Uplink\Features\Types\Plugin;
 use StellarWP\Uplink\Tests\UplinkTestCase;
 use WP_Error;
+use WP_Upgrader;
 
 /**
  * Tests for the Plugin_Strategy feature-gating strategy.
  *
  * These tests exercise the strategy's logic against real WordPress state
- * (active_plugins option, transients) via the WPLoader module.
+ * (active_plugins option, WP_Upgrader locks) via the WPLoader module.
  * Plugin installation is not tested here — it requires actual filesystem and
  * HTTP operations better suited to integration tests with a real ZIP URL.
  *
@@ -46,13 +47,17 @@ final class PluginStrategyTest extends UplinkTestCase {
 		// Load plugin.php so is_plugin_active() etc. are available.
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
+		if ( ! class_exists( 'WP_Upgrader' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+		}
+
 		$this->feature  = $this->make_plugin_feature();
 		$this->strategy = new Plugin_Strategy( $this->feature );
 	}
 
 	protected function tearDown(): void {
 		// Clean up locks.
-		delete_transient( 'stellarwp_uplink_install_lock' );
+		WP_Upgrader::release_lock( 'stellarwp_uplink_install_lock' );
 
 		// Ensure the test plugin is deactivated.
 		$active = get_option( 'active_plugins', [] );
@@ -149,8 +154,8 @@ final class PluginStrategyTest extends UplinkTestCase {
 	 * in progress (global lock).
 	 */
 	public function test_enable_returns_install_locked_error_when_concurrent_install_in_progress(): void {
-		// Simulate an in-progress install by setting the transient lock.
-		set_transient( 'stellarwp_uplink_install_lock', '1', 120 );
+		// Simulate an in-progress install by acquiring the WP_Upgrader lock.
+		WP_Upgrader::create_lock( 'stellarwp_uplink_install_lock', 120 );
 
 		$result = $this->strategy->enable();
 
@@ -184,7 +189,7 @@ final class PluginStrategyTest extends UplinkTestCase {
 
 			// Verify no lock was left behind (it should have been released or
 			// never acquired since the plugin was already on disk).
-			$this->assertFalse( get_transient( 'stellarwp_uplink_install_lock' ) );
+			$this->assertFalse( get_option( 'stellarwp_uplink_install_lock.lock' ) );
 		} finally {
 			// Clean up the dummy plugin.
 			deactivate_plugins( self::PLUGIN_FILE );
@@ -198,7 +203,7 @@ final class PluginStrategyTest extends UplinkTestCase {
 	}
 
 	/**
-	 * enable() releases the transient lock even when installation fails.
+	 * enable() releases the install lock even when installation fails.
 	 *
 	 * We simulate a plugins_api() response with a fake download_link that
 	 * Plugin_Upgrader::install() cannot fetch. The lock should be released
@@ -233,7 +238,7 @@ final class PluginStrategyTest extends UplinkTestCase {
 			$this->assertWPError( $result );
 
 			// Lock should be released.
-			$this->assertFalse( get_transient( 'stellarwp_uplink_install_lock' ) );
+			$this->assertFalse( get_option( 'stellarwp_uplink_install_lock.lock' ) );
 		} finally {
 			remove_filter( 'plugins_api', $filter, 10 );
 		}
@@ -864,7 +869,7 @@ final class PluginStrategyTest extends UplinkTestCase {
 			// Exception details must not leak.
 			$this->assertStringNotContainsString( 'Simulated fatal', $result->get_error_message() );
 			// Lock should be released even after a fatal throw.
-			$this->assertFalse( get_transient( 'stellarwp_uplink_install_lock' ) );
+			$this->assertFalse( get_option( 'stellarwp_uplink_install_lock.lock' ) );
 		} finally {
 			remove_filter( 'plugins_api', $api_filter, 10 );
 			remove_filter( 'pre_http_request', $http_filter, 10 );
@@ -945,7 +950,7 @@ final class PluginStrategyTest extends UplinkTestCase {
 				]
 			);
 
-			set_transient( 'stellarwp_uplink_install_lock', '1', 120 );
+			WP_Upgrader::create_lock( 'stellarwp_uplink_install_lock', 120 );
 
 			$result = $this->strategy->update();
 

--- a/tests/wpunit/Features/Strategy/PluginStrategyTest.php
+++ b/tests/wpunit/Features/Strategy/PluginStrategyTest.php
@@ -164,6 +164,57 @@ final class PluginStrategyTest extends UplinkTestCase {
 	}
 
 	/**
+	 * enable() proceeds when a stale lock has expired past the TTL.
+	 *
+	 * Simulates a process that crashed without releasing the lock by writing
+	 * an option timestamp older than the TTL. The next enable() should
+	 * reclaim the expired lock and proceed normally.
+	 */
+	public function test_enable_proceeds_when_stale_lock_has_expired(): void {
+		$plugin_dir  = WP_PLUGIN_DIR . '/test-feature';
+		$plugin_path = $plugin_dir . '/test-feature.php';
+
+		if ( ! is_dir( $plugin_dir ) ) {
+			mkdir( $plugin_dir, 0755, true );
+		}
+		file_put_contents( $plugin_path, "<?php\n/**\n * Plugin Name: Test Feature\n * Author: StellarWP\n */\n" );
+
+		// Simulate a stale lock from 5 minutes ago (TTL is 2 minutes).
+		update_option( 'stellarwp_uplink_install_lock.lock', time() - 300, false );
+
+		try {
+			$result = $this->strategy->enable();
+
+			$this->assertTrue( $result );
+			$this->assertTrue( is_plugin_active( self::PLUGIN_FILE ) );
+		} finally {
+			deactivate_plugins( self::PLUGIN_FILE );
+			if ( file_exists( $plugin_path ) ) {
+				unlink( $plugin_path );
+			}
+			if ( is_dir( $plugin_dir ) ) {
+				rmdir( $plugin_dir );
+			}
+		}
+	}
+
+	/**
+	 * enable() is blocked by a lock that is still within the TTL window.
+	 *
+	 * Writes an option timestamp just 10 seconds ago — well within the
+	 * 2-minute TTL — to verify the boundary is respected.
+	 */
+	public function test_enable_blocked_by_fresh_lock_within_ttl(): void {
+		// Lock acquired 10 seconds ago — still valid.
+		update_option( 'stellarwp_uplink_install_lock.lock', time() - 10, false );
+
+		$result = $this->strategy->enable();
+
+		$this->assertWPError( $result );
+		$this->assertSame( Error_Code::INSTALL_LOCKED, $result->get_error_code() );
+	}
+
+	/**
 	 * enable() skips installation when the plugin file already exists on disk
 	 * and proceeds directly to activation.
 	 *

--- a/tests/wpunit/Features/Strategy/ThemeStrategyTest.php
+++ b/tests/wpunit/Features/Strategy/ThemeStrategyTest.php
@@ -7,12 +7,13 @@ use StellarWP\Uplink\Features\Strategy\Theme_Strategy;
 use StellarWP\Uplink\Features\Types\Theme;
 use StellarWP\Uplink\Tests\UplinkTestCase;
 use WP_Error;
+use WP_Upgrader;
 
 /**
  * Tests for the Theme_Strategy feature-gating strategy.
  *
  * These tests exercise the strategy's logic against real WordPress state
- * (theme directories, transients) via the WPLoader module.
+ * (theme directories, WP_Upgrader locks) via the WPLoader module.
  *
  * Theme enable = install only (no switch_theme).
  * Theme disable = error if on disk (user must delete manually), success if not on disk.
@@ -52,6 +53,10 @@ final class ThemeStrategyTest extends UplinkTestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
+		if ( ! class_exists( 'WP_Upgrader' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+		}
+
 		$this->feature             = $this->make_theme_feature();
 		$this->strategy            = new Theme_Strategy( $this->feature );
 		$this->original_stylesheet = get_option( 'stylesheet', '' );
@@ -59,7 +64,7 @@ final class ThemeStrategyTest extends UplinkTestCase {
 
 	protected function tearDown(): void {
 		// Clean up locks.
-		delete_transient( 'stellarwp_uplink_install_lock' );
+		WP_Upgrader::release_lock( 'stellarwp_uplink_install_lock' );
 
 		// Restore original active theme.
 		update_option( 'stylesheet', $this->original_stylesheet );
@@ -139,7 +144,7 @@ final class ThemeStrategyTest extends UplinkTestCase {
 	 * in progress (global lock).
 	 */
 	public function test_enable_returns_install_locked_error_when_concurrent_install_in_progress(): void {
-		set_transient( 'stellarwp_uplink_install_lock', '1', 120 );
+		WP_Upgrader::create_lock( 'stellarwp_uplink_install_lock', 120 );
 
 		$result = $this->strategy->enable();
 
@@ -157,7 +162,7 @@ final class ThemeStrategyTest extends UplinkTestCase {
 		$result = $this->strategy->enable();
 
 		$this->assertTrue( $result );
-		$this->assertFalse( get_transient( 'stellarwp_uplink_install_lock' ) );
+		$this->assertFalse( get_option( 'stellarwp_uplink_install_lock.lock' ) );
 		// The active theme should NOT have changed.
 		$this->assertSame( $this->original_stylesheet, get_option( 'stylesheet' ) );
 	}
@@ -331,7 +336,7 @@ final class ThemeStrategyTest extends UplinkTestCase {
 			// Exception details must not leak.
 			$this->assertStringNotContainsString( 'Simulated fatal', $result->get_error_message() );
 			// Lock should be released even after a fatal throw.
-			$this->assertFalse( get_transient( 'stellarwp_uplink_install_lock' ) );
+			$this->assertFalse( get_option( 'stellarwp_uplink_install_lock.lock' ) );
 		} finally {
 			remove_filter( 'themes_api', $api_filter, 10 );
 			remove_filter( 'pre_http_request', $http_filter, 10 );
@@ -385,7 +390,7 @@ final class ThemeStrategyTest extends UplinkTestCase {
 			]
 		);
 
-		set_transient( 'stellarwp_uplink_install_lock', '1', 120 );
+		WP_Upgrader::create_lock( 'stellarwp_uplink_install_lock', 120 );
 
 		try {
 			$result = $this->strategy->update();

--- a/tests/wpunit/Features/Strategy/ThemeStrategyTest.php
+++ b/tests/wpunit/Features/Strategy/ThemeStrategyTest.php
@@ -153,6 +153,41 @@ final class ThemeStrategyTest extends UplinkTestCase {
 	}
 
 	/**
+	 * enable() proceeds when a stale lock has expired past the TTL.
+	 *
+	 * Simulates a process that crashed without releasing the lock by writing
+	 * an option timestamp older than the TTL. The next enable() should
+	 * reclaim the expired lock and proceed normally.
+	 */
+	public function test_enable_proceeds_when_stale_lock_has_expired(): void {
+		$this->install_test_theme( self::STYLESHEET, 'StellarWP' );
+
+		// Simulate a stale lock from 5 minutes ago (TTL is 2 minutes).
+		update_option( 'stellarwp_uplink_install_lock.lock', time() - 300, false );
+
+		$result = $this->strategy->enable();
+
+		$this->assertTrue( $result );
+		$this->assertSame( $this->original_stylesheet, get_option( 'stylesheet' ) );
+	}
+
+	/**
+	 * enable() is blocked by a lock that is still within the TTL window.
+	 *
+	 * Writes an option timestamp just 10 seconds ago — well within the
+	 * 2-minute TTL — to verify the boundary is respected.
+	 */
+	public function test_enable_blocked_by_fresh_lock_within_ttl(): void {
+		// Lock acquired 10 seconds ago — still valid.
+		update_option( 'stellarwp_uplink_install_lock.lock', time() - 10, false );
+
+		$result = $this->strategy->enable();
+
+		$this->assertWPError( $result );
+		$this->assertSame( Error_Code::INSTALL_LOCKED, $result->get_error_code() );
+	}
+
+	/**
 	 * enable() skips installation when the theme is already installed
 	 * and does NOT switch the active theme.
 	 */


### PR DESCRIPTION
🎫 [SCON-450]

Today I learned WP has such a feature https://developer.wordpress.org/reference/classes/wp_upgrader/create_lock/, so improving!

I replaced the `get_transient() + set_transient()` lock in `Installable_Strategy` with `WP_Upgrader::create_lock() / release_lock()`.

The old pattern had a race condition — two concurrent requests could both read `false` from `get_transient()` and both proceed, defeating the lock.

`WP_Upgrader::create_lock()` uses `INSERT IGNORE` on `wp_options` under the hood, which is atomic at the database level. Stale lock behavior is unchanged — if a process dies without releasing, the lock auto-expires after the TTL on the next acquisition attempt.       

[SCON-450]: https://stellarwp.atlassian.net/browse/SCON-450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ