### PR TITLE
feature: add global function to get license page url

### DIFF
--- a/src/Uplink/API/Functions/Global_Function_Registry.php
+++ b/src/Uplink/API/Functions/Global_Function_Registry.php
@@ -2,6 +2,7 @@
 
 namespace StellarWP\Uplink\API\Functions;
 
+use StellarWP\Uplink\Admin\Feature_Manager_Page;
 use StellarWP\Uplink\Config;
 use StellarWP\Uplink\Features\Manager;
 use StellarWP\Uplink\Licensing\Repositories\License_Repository;
@@ -115,6 +116,14 @@ class Global_Function_Registry {
 
 					return false;
 				}
+			}
+		);
+
+		\_stellarwp_uplink_global_function_registry(
+			'stellarwp_uplink_get_license_page_url',
+			$version,
+			static function (): string {
+				return admin_url( 'admin.php?page=' . Feature_Manager_Page::PAGE_SLUG );
 			}
 		);
 	}

--- a/src/Uplink/global-functions.php
+++ b/src/Uplink/global-functions.php
@@ -81,7 +81,7 @@ if ( ! function_exists( '_stellarwp_uplink_global_function_registry' ) ) {
 			static function ( string $carry, string $v ): string {
 				return version_compare( $v, $carry, '>' ) ? $v : $carry;
 			},
-			'0.0.0' 
+			'0.0.0'
 		);
 
 		return $registry[ $key ][ $highest ] ?? null;
@@ -185,6 +185,8 @@ if ( ! function_exists( 'stellarwp_uplink_get_license_page_url' ) ) {
 	function stellarwp_uplink_get_license_page_url(): string {
 		$callback = _stellarwp_uplink_global_function_registry( 'stellarwp_uplink_get_license_page_url' );
 
-		return $callback ? (string) $callback() : '';
+		$result = $callback ? $callback() : '';
+
+		return is_string( $result ) ? $result : '';
 	}
 }

--- a/src/Uplink/global-functions.php
+++ b/src/Uplink/global-functions.php
@@ -173,3 +173,18 @@ if ( ! function_exists( 'stellarwp_uplink_is_feature_available' ) ) {
 		return $callback ? (bool) $callback( $slug ) : false;
 	}
 }
+
+if ( ! function_exists( 'stellarwp_uplink_get_license_page_url' ) ) {
+	/**
+	 * Returns the admin URL for the unified Feature Manager page.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return string The admin URL, or an empty string if no instance is active.
+	 */
+	function stellarwp_uplink_get_license_page_url(): string {
+		$callback = _stellarwp_uplink_global_function_registry( 'stellarwp_uplink_get_license_page_url' );
+
+		return $callback ? (string) $callback() : '';
+	}
+}


### PR DESCRIPTION
Resolves: [SCON-464]

## Description

This PR adds a new global function `stellarwp_uplink_get_license_page_url()` that can be used by our products to link over to the new software manager UI page.

**Demo**

https://www.loom.com/share/e101493b974a4573a08e1346376f7d51

Ref: https://github.com/stellarwp/uplink-sample-plugin/pull/14

[SCON-464]: https://stellarwp.atlassian.net/browse/SCON-464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ